### PR TITLE
Improved design of with_intro_and_tabs partial

### DIFF
--- a/layouts/partials/sections/features/with_intro_and_tabs.html
+++ b/layouts/partials/sections/features/with_intro_and_tabs.html
@@ -27,18 +27,18 @@
 <div class="{{ $backgroundColor }}">
   <section aria-labelledby="{{ $uniqueID }}-heading" class="mx-auto max-w-7xl py-32 sm:px-2 lg:px-8">
     <div class="mx-auto max-w-2xl px-4 lg:max-w-none lg:px-0">
-      <div class="max-w-3xl">
-        <h2 id="{{ $uniqueID }}-heading" class="text-3xl font-bold tracking-tight text-gray-900 sm:text-4xl">{{ $heading }}</h2>
+      <div class="w-full text-center">
+        <h2 id="{{ $uniqueID }}-heading" class="text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">{{ $heading }}</h2>
         <p class="mt-4 text-gray-500">{{ partial "utils/linkbuilding" (dict "content" $description "page" $page) | safeHTML }}</p>
       </div>
 
       <div class="mt-4">
         <div class="-mx-4 flex overflow-x-auto sm:mx-0">
           <div class="flex-auto border-b border-gray-200 px-4 sm:px-0">
-            <div class="-mb-px flex space-x-10" aria-orientation="horizontal" role="tablist">
+            <div class="-mb-px flex justify-center space-x-10" aria-orientation="horizontal" role="tablist">
               {{ range $index, $tab := $tabs }}
                 <button id="{{ $uniqueID }}-tab-{{ $tab.id }}" 
-                  class="border-b-2 {{ if eq $index 0 }}border-indigo-500 text-indigo-600{{ else }}border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700{{ end }} py-6 text-sm font-medium whitespace-nowrap" 
+                  class="border-b-2 {{ if eq $index 0 }}border-indigo-500 text-indigo-600{{ else }}border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700{{ end }} py-6 text-base font-medium whitespace-nowrap" 
                   aria-controls="{{ $uniqueID }}-panel-{{ $tab.id }}" 
                   role="tab" 
                   type="button"
@@ -53,18 +53,18 @@
 
         {{ range $index, $tab := $tabs }}
           <div id="{{ $uniqueID }}-panel-{{ $tab.id }}" 
-            class="space-y-16 pt-10 lg:pt-16 {{ if ne $index 0 }}hidden{{ end }}" 
+            class="text-lg space-y-16 pt-10 lg:pt-16 {{ if ne $index 0 }}hidden{{ end }}" 
             aria-labelledby="{{ $uniqueID }}-tab-{{ $tab.id }}" 
             role="tabpanel" 
             tabindex="0">
             {{ if or $tab.content.title $tab.content.description }}
-            <div class="flex flex-col-reverse lg:grid lg:grid-cols-12 lg:gap-x-8">
-              <div class="mt-6 lg:col-span-5 lg:mt-0">
-                {{if $tab.content.title }}<h3 class="text-lg font-medium text-gray-900">{{ $tab.content.title }}</h3>{{ end }}
-                {{if $tab.content.description }}<p class="mt-2 text-sm text-gray-500">{{ partial "utils/linkbuilding" (dict "content" $tab.content.description "page" $page) | safeHTML }}</p>{{ end }}
+            <div class="flex flex-col-reverse lg:grid lg:grid-cols-12 lg:gap-x-8 lg:items-center">
+              <div class="mt-6 lg:col-span-6 lg:mt-0">
+                {{if $tab.content.title }}<h3 class="text-3xl font-medium text-gray-900">{{ $tab.content.title }}</h3>{{ end }}
+                {{if $tab.content.description }}<p class="mt-2 text-md text-gray-500">{{ partial "utils/linkbuilding" (dict "content" $tab.content.description "page" $page) | safeHTML }}</p>{{ end }}
               </div>
               {{ if $tab.content.imageUrl }}
-              <div class="lg:col-span-7">
+              <div class="lg:col-span-6">
                 {{ partial "components/media/lazyimg.html" (dict 
                   "src" $tab.content.imageUrl
                   "alt" $tab.content.imageAlt


### PR DESCRIPTION
### Before: 
![Screenshot 2025-05-29 at 16 57 48](https://github.com/user-attachments/assets/6b3f4458-128f-48e7-b43a-ee7d50bb4147)

### After: 
![Screenshot 2025-05-29 at 16 58 36](https://github.com/user-attachments/assets/1259cdf5-3c33-405c-82aa-c175308a0daa)
