### PR TITLE
update config structure in theme and update readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,15 @@ This theme uses Tailwind CSS which requires PostCSS for processing. You **must**
 module.exports = {
   plugins: {
     tailwindcss: {
-      config: './themes/boilerplate/tailwind.config.js'
+      config: './themes/boilerplate/tailwind.config.js',
     },
-    autoprefixer: {}
-  }
-}
+    autoprefixer: {},
+  },
+};
 ```
 
 This configuration tells PostCSS to:
+
 1. Use the Tailwind CSS plugin with the configuration file located in the theme directory
 2. Apply autoprefixer for cross-browser compatibility
 
@@ -125,21 +126,25 @@ module.exports = {
     'postcss-import': {},
     'tailwindcss/nesting': {},
     tailwindcss: {
-      config: './themes/boilerplate/tailwind.config.js'
+      config: './themes/boilerplate/tailwind.config.js',
     },
     autoprefixer: {
-      flexbox: 'no-2009'
+      flexbox: 'no-2009',
     },
     'postcss-preset-env': {
-      features: { 'nesting-rules': false }
-    }
-  }
-}
+      features: { 'nesting-rules': false },
+    },
+  },
+};
 ```
 
 ## Configuration
 
 ### Basic Configuration
+
+This theme supports two configuration approaches:
+
+#### Option 1: Using a Single Configuration File (Traditional)
 
 Add the following to your `hugo.toml` file:
 
@@ -163,9 +168,31 @@ defaultContentLanguageInSubdir = true
   dateFormat = "January 2, 2006"
 ```
 
+#### Option 2: Using Split Configuration Files (Recommended)
+
+For better organization, you can split your configuration into multiple files in a `config/_default/` directory:
+
+1. Copy the example configuration structure from the theme:
+
+```bash
+mkdir -p config/_default
+cp -r themes/boilerplate/config_example/_default/* config/_default/
+```
+
+2. Edit the individual configuration files to customize your site:
+   - `hugo.toml` - Basic site configuration
+   - `languages.toml` - Multilingual settings
+   - `menus.toml` - Navigation menu structure
+   - `params.toml` - Site parameters and features
+   - `outputFormats.toml` - Output format configuration
+   - `markup.toml` - Content rendering settings
+   - `module.toml` - Hugo modules configuration
+
+This modular approach makes your configuration more maintainable, especially for complex sites.
+
 ### Multilingual Setup
 
-The theme supports multiple languages out of the box. Configure them in your `hugo.toml`:
+The theme supports multiple languages out of the box. Configure them in `languages.toml` (if using split configuration) or in your `hugo.toml` under the `[languages]` section:
 
 ```toml
 [languages]
@@ -190,9 +217,27 @@ The theme supports multiple languages out of the box. Configure them in your `hu
       description = "Deutsche Seitenbeschreibung"
 ```
 
+### Menu Configuration
+
+Define your site's navigation in `menus.toml` (if using split configuration) or in your `hugo.toml` under language-specific menu sections:
+
+```toml
+[languages.en.menu]
+  [[languages.en.menu.main]]
+    identifier = "home"
+    name = "Home"
+    url = "/"
+    weight = 1
+  [[languages.en.menu.main]]
+    identifier = "blog"
+    name = "Blog"
+    url = "/blog/"
+    weight = 2
+```
+
 ### Image Processing Configuration
 
-For optimal image processing, add the following to your `hugo.toml`:
+For optimal image processing, add the following to your `params.toml` (if using split configuration) or to the `[params]` section of your `hugo.toml`:
 
 ```toml
 [params.imaging]
@@ -284,7 +329,7 @@ Main content about the term goes here...
 The theme includes various shortcodes for common components:
 
 ```markdown
-{{< products-with-image-grid 
+{{< products-with-image-grid
   background="bg-gray-50"
   product="{ title: 'Product Title', ... }" >}}
 
@@ -299,7 +344,7 @@ The theme includes various shortcodes for common components:
 You can include partials in your templates:
 
 ```go
-{{ partial "headers/centered_with_eyebrow.html" (dict 
+{{ partial "headers/centered_with_eyebrow.html" (dict
   "eyebrow" "Eyebrow Text"
   "heading" "Main Heading"
   "description" "Description text") }}

--- a/config_example/README.md
+++ b/config_example/README.md
@@ -1,0 +1,35 @@
+# Configuration Structure
+
+This directory contains example configuration files for the Hugo Boilerplate theme.
+
+## Usage
+
+Instead of using a single `hugo.toml` file, this approach splits your configuration into multiple files for better organization and maintainability. This is especially helpful for complex sites with many settings.
+
+### How to Use These Files
+
+1. Copy this entire directory structure to your project root:
+
+   ```bash
+   mkdir -p config/_default
+   cp -r themes/boilerplate/config_example/_default/* config/_default/
+   ```
+
+2. Edit each file to customize your site settings:
+
+   - **hugo.toml** - Basic site configuration (baseURL, title, theme, etc.)
+   - **languages.toml** - Multilingual settings
+   - **menus.toml** - Navigation menu structure
+   - **params.toml** - Site parameters and features
+   - **outputFormats.toml** - Output format configuration
+   - **markup.toml** - Content rendering settings
+   - **module.toml** - Hugo modules configuration
+
+### Advantages of This Approach
+
+- **Cleaner Organization** - Logical separation of configuration by purpose
+- **Easier Maintenance** - Shorter files that are focused on specific settings
+- **Better Collaboration** - Reduced merge conflicts when multiple people work on the configuration
+- **Improved Readability** - Easier to find specific settings when they're organized by category
+
+For more information, see the theme's main README.md file or the [Hugo documentation on configuration](https://gohugo.io/getting-started/configuration/).

--- a/config_example/_default/hugo.toml
+++ b/config_example/_default/hugo.toml
@@ -1,0 +1,24 @@
+baseURL = 'http://localhost:1313/'
+languageCode = 'en-us'
+title = 'Hugo Boilerplate'
+defaultContentLanguage = "en"
+defaultContentLanguageInSubdir = true
+theme = 'boilerplate'
+
+# Asset configuration for multilingual sites
+assetDir = "assets"
+
+# Taxonomies
+[taxonomies]
+  tag = "tags"
+  category = "categories"
+
+# Build settings
+[build]
+  writeStats = true
+
+# Multilingual settings
+[sitemap]
+  changefreq = "monthly"
+  filename = "sitemap.xml"
+  priority = 0.5

--- a/config_example/_default/languages.toml
+++ b/config_example/_default/languages.toml
@@ -1,0 +1,34 @@
+# Language configuration
+[languages]
+  [languages.en]
+    languageName = "English"
+    title = "English Site Title"
+    weight = 1
+    contentDir = "content/en"
+    baseURL = "https://example.com"
+    [languages.en.params]
+      bcp47Lang = "en-us"
+      description = "English site description"
+      gaMeasurementID = "G-PROD7890123"
+
+  [languages.de]
+    languageName = "Deutsch"
+    title = "Deutsche Site Title"
+    weight = 2
+    contentDir = "content/de"
+    baseURL = "https://example.de"
+    [languages.de.params]
+      bcp47Lang = "de"
+      description = "Deutsche Seitenbeschreibung"
+      gaMeasurementID = "G-GERMAN12345"
+
+  [languages.sk]
+    languageName = "Slovenčina"
+    title = "Slovenský Názov Stránky"
+    weight = 3
+    contentDir = "content/sk"
+    baseURL = "https://example.sk"
+    [languages.sk.params]
+      bcp47Lang = "sk"
+      description = "Slovenský popis stránky"
+      gaMeasurementID = "G-SLOVAK67890"

--- a/config_example/_default/markup.toml
+++ b/config_example/_default/markup.toml
@@ -1,0 +1,14 @@
+# Markup configuration
+# Uncomment and modify as needed
+
+#[markup]
+#  [markup.highlight]
+#    codeFences = true
+#    guessSyntax = false
+#    hl_Lines = ""
+#    lineNoStart = 1
+#    lineNos = false
+#    lineNumbersInTable = true
+#    noClasses = true
+#    style = "monokai"
+#    tabWidth = 4

--- a/config_example/_default/menus.toml
+++ b/config_example/_default/menus.toml
@@ -1,0 +1,36 @@
+# Menu configuration
+[languages.en.menu]
+  [[languages.en.menu.main]]
+    identifier = "home"
+    name = "Home"
+    url = "/"
+    weight = 1
+  [[languages.en.menu.main]]
+    identifier = "blog"
+    name = "Blog"
+    url = "/blog/"
+    weight = 2
+
+[languages.de.menu]
+  [[languages.de.menu.main]]
+    identifier = "home"
+    name = "Startseite"
+    url = "/"
+    weight = 1
+  [[languages.de.menu.main]]
+    identifier = "blog"
+    name = "Blog"
+    url = "/blog/"
+    weight = 2
+
+[languages.sk.menu]
+  [[languages.sk.menu.main]]
+    identifier = "home"
+    name = "Domov"
+    url = "/"
+    weight = 1
+  [[languages.sk.menu.main]]
+    identifier = "blog"
+    name = "Blog"
+    url = "/blog/"
+    weight = 2

--- a/config_example/_default/module.toml
+++ b/config_example/_default/module.toml
@@ -1,0 +1,5 @@
+# Module configuration
+# Uncomment and modify as needed
+
+#[[module.imports]]
+#  path = "github.com/gohugoio/hugo-mod-bootstrap-scss/v5"

--- a/config_example/_default/outputFormats.toml
+++ b/config_example/_default/outputFormats.toml
@@ -1,0 +1,24 @@
+# Output formats configuration
+[outputs]
+  home = ["HTML", "RSS", "SITEMAP"]
+
+[mediaTypes]
+  [mediaTypes."text/plain"]
+    suffixes = ["txt"]
+  [mediaTypes."application/xml"]
+    suffixes = ["xml"]
+
+[outputFormats]
+  [outputFormats.ROBOTS]
+    mediaType = "text/plain"
+    baseName = "robots"
+    isPlainText = true
+    notAlternative = true
+    permalinkable = true
+  [outputFormats.SITEMAP]
+    mediaType = "application/xml"
+    baseName = "sitemap"
+    isPlainText = false
+    isHTML = false
+    noUgly = true
+    rel = "sitemap"

--- a/config_example/_default/params.toml
+++ b/config_example/_default/params.toml
@@ -1,0 +1,30 @@
+# Site parameters
+[params]
+  description = "A clean Hugo boilerplate"
+  author = "Your Name"
+  mainSections = ["blog"]
+  dateFormat = "January 2, 2006"
+  
+  # Image processing configuration
+  [params.imaging]
+    # Default resample filter used for resizing. Default is Box,
+    # a simple and fast averaging filter appropriate for downscaling.
+    # See https://github.com/disintegration/imaging
+    resampleFilter = "Lanczos"
+    
+    # Default JPEG quality setting. Default is 75.
+    quality = 85
+    
+    # Anchor used when cropping pictures.
+    # Default is "smart" which does Smart Cropping, using https://github.com/muesli/smartcrop
+    anchor = "smart"
+    
+    # Default background color.
+    # Hugo will preserve transparency for target formats that support it,
+    # but will fall back to this color for JPEG.
+    # Expects a standard HEX color string with 3 or 6 digits.
+    # See https://www.google.com/search?q=color+picker
+    bgColor = "#ffffff"
+
+    # Default WebP quality setting. Default is 75.
+    webpQuality = 85


### PR DESCRIPTION
Refactor Hugo configuration into multiple files

Split the main hugo.toml_exemple configuration into separate files in config_example/_default/ directory for improved readability and maintenance. 
Configuration is now organized into specialized files: params.toml, languages.toml, menus.toml, markup.toml, outputFormats.toml, and module.toml.
