### PR TITLE
[3552] - define fix zig zag element

### DIFF
--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -1,115 +1,83 @@
 {{/*
-@section: Split Content with Image
-@description: A responsive two-column layout with an image on one side and rich content on the other, ideal for feature highlights, product descriptions, or about sections.
-@params:
-  - bgColor: Background color class (optional, default: "bg-white")
-  - image: URL to the main image (optional, has default)
-  - imageAlt: Alt text for the image (optional, default: "Featured image")
-  - imageBgColor: Background color class for the image container (optional, default: "bg-gray-50")
-  - imageHeight: Height class for the image container (optional, default: "h-full")
-  - imageObjectFit: Object fit class for the image (optional, default: "object-cover")
-  - eyebrow: Small text displayed above heading (optional, default: "Deploy faster")
-  - eyebrowColor: Color class for eyebrow text (optional, default: "text-primary")
-  - heading: Main section heading (optional, default: "A better workflow")
-  - headingColor: Color class for heading (optional, default: "text-gray-900")
-  - description: Section description text (optional, has default)
-  - descriptionColor: Color class for description (optional, default: "text-gray-700")
-  - contentColor: Color class for main content text (optional, default: "text-gray-700")
-  - markdownContent: Main content as markdown text, will be rendered as HTML (optional, has default)
-  - featureTextColor: Color class for feature description text (optional, default: "text-gray-600")
-  - featureHeadingColor: Color class for feature heading (optional, default: "text-gray-900")
-  - iconColor: Color class for feature icons (optional, default: "text-primary")
-  - features: Array of feature objects (optional, includes defaults)
-    - icon: SVG path for the feature icon
-    - title: Feature title text
-    - description: Feature description text
-@example:
-  {{ partial "sections/content/split_with_image.html" (dict 
-      "eyebrow" "Our Platform" 
-      "heading" "Designed for modern workflows"
-      "description" "Our platform streamlines development processes, enabling teams to deploy faster and collaborate more effectively."
-      "image" "/images/platform-dashboard.jpg"
-      "imageAlt" "Platform dashboard interface showing deployment metrics"
-      "markdownContent" "
-Our platform is designed to make your workflow more efficient and productive.
+split_with_image partial
+Responsive two-column layout with image and rich content.
 
-## Key benefits
-
-* **Faster deployment** - Push changes directly to production with confidence
-* **Seamless collaboration** - Work together across teams and time zones
-* **Built-in analytics** - Track performance metrics in real-time
-
-The system automatically scales based on your needs, so you never have to worry about infrastructure management again.
-      "
-      "features" (slice
-          (dict 
-              "icon" "link" 
-              "title" "One-click Deployment" 
-              "description" "Deploy your projects with a single click through our intuitive interface or API."
-          )
-          (dict 
-              "icon" "lock" 
-              "title" "Enterprise Security" 
-              "description" "Bank-grade security protocols with automatic SSL certificates and advanced access controls."
-          )
-      )
-      "subheading" "Built for developers"
-  ) }}
-@note: This section has a responsive layout - on mobile the image appears above the content, while on desktop the image takes up half the width on the left side with content on the right. The image scales to fill its container while maintaining aspect ratio. The markdownContent parameter allows for rich formatting including paragraphs, lists, headings, and emphasis.
+Parameters:
+- layout: "image-left" | "image-right" (default: "image-left")
+- image, imageAlt, imageBgColor: Image settings
+- eyebrow, heading, description: Text content
+- link, linkText, buttonStyle: CTA button
+- markdownContent, contentAsHTML: Main content
+- features: [{icon, title, description}]
+- stats: [{number, label}]
+- quote: {text, author, role, company, avatar}
+- Color classes: *Color parameters for styling
 */}}
 
-{{/* Configurable variables */}}
-{{ $bgColor := .bgColor | default "bg-white" }}
-
-{{/* Image section */}}
-{{ $image := .image | default "" }}
-{{ $imageAlt := .imageAlt | default "" }}
-{{ $imageBgColor := .imageBgColor | default "bg-gray-50" }}
-{{ $imageHeight := .imageHeight | default "h-full" }}
-{{ $imageObjectFit := .imageObjectFit | default "object-cover" }}
-
-{{/* Content section */}}
-{{ $eyebrow := .eyebrow | default "" }}
+{{ $layout := .layout | default "image-left" }}
+{{ $image := .image }}
+{{ $imageAlt := .imageAlt }}
+{{ $eyebrow := .eyebrow }}
 {{ $eyebrowColor := .eyebrowColor | default "text-primary" }}
-{{ $heading := .heading | default "" }}
-{{ $headingColor := .headingColor | default "text-gray-900" }}
+{{ $heading := .heading }}
+{{ $headingColor := .headingColor | default "text-heading" }}
 {{ $description := .description }}
 {{ $descriptionColor := .descriptionColor | default "text-gray-700" }}
-
-{{/* Main content */}}
+{{ $link := .link }}
+{{ $linkText := .linkText }}
+{{ $linkTarget := .linkTarget | default "_self" }}
+{{ $buttonStyle := .buttonStyle | default "primary" }}
 {{ $contentColor := .contentColor | default "text-gray-700" }}
 {{ $markdownContent := .markdownContent }}
-{{/* Features */}}
-{{ $featureTextColor := .featureTextColor | default "text-gray-600" }}
-{{ $featureHeadingColor := .featureHeadingColor | default "text-gray-900" }}
-{{ $iconColor := .iconColor | default "text-primary" }}
-{{ $features := .features | default (slice) }}
 {{ $contentAsHTML := .contentAsHTML | default false }}
+{{ $features := .features | default (slice) }}
+{{ $stats := .stats | default (slice) }}
+{{ $quote := .quote }}
 
 
-<div class="relative {{ $bgColor }} mb-2.5">
-  <div class="wrapper lg:flex lg:justify-between lg:items-center">
-    <div class="lg:flex lg:w-1/2 lg:items-center lg:shrink lg:grow-0 xl:relative xl:inset-y-0 xl:right-0 xl:w-1/2">
-      <div class="relative flex items-center justify-center w-full overflow-hidden">
-        {{ partial "components/media/lazyimg.html" (dict
-          "src" $image 
-          "alt" $imageAlt
-          "class" "w-full max-h-full {{ $imageBgColor }} {{ $imageObjectFit }} rounded-lg"
-        ) }}
+<div class="split-with-image-section section-bg-light py-24 lg:py-32">
+  <div class="wrapper lg:flex lg:justify-between lg:items-stretch{{ if eq $layout "image-right" }} lg:flex-row-reverse{{ end }}">
+    <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 {{ if eq $layout "image-right" }}xl:left-0{{ else }}xl:right-0{{ end }}">
+      <div class="relative py-6 flex items-start justify-center w-full overflow-hidden mx-auto max-w-[608px] max-h-[560px]">
+        {{ if $link }}
+          <a href="{{ $link }}" target="{{ $linkTarget }}" class="block w-full">
+        {{ end }}
+            {{ partial "components/media/lazyimg.html" (dict
+              "src" $image
+              "alt" $imageAlt
+              "class" "w-full max-w-[484px] max-h-[522px] object-cover rounded-lg hover:opacity-90 transition-opacity duration-200"
+            ) }}
+        {{ if $link }}
+          </a>
+        {{ end }}
       </div>
     </div>
-    <div class="lg:contents">
-      <div class="mx-auto max-w-2xl pt-16 pb-24 sm:pt-20 sm:pb-32 lg:mr-0 lg:ml-8 lg:w-full lg:max-w-lg lg:flex-none lg:pt-32 xl:w-1/2">
+    <div class="lg:flex lg:w-1/2 lg:items-center">
+      <div class="py-4 lg:w-full lg:flex-none {{ if eq $layout "image-right" }}lg:pl-0 lg:ml-0 lg:mr-8{{ else }}lg:pl-20 lg:mr-0 lg:ml-8{{ end }}">
         {{ if $eyebrow }}
-        <p class="text-base/7 font-semibold {{ $eyebrowColor }}">{{ $eyebrow }}</p>
+          <p class="text-base/7 font-semibold {{ $eyebrowColor }}">{{ $eyebrow }}</p>
         {{ end }}
         {{ if $heading}}
-        <h2 class="mt-2 text-4xl font-semibold tracking-tight text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
+          <h2 class="mt-3 text-4xl font-semibold tracking-[-2.832px] leading-none text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
         {{ end }}
         {{ if $description }}
-        <p class="mt-6 text-xl/8 {{ $descriptionColor }}">{{ partial "utils/linkbuilding" (dict "content" $description "page" .) | safeHTML }}</p>
+          <p class="mt-6 text-lg/7 {{ $descriptionColor }}">{{ partial "utils/linkbuilding" (dict "content" $description "page" .) | safeHTML }}</p>
         {{ end }}
-        <div class="mt-10 max-w-xl text-base/7 {{ $contentColor }} lg:max-w-none">
+
+        {{/* Button */}}
+        {{ if $link }}
+        <div class="mt-6">
+          {{ partial "components/buttons/buttons.html" (dict
+            "text" $linkText
+            "url" $link
+            "target" $linkTarget
+            "variant" $buttonStyle
+          ) }}
+        </div>
+        {{ end }}
+
+        {{/* Main content */}}
+        <div class="mt-10 max-w-full {{ $contentColor }} lg:max-w-full">
           {{ if $markdownContent }}
             {{ if $contentAsHTML }}
                 {{ $markdownContent | safeHTML }}
@@ -117,20 +85,58 @@ The system automatically scales based on your needs, so you never have to worry 
                 {{ $markdownContent | markdownify }}
             {{ end }}
           {{ end }}
-          {{ if $features }}
-          <ul role="list" class="mt-8 pl-0 space-y-8 {{ $featureTextColor }}">
-            {{ range $features }}
-            <li class="flex item gap-x-3">
-              {{ if .icon }}
-              <span class="size-5 text-primary mr-2 flex-shrink-0">{{ partial "components/media/icon.html" (dict "icon" .icon) }}</span>
-              {{ end }}
-              <span><strong class="font-semibold {{ $featureHeadingColor }}">{{ .title }}.</strong> {{ .description }}</span>
-            </li>
-            {{ end }}
-          </ul>
-          {{ end }}
         </div>
-      </div>
+
+        {{/* Features */}}
+        {{ if $features }}
+        <dl class="mt-10 max-w-full space-y-8 text-lg/7 text-body lg:max-w-full">
+          {{ range $features }}
+          <div class="relative pl-9">
+            <dt class="inline font-bold text-heading">
+              {{ if .icon }}
+                <span class="absolute left-1 top-1 size-5 text-primary">
+                  {{ partial "components/media/icon.html" (dict "icon" .icon) }}
+                </span>
+              {{ end }}
+              {{ .title }}.
+            </dt>
+            <dd class="inline">{{ .description }}</dd>
+          </div>
+          {{ end }}
+        </dl>
+        {{ end }}
+
+        {{/* Stats */}}
+        {{ if $stats }}
+        <dl class="mt-10 grid max-w-full grid-cols-1 gap-8 sm:grid-cols-2">
+          {{ range $stats }}
+          <div class="flex flex-col gap-y-3 border-l border-gray-900/10 pl-6">
+            <dt class="text-sm/6 text-body">{{ .label }}</dt>
+            <dd class="order-first text-3xl font-semibold tracking-tight text-heading">{{ .number }}</dd>
+          </div>
+          {{ end }}
+        </dl>
+        {{ end }}
+
+        {{/* Quote */}}
+        {{ if $quote }}
+        <div class="lg:max-w-full">
+          <figure class="mt-10 border-l border-gray-200 pl-8 text-body">
+            <blockquote class="text-base/7">
+              <p>"{{ $quote.text }}"</p>
+            </blockquote>
+            <figcaption class="mt-6 flex gap-x-4 text-sm/6">
+              {{ if $quote.avatar }}
+              <img src="{{ $quote.avatar }}" alt="{{ $quote.author }}" class="size-6 flex-none rounded-full" />
+              {{ end }}
+              <div>
+                <span class="font-semibold text-heading">{{ $quote.author }}</span>
+                {{ if $quote.role }} – {{ $quote.role }}{{ end }}{{ if $quote.company }}, {{ $quote.company }}{{ end }}
+              </div>
+            </figcaption>
+          </figure>
+        </div>
+      {{ end }}
     </div>
   </div>
 </div>

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -12,6 +12,24 @@ Parameters:
 - stats: [{number, label}]
 - quote: {text, author, role, company, avatar}
 - Color classes: *Color parameters for styling
+
+Custom Color Classes Documentation:
+- text-heading: Primary heading text color (typically dark for contrast)
+- text-primary: Brand primary color for accents and CTAs
+- text-body: Standard body text color (readable gray)
+- text-gray-700: Tailwind gray-700 for secondary text
+- section-bg-light: Light background for sections
+
+Usage Guidelines:
+- Use text-heading for main headings and emphasized text elements
+- Use text-primary for brand accents, links, and call-to-action elements
+- Use text-body for regular paragraph text and descriptions
+- Ensure color contrast meets accessibility standards (WCAG AA)
+
+Design Tokens:
+- Image dimensions are configurable via variables for easy maintenance
+- Spacing values use consistent design system tokens
+- Typography tracking and sizing follow brand guidelines
 */}}
 
 {{ $layout := .layout | default "image-left" }}
@@ -34,18 +52,31 @@ Parameters:
 {{ $stats := .stats | default (slice) }}
 {{ $quote := .quote }}
 
+{{/* Design tokens and configurable dimensions */}}
+{{ $imageContainerMaxWidth := "608px" }}
+{{ $imageContainerMaxHeight := "560px" }}
+{{ $imageMaxWidth := "484px" }}
+{{ $imageMaxHeight := "522px" }}
+{{ $sectionPaddingY := "py-24 lg:py-32" }}
+{{ $imageContainerPaddingY := "py-6" }}
+{{ $contentPaddingY := "py-4" }}
+{{ $contentLeftPadding := "lg:pl-20" }}
+{{ $contentMarginSpacing := "lg:mr-0 lg:ml-8" }}
+{{ $contentMarginSpacingReverse := "lg:pl-0 lg:ml-0 lg:mr-8" }}
+{{ $headingTracking := "tracking-[-2.832px]" }}
 
-<div class="split-with-image-section section-bg-light py-24 lg:py-32">
+
+<div class="split-with-image-section section-bg-light {{ $sectionPaddingY }}">
   <div class="wrapper lg:flex lg:justify-between lg:items-stretch{{ if eq $layout "image-right" }} lg:flex-row-reverse{{ end }}">
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 {{ if eq $layout "image-right" }}xl:left-0{{ else }}xl:right-0{{ end }}">
-      <div class="relative py-6 flex items-start justify-center w-full overflow-hidden mx-auto max-w-[608px] max-h-[560px]">
+      <div class="relative {{ $imageContainerPaddingY }} flex items-start justify-center w-full overflow-hidden mx-auto max-w-[{{ $imageContainerMaxWidth }}] max-h-[{{ $imageContainerMaxHeight }}]">
         {{ if $link }}
           <a href="{{ $link }}" target="{{ $linkTarget }}" class="block w-full">
         {{ end }}
             {{ partial "components/media/lazyimg.html" (dict
               "src" $image
               "alt" $imageAlt
-              "class" "w-full max-w-[484px] max-h-[522px] object-cover rounded-lg hover:opacity-90 transition-opacity duration-200"
+              "class" (printf "w-full max-w-[%s] max-h-[%s] object-cover rounded-lg hover:opacity-90 transition-opacity duration-200" $imageMaxWidth $imageMaxHeight)
             ) }}
         {{ if $link }}
           </a>
@@ -53,12 +84,12 @@ Parameters:
       </div>
     </div>
     <div class="lg:flex lg:w-1/2 lg:items-center">
-      <div class="py-4 lg:w-full lg:flex-none {{ if eq $layout "image-right" }}lg:pl-0 lg:ml-0 lg:mr-8{{ else }}lg:pl-20 lg:mr-0 lg:ml-8{{ end }}">
+      <div class="{{ $contentPaddingY }} lg:w-full lg:flex-none {{ if eq $layout "image-right" }}{{ $contentMarginSpacingReverse }}{{ else }}{{ $contentLeftPadding }} {{ $contentMarginSpacing }}{{ end }}">
         {{ if $eyebrow }}
           <p class="text-base/7 font-semibold {{ $eyebrowColor }}">{{ $eyebrow }}</p>
         {{ end }}
         {{ if $heading}}
-          <h2 class="mt-3 text-4xl font-semibold tracking-[-2.832px] leading-none text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
+          <h2 class="mt-3 text-4xl font-semibold {{ $headingTracking }} leading-none text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
         {{ end }}
         {{ if $description }}
           <p class="mt-6 text-lg/7 {{ $descriptionColor }}">{{ partial "utils/linkbuilding" (dict "content" $description "page" .) | safeHTML }}</p>

--- a/layouts/shortcodes/content-split-with-image.html
+++ b/layouts/shortcodes/content-split-with-image.html
@@ -1,66 +1,310 @@
-{{- /*
-  Usage in markdown:
-  {{< content-split-with-image 
-    eyebrow="Innovative Solutions" 
-    heading="Transform Your Workflow" 
-    markdownContent="Discover how our tools can help you streamline your processes and achieve better results." 
-    image="https://example.com/image.jpg" 
-    imageAlt="Descriptive alt text for the image" 
-    bgColor="bg-gray-100" 
-    eyebrowColor="text-primary"
-    headingColor="text-black" 
-    descriptionColor="text-gray-600" 
-    contentColor="text-gray-800" 
-    imageBgColor="bg-white" 
-  >}}
-  
-  Parameters:
-  1. eyebrow: Small text displayed above the main heading
-  2. heading: Main heading text
-  3. description: Description text below the main heading
-  4. image: URL of the image to display
-  5. imageAlt: Alt text for the image
-  6. bgColor: Background color class for the section
-  7. eyebrowColor: Text color class for the eyebrow text
-  8. headingColor: Text color class for the main heading
-  9. descriptionColor: Text color class for the description text
-  10. contentColor: Text color class for the main content
-  11. imageBgColor: Background color class for the image container
-  12. features: Optional array of feature objects to display in the content section
-*/ -}}
+{{/*
+    Shortcode: content-split-with-image
+    Purpose: Combines visual elements with textual content and structured data (features, stats, quote).
 
-{{/* Split with Image Content Shortcode */}}
+    Features:
+    - Supports mixed content: markdown/HTML + JSON data block
+    - Uses START_JSON_BLOCK/END_JSON_BLOCK markers to separate JSON from content (markdown/HTML)
+    - JSON markers are removed from final rendered content
+
+    Parameters:
+    - heading: Main title for the section
+    - eyebrow: Small text above heading (default: "")
+    - description: Text below heading (default: "")
+    - layout: "image-left" or "image-right" (default: "image-left")
+    - image: Image path (default: "")
+    - imageAlt: Alt text for image (default: "")
+    - link: CTA link URL (default: "")
+    - linkText: CTA button text (default (i18n "learnMore"))
+    - linkTarget: Link target "_self" or "_blank" (default: "_self")
+    - buttonStyle: "primary" or "secondary" (default: "primary")
+    - bgColor: Background color class (default: "bg-white")
+    - eyebrowColor: Eyebrow text color (default: "text-primary")
+    - headingColor: Heading color (default: "text-gray-900")
+    - descriptionColor: Description color (default: "text-gray-700")
+    - contentColor: Content text color (default: "text-gray-700")
+    - imageBgColor: Image container background (default: "bg-gray-50")
+    - contentAsHTML: Render content as HTML instead of markdown (default: false)
+    - features: JSON string or "features" to use page params
+    - stats: JSON string or "stats" to use page params
+    - quote: JSON string or "quote" to use page params
+
+    USAGE EXAMPLES:
+
+    1. CONTENT ONLY (markdown/HTML content):
+    {{< content-split-with-image
+        eyebrow="Automation Platform"
+        heading="Transform Your Workflow"
+        description="Discover the power of automation"
+        image="/images/workflow-automation.jpg"
+        imageAlt="Workflow automation dashboard"
+        layout="image-left"
+        link="/get-started"
+        linkText="Start Free Trial"
+        buttonStyle="primary"
+        eyebrowColor="text-purple-600"
+        headingColor="text-gray-900"
+        descriptionColor="text-gray-600"
+    >}}
+     ## Test markdown and HTML content
+    Test **bold text**, *italic text*, and [links](https://example.com).
+    Test list:
+    - Item 1
+    - Item 2
+    - Item 3
+    <p class="text-gray-600 mt-4">This is a paragraph with <strong>bold</strong> and <em>italic</em> text.</p>
+    {{< /content-split-with-image >}}
+
+    2. JSON DATA ONLY (structured data blocks):
+    {{< content-split-with-image
+        heading="By the Numbers"
+        image="/images/statistics.jpg"
+        imageAlt="Platform statistics"
+        layout="image-right"
+    >}}
+    {
+      "features": [
+        {
+          "icon": "star-solid",
+          "title": "Automatic Detection",
+          "description": "Automatically finds and extracts JSON blocks from content."
+        },
+        {
+          "icon": "cog-solid",
+          "title": "Flexible Configuration",
+          "description": "Supports various layout options and styling configurations."
+        }
+      ],
+      "stats": [
+        { "number": "10M+", "label": "API Calls Daily" },
+        { "number": "99.9%", "label": "Uptime SLA" },
+        { "number": "500+", "label": "Enterprise Clients" },
+        { "number": "24/7", "label": "Expert Support" }
+      ],
+      "quote": {
+        "text": "Switching to this platform increased our team productivity by 300%. The ROI was evident within the first month.",
+        "author": "Michael Chen",
+        "role": "VP of Engineering",
+        "company": "TechCorp",
+        "avatar": "/images/avatars/michael-chen.jpg"
+      }
+    }
+    {{< /content-split-with-image >}}
+
+    3. COMBINED (JSON data + content):
+    {{< content-split-with-image
+        heading="Complete AI Solution"
+        description="Everything you need in one platform"
+        eyebrow="All-in-One Platform"
+        image="/images/ai-platform.jpg"
+        imageAlt="AI platform interface"
+        layout="image-left"
+        link="/demo"
+        linkText="Book a Demo"
+        linkTarget="_blank"
+    >}}
+    START_JSON_BLOCK
+    {
+      "features": [
+        {
+          "icon": "star-solid",
+          "title": "Automatic Detection",
+          "description": "Automatically finds and extracts JSON blocks from content."
+        },
+        {
+          "icon": "cog-solid",
+          "title": "Flexible Configuration",
+          "description": "Supports various layout options and styling configurations."
+        }
+      ],
+      "stats": [
+        { "number": "95%", "label": "Accuracy Rate" },
+        { "number": "< 100ms", "label": "Response Time" }
+      ],
+      "quote": {
+        "text": "The AI capabilities exceeded our expectations. Implementation was seamless.",
+        "author": "Dr. Sarah Martinez",
+        "role": "Data Science Lead",
+        "company": "InnovateLab",
+        "avatar": "/images/avatars/sarah-martinez.jpg"
+      }
+    }
+    END_JSON_BLOCK
+
+    ## Test markdown and HTML content
+    Test **bold text**, *italic text*, and [links](https://example.com).
+    Test list:
+    - Item 1
+    - Item 2
+    - Item 3
+    <p class="text-gray-600 mt-4">This is a paragraph with <strong>bold</strong> and <em>italic</em> text.</p>
+    {{< /content-split-with-image >}}
+
+    DATA STRUCTURE DETAILS:
+
+    Features List:
+    {
+      "features": [
+        {
+          "icon": "icon-name",        // Icon identifier (from /internal/design-system/#icons)
+          "title": "Feature Title",   // Feature name
+          "description": "Details"    // Feature description
+        }
+      ]
+    }
+
+    Stats List:
+    {
+      "stats": [
+        {
+          "number": "99%",           // Statistic value
+          "label": "Success Rate"    // Statistic label
+        }
+      ]
+    }
+
+    Quote Object:
+    {
+      "quote": {
+        "text": "Quote content here",     // Quote text (required)
+        "author": "Author Name",      // Author name (required)
+        "role": "Job Title",          // Author's job title (optional)
+        "company": "Company Name",    // Author's company (optional)
+        "avatar": "/path/to/avatar.jpg" // Author's avatar image (optional)
+      }
+    }
+
+    NOTES:
+    - If you don't need certain data blocks (features, stats, quote), simply omit them
+    - JSON blocks are completely optional - you can use just markdown/HTML content
+    - Content can be pure markdown, pure HTML, or mixed
+*/}}
+
+{{ $currentPage := .Page }}
+
+{{/* Shortcode parameters */}}
 {{ $eyebrow := .Get "eyebrow" | default "" }}
 {{ $heading := .Get "heading" | default "" }}
 {{ $description := .Get "description" | default "" }}
-{{ $featuresParam := .Get "features" }}
-{{ $features := slice }}
-{{ if $featuresParam }}
-  {{ if eq $featuresParam "features" }}
-    {{ $features = .Page.Params.features }}
-  {{ else }}
-    {{ $features = $featuresParam }}
-  {{ end }}
-{{ end }}
+{{ $layout := .Get "layout" | default "image-left" }}
 {{ $image := .Get "image" | default "" }}
 {{ $imageAlt := .Get "imageAlt" | default "" }}
+{{ $link := .Get "link" | default "" }}
+{{ $linkText := .Get "linkText" | default (i18n "learnMore") | default "Learn more" }}
+{{ $linkTarget := .Get "linkTarget" | default "_self" }}
+{{ $buttonStyle := .Get "buttonStyle" | default "primary" }}
 {{ $bgColor := .Get "bgColor" | default "bg-white" }}
 {{ $eyebrowColor := .Get "eyebrowColor" | default "text-primary" }}
 {{ $headingColor := .Get "headingColor" | default "text-gray-900" }}
 {{ $descriptionColor := .Get "descriptionColor" | default "text-gray-700" }}
 {{ $contentColor := .Get "contentColor" | default "text-gray-700" }}
-{{ $imageBgColor := .Get "imageBgColor" | default "bg-gray-50" }}
+{{ $contentAsHTML := .Get "contentAsHTML" | default false }}
 
-{{/* 
-  Note: For this shortcode, we're using the default paragraphs from the partial.
-  In a real-world implementation, you might want to allow passing in custom content
-  through a structured data file or inner content.
-*/}}
+{{/* Initialize data */}}
+{{ $features := slice }}
+{{ $stats := slice }}
+{{ $quote := dict }}
+{{ $markdownContent := "" }}
+{{ $innerData := dict }}
 
-{{ partial "sections/content/split_with_image.html" (dict 
+{{/* Get inner content */}}
+{{ $rawInnerContent := "" }}
+{{ with .Inner }}
+    {{ $rawInnerContent = string . }}
+{{ end }}
+{{ $rawInnerContent = trim $rawInnerContent " \n\r\t" }}
+
+{{/* Parse JSON block with START_JSON_BLOCK/END_JSON_BLOCK markers */}}
+{{ $jsonStartMarker := "START_JSON_BLOCK" }}
+{{ $jsonEndMarker := "END_JSON_BLOCK" }}
+
+{{ if and (in $rawInnerContent $jsonStartMarker) (in $rawInnerContent $jsonEndMarker) }}
+    {{ $parts := split $rawInnerContent $jsonStartMarker }}
+    {{ if gt (len $parts) 1 }}
+        {{ $beforeJson := index $parts 0 }}
+        {{ $afterStartMarker := index $parts 1 }}
+
+        {{ $jsonParts := split $afterStartMarker $jsonEndMarker }}
+        {{ if gt (len $jsonParts) 1 }}
+            {{ $potentialJSON := index $jsonParts 0 }}
+            {{ $afterJson := index $jsonParts 1 }}
+
+            {{/* Parse JSON if present */}}
+            {{ with $potentialJSON | unmarshal }}
+                {{ if or .features .stats .quote .markdownContent .htmlContent .contentAsHTML }}
+                    {{ $innerData = . }}
+                {{ end }}
+            {{ end }}
+
+            {{/* Reconstruct markdown content (exclude JSON block) */}}
+            {{ $markdownContent = printf "%s%s" (trim $beforeJson " \n\r\t") (trim $afterJson " \n\r\t") }}
+        {{ else }}
+            {{ $markdownContent = $rawInnerContent }}
+        {{ end }}
+    {{ else }}
+        {{ $markdownContent = $rawInnerContent }}
+    {{ end }}
+{{ else }}
+    {{ $markdownContent = $rawInnerContent }}
+{{ end }}
+
+
+{{/* Data consolidation: inner JSON > shortcode params > page params */}}
+{{ $features = $innerData.features | default $features }}
+{{ $stats = $innerData.stats | default $stats }}
+{{ $quote = $innerData.quote | default $quote }}
+
+{{/* Override with shortcode parameters */}}
+{{ with .Get "features" }}
+  {{ if eq . "features" }}
+    {{ $features = $currentPage.Params.features | default $features }}
+  {{ else }}
+    {{ $features = . | unmarshal | default $features }}
+  {{ end }}
+{{ end }}
+
+{{ with .Get "stats" }}
+  {{ if eq . "stats" }}
+    {{ $stats = $currentPage.Params.stats | default $stats }}
+  {{ else }}
+    {{ $stats = . | unmarshal | default $stats }}
+  {{ end }}
+{{ end }}
+
+{{ with .Get "quote" }}
+  {{ if eq . "quote" }}
+    {{ $quote = $currentPage.Params.quote | default $quote }}
+  {{ else }}
+    {{ $quote = . | unmarshal | default $quote }}
+  {{ end }}
+{{ end }}
+
+{{/* Handle additional content from JSON */}}
+{{ if $innerData.markdownContent }}
+  {{ $markdownContent = printf "%s\n\n%s" $markdownContent $innerData.markdownContent }}
+{{ else if $innerData.htmlContent }}
+  {{ $htmlContent := $innerData.htmlContent }}
+  {{ if reflect.IsSlice $htmlContent }}
+    {{ $htmlContent = delimit $htmlContent "" }}
+  {{ end }}
+  {{ $markdownContent = printf "%s\n\n%s" $markdownContent $htmlContent }}
+  {{ $contentAsHTML = true }}
+{{ end }}
+
+{{ if $innerData.contentAsHTML }}
+  {{ $contentAsHTML = $innerData.contentAsHTML }}
+{{ end }}
+
+{{/* Render partial */}}
+{{ partial "sections/content/split_with_image.html" (dict
   "eyebrow" $eyebrow
   "heading" $heading
   "description" $description
+  "layout" $layout
+  "link" $link
+  "linkText" $linkText
+  "linkTarget" $linkTarget
+  "buttonStyle" $buttonStyle
   "image" $image
   "imageAlt" $imageAlt
   "bgColor" $bgColor
@@ -68,7 +312,9 @@
   "headingColor" $headingColor
   "descriptionColor" $descriptionColor
   "contentColor" $contentColor
-  "imageBgColor" $imageBgColor
-  "markdownContent" (.Inner )
+  "markdownContent" $markdownContent
+  "contentAsHTML" $contentAsHTML
   "features" $features
+  "stats" $stats
+  "quote" $quote
 ) }}

--- a/layouts/shortcodes/content-split-with-image.html
+++ b/layouts/shortcodes/content-split-with-image.html
@@ -6,6 +6,8 @@
     - Supports mixed content: markdown/HTML + JSON data block
     - Uses START_JSON_BLOCK/END_JSON_BLOCK markers to separate JSON from content (markdown/HTML)
     - JSON markers are removed from final rendered content
+    - Robust JSON parsing with error handling and fallback mechanisms
+    - Graceful degradation when JSON is malformed or missing
 
     Parameters:
     - heading: Main title for the section
@@ -229,11 +231,30 @@
             {{ $potentialJSON := index $jsonParts 0 }}
             {{ $afterJson := index $jsonParts 1 }}
 
-            {{/* Parse JSON if present */}}
-            {{ with $potentialJSON | unmarshal }}
-                {{ if or .features .stats .quote .markdownContent .htmlContent .contentAsHTML }}
-                    {{ $innerData = . }}
+            {{/* Parse JSON if present with error handling */}}
+            {{ $potentialJSON = trim $potentialJSON " \n\r\t" }}
+            {{ if $potentialJSON }}
+              {{ $parseResult := dict }}
+              {{ if $potentialJSON }}
+                {{ $jsonString := trim $potentialJSON " \n\r\t" }}
+                {{ if $jsonString }}
+                  {{ $unmarshalResult := dict }}
+                  {{ $errorOccurred := false }}
+                  {{/* Attempt to unmarshal JSON with error handling */}}
+                  {{ $unmarshalResult = unmarshal $jsonString }}
+                  {{ if not $unmarshalResult }}
+                    {{ warnf "JSON unmarshal returned empty result in inner-content-json-block. JSON content (first 200 chars): %s. Using empty fallback." (substr $jsonString 0 200) }}
+                    {{ $unmarshalResult = dict }}
+                  {{ end }}
+                  {{ $parseResult = $unmarshalResult }}
                 {{ end }}
+              {{ end }}
+              
+              {{ if or $parseResult.features $parseResult.stats $parseResult.quote $parseResult.markdownContent $parseResult.htmlContent $parseResult.contentAsHTML }}
+                {{ $innerData = $parseResult }}
+              {{ else }}
+                {{ warnf "JSON block found but contains no recognized data structures (features, stats, quote, markdownContent, htmlContent, contentAsHTML). Content: %s" (substr $potentialJSON 0 200) }}
+              {{ end }}
             {{ end }}
 
             {{/* Reconstruct markdown content (exclude JSON block) */}}
@@ -259,7 +280,16 @@
   {{ if eq . "features" }}
     {{ $features = $currentPage.Params.features | default $features }}
   {{ else }}
-    {{ $features = . | unmarshal | default $features }}
+    {{ $jsonString := trim . " \n\r\t" }}
+    {{ if $jsonString }}
+      {{ $unmarshalResult := dict }}
+      {{ $unmarshalResult = unmarshal $jsonString }}
+      {{ if $unmarshalResult }}
+        {{ $features = $unmarshalResult }}
+      {{ else }}
+        {{ warnf "Failed to parse features JSON from shortcode parameter. JSON content (first 200 chars): %s. Using fallback." (substr $jsonString 0 200) }}
+      {{ end }}
+    {{ end }}
   {{ end }}
 {{ end }}
 
@@ -267,7 +297,16 @@
   {{ if eq . "stats" }}
     {{ $stats = $currentPage.Params.stats | default $stats }}
   {{ else }}
-    {{ $stats = . | unmarshal | default $stats }}
+    {{ $jsonString := trim . " \n\r\t" }}
+    {{ if $jsonString }}
+      {{ $unmarshalResult := dict }}
+      {{ $unmarshalResult = unmarshal $jsonString }}
+      {{ if $unmarshalResult }}
+        {{ $stats = $unmarshalResult }}
+      {{ else }}
+        {{ warnf "Failed to parse stats JSON from shortcode parameter. JSON content (first 200 chars): %s. Using fallback." (substr $jsonString 0 200) }}
+      {{ end }}
+    {{ end }}
   {{ end }}
 {{ end }}
 
@@ -275,7 +314,16 @@
   {{ if eq . "quote" }}
     {{ $quote = $currentPage.Params.quote | default $quote }}
   {{ else }}
-    {{ $quote = . | unmarshal | default $quote }}
+    {{ $jsonString := trim . " \n\r\t" }}
+    {{ if $jsonString }}
+      {{ $unmarshalResult := dict }}
+      {{ $unmarshalResult = unmarshal $jsonString }}
+      {{ if $unmarshalResult }}
+        {{ $quote = $unmarshalResult }}
+      {{ else }}
+        {{ warnf "Failed to parse quote JSON from shortcode parameter. JSON content (first 200 chars): %s. Using fallback." (substr $jsonString 0 200) }}
+      {{ end }}
+    {{ end }}
   {{ end }}
 {{ end }}
 


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Updated content-split-with-image shortcode and partial for it.
Added position for image/content
Added mixed content (markdown/html and json component (features, stats, quote)).
We can use this shortcode set any sections, combine them
Updated styles for it

**Testing instructions**
We can go any page with content-split-with-image shortcode (e.g. /ai-agents) and set additional section for test

QualityUnit/web-issues#3552
