### PR TITLE
fix: add logo alignment support in simple logos component

### DIFF
--- a/layouts/partials/components/logos/simple.html
+++ b/layouts/partials/components/logos/simple.html
@@ -37,6 +37,10 @@
 {{ $isDark := eq $theme "dark" }}
 {{ $darkClass := cond $isDark "dark" "" }}
 
+{{/* Logo alignment setup */}}
+{{ $alignment := .alignment | default "responsive" }}
+{{ $justifyClass := cond (eq $alignment "center") "justify-center" "justify-center lg:justify-between" }}
+
 {{/* Logos */}}
 {{ $defaultLogos := slice 
   (dict
@@ -82,7 +86,7 @@
         </div>
         {{ end }}
 
-        <div class="mx-auto flex flex-wrap justify-center lg:justify-between items-center gap-8 sm:gap-12 md:gap-16">
+        <div class="mx-auto flex flex-wrap {{ $justifyClass }} items-center gap-8 sm:gap-12 md:gap-16">
           {{ range $index, $logo := $logos }}
             <div class="flex items-center justify-center">
               {{ $class := "block max-h-12 h-10 lg:h-12 w-full object-contain" }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added logo alignment support in simple logos component

**Testing instructions**
- Go to /enterprise-pricing/ and check logos (should be aligned center)

Related with https://github.com/QualityUnit/FlowHunt-hugo/pull/71