### PR TITLE
fix: remove default values from Bento Grid, replaced h1 to h2

### DIFF
--- a/layouts/partials/sections/bentogrids/three_column_bento_grid.html
+++ b/layouts/partials/sections/bentogrids/three_column_bento_grid.html
@@ -53,32 +53,7 @@
 {{ $taglineColor := .taglineColor | default "primary" }}
 {{ $backgroundColor := .backgroundColor | default "gray-50" }}
 
-{{ $cards := .cards | default (slice
-  (dict
-    "title" "Mobile friendly"
-    "description" "Anim aute id magna aliqua ad ad non deserunt sunt. Qui irure qui lorem cupidatat commodo."
-    "image" "https://tailwindcss.com/plus-assets/img/component-images/bento-03-mobile-friendly.png"
-    "imageAlt" "Mobile friendly interface"
-  )
-  (dict
-    "title" "Performance"
-    "description" "Lorem ipsum, dolor sit amet consectetur adipisicing elit maiores impedit."
-    "image" "https://tailwindcss.com/plus-assets/img/component-images/bento-03-performance.png"
-    "imageAlt" "Performance metrics"
-  )
-  (dict
-    "title" "Security"
-    "description" "Morbi viverra dui mi arcu sed. Tellus semper adipiscing suspendisse semper morbi."
-    "image" "https://tailwindcss.com/plus-assets/img/component-images/bento-03-security.png"
-    "imageAlt" "Security shield"
-  )
-  (dict
-    "title" "Additional Features"
-    "description" "Sit quis amet rutrum tellus ullamcorper ultricies libero dolor eget sem sodales gravida."
-    "image" "https://tailwindcss.com/plus-assets/img/component-images/bento-03-api.png" 
-    "imageAlt" "API documentation"
-  )
-) }}
+{{ $cards := .cards | default (slice) }}
 
 <div class="bg-{{ $backgroundColor }} py-24 sm:py-32">
   <div class="mx-auto max-w-2xl px-6 lg:max-w-7xl lg:px-8">

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -104,7 +104,7 @@ The system automatically scales based on your needs, so you never have to worry 
         <p class="text-base/7 font-semibold {{ $eyebrowColor }}">{{ $eyebrow }}</p>
         {{ end }}
         {{ if $heading}}
-        <h1 class="mt-2 text-4xl font-semibold tracking-tight text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h1>
+        <h2 class="mt-2 text-4xl font-semibold tracking-tight text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
         {{ end }}
         {{ if $description }}
         <p class="mt-6 text-xl/8 {{ $descriptionColor }}">{{ partial "utils/linkbuilding" (dict "content" $description "page" .) | safeHTML }}</p>

--- a/layouts/shortcodes/bentogrid-two-row.html
+++ b/layouts/shortcodes/bentogrid-two-row.html
@@ -89,55 +89,8 @@
 {{ $taglineColor := .Get "taglineColor" | default "primary" }}
 {{ $linkText := .Get "linkText" | default "" }}
 {{ $linkUrl := .Get "linkUrl" | default "" }}
-{{ $defaultCards := slice
-  (dict
-    "title" "Lightning-fast builds"
-    "category" "Performance"
-    "description" "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In gravida justo et nulla efficitur, maximus egestas sem pellentesque."
-    "image" "https://tailwindcss.com/plus-assets/img/component-images/bento-01-performance.png"
-    "imageAlt" "Performance dashboard"
-    "cardSize" "large"
-    "categoryColor" "primary"
-  )
-  (dict
-    "title" "Push to deploy"
-    "category" "Releases"
-    "description" "Curabitur auctor, ex quis auctor venenatis, eros arcu rhoncus massa, laoreet dapibus ex elit vitae odio."
-    "image" "https://tailwindcss.com/plus-assets/img/component-images/bento-01-releases.png"
-    "imageAlt" "Releases panel"
-    "cardSize" "large"
-    "categoryColor" "primary"
-  )
-  (dict
-    "title" "Built for power users"
-    "category" "Speed"
-    "description" "Sed congue eros non finibus molestie. Vestibulum euismod augue."
-    "image" "https://tailwindcss.com/plus-assets/img/component-images/bento-01-speed.png"
-    "imageAlt" "Speed metrics"
-    "cardSize" "small"
-    "categoryColor" "primary"
-  )
-  (dict
-    "title" "Connect your favorite tools"
-    "category" "Integrations"
-    "description" "Maecenas at augue sed elit dictum vulputate, in nisi aliquam maximus arcu."
-    "image" "https://tailwindcss.com/plus-assets/img/component-images/bento-01-integrations.png"
-    "imageAlt" "Integrations panel"
-    "cardSize" "small"
-    "categoryColor" "primary"
-  )
-  (dict
-    "title" "Globally distributed CDN"
-    "category" "Network"
-    "description" "Aenean vulputate justo commodo auctor vehicula in malesuada semper."
-    "image" "https://tailwindcss.com/plus-assets/img/component-images/bento-01-network.png"
-    "imageAlt" "Network map"
-    "cardSize" "small"
-    "categoryColor" "primary"
-  )
-}}
 
-{{ $cards := $defaultCards }}
+{{ $cards := slice }}
 {{ with .Inner }}
   {{ if . }}
     {{ $cards = . | unmarshal }}


### PR DESCRIPTION
Remove default values from Bento Grid, replaced h1 to h2 in cont…ent/split_with_image partial

Related with https://github.com/QualityUnit/web-issues/issues/3436