### PR TITLE
feat: added alternate background style and numbered features

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -58,8 +58,13 @@
 
   /* PRODUCT CONTENT STYLES */
   .product-primary {
-    @apply bg-primary dark:bg-primary-500;
+    @apply text-primary dark:text-primary-500;
     /* Primary product text – primary color in light mode, primary-500 in dark mode */
+  }
+
+  .product-bg-primary {
+    @apply bg-primary dark:bg-primary-500;
+    /* Primary product background – primary color in light mode, primary-500 in dark mode */
   }
 
   .product-text {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -16,6 +16,11 @@
     /* Light background, typically for white or neutral sections */
   }
 
+  .section-bg-alternate {
+    @apply bg-gray-50;
+    /* Alternate background, light gray in light mode, dark gray in dark mode */
+  }
+
   .section-bg-dark {
     @apply bg-gray-900;
     /* Dark background, used for contrast or "dark mode" sections */
@@ -53,7 +58,7 @@
 
   /* PRODUCT CONTENT STYLES */
   .product-primary {
-    @apply text-primary dark:text-primary-500;
+    @apply bg-primary dark:bg-primary-500;
     /* Primary product text – primary color in light mode, primary-500 in dark mode */
   }
 

--- a/layouts/partials/sections/bentogrids/three_column_bento_grid.html
+++ b/layouts/partials/sections/bentogrids/three_column_bento_grid.html
@@ -71,7 +71,7 @@
   <div class="section-bg-light dark:section-bg-dark py-24 sm:py-32">
     <div class="wrapper">
       {{ if $tagline }}
-        <h2 class="text-center text-base/7 font-semibold text-product-primary">{{ $tagline }}</h2>
+        <h2 class="text-center text-base/7 font-semibold product-text">{{ $tagline }}</h2>
       {{ end }}
       {{ if $heading }}
         <p class="{{ if $tagline }}mt-2{{ end }} text-center text-4xl font-semibold tracking-tight text-balance text-heading sm:text-5xl">{{ $heading }}</p>
@@ -93,7 +93,7 @@
                 
                 <div class="p-4 lg:p-8">
                   {{ if $card.title }}
-                    <p class="text-base/8 font-medium tracking-tight text-heading max-md:text-center {{ if $card.url }}group-hover:text-product-primary{{ end }}">{{ $card.title }}</p>
+                    <p class="text-base/8 font-medium tracking-tight text-heading max-md:text-center {{ if $card.url }}group-hover:product-text{{ end }}">{{ $card.title }}</p>
                   {{ end }}
 
                   {{ if $card.description }}

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -57,10 +57,6 @@ Design Tokens:
 {{ $quote := .quote }}
 
 {{/* Design tokens and configurable dimensions */}}
-{{ $imageContainerMaxWidth := "608px" }}
-{{ $imageContainerMaxHeight := "560px" }}
-{{ $imageMaxWidth := "484px" }}
-{{ $imageMaxHeight := "522px" }}
 {{ $sectionPaddingY := "py-24 lg:py-32" }}
 {{ $imageContainerPaddingY := "py-6" }}
 {{ $contentPaddingY := "py-4" }}
@@ -72,16 +68,14 @@ Design Tokens:
 <div class="split-with-image-section {{ if $isDark }}dark section-bg-dark{{ else if $isAlternate }}section-bg-alternate{{ else }}section-bg-light{{ end }} {{ $sectionPaddingY }}">
   <div class="wrapper lg:flex lg:justify-between lg:items-stretch{{ if eq $layout "image-right" }} lg:flex-row-reverse{{ end }}">
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 {{ if eq $layout "image-right" }}xl:left-0{{ else }}xl:right-0{{ end }}">
-      <div class="relative {{ $imageContainerPaddingY }} flex items-start justify-center w-full overflow-hidden mx-auto max-w-[{{ $imageContainerMaxWidth }}] max-h-[{{ $imageContainerMaxHeight }}]">
+      <div class="relative {{ $imageContainerPaddingY }} flex items-start justify-center w-full overflow-hidden mx-auto max-w-[38rem] max-h-[35rem]">
         {{ if $link }}
           <a href="{{ $link }}" target="{{ $linkTarget }}" class="block w-full">
         {{ end }}
             {{ partial "components/media/lazyimg.html" (dict
               "src" $image
               "alt" $imageAlt
-              "class" (printf "max-w-[%s] max-h-[%s] object-cover rounded-lg hover:opacity-90 transition-opacity duration-200" $imageMaxWidth $imageMaxHeight)
-              "width" $imageMaxWidth
-              "height" $imageMaxHeight
+              "class" "w-[30.25rem] h-[32.625rem] object-cover rounded-lg hover:opacity-90 transition-opacity duration-200"
             ) }}
         {{ if $link }}
           </a>

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -145,13 +145,13 @@ Design Tokens:
         {{ if $numbered_features }}
           <ol class="mt-10 max-w-full space-y-3 text-lg/7 text-body lg:max-w-full">
             {{ range $index, $feature := $numbered_features }}
-              <div class="relative pl-9">
+              <li class="relative pl-9">
                 <span class="inline text-heading font-bold">
                   <span class="absolute left-1 top-2 w-5 h-5 text-[10px] flex justify-center items-center text-white rounded-full bg-primary">{{ add $index 1 }}</span>
                   {{ .title }}.
                 </span>
                 <span class="inline">{{ .description }}</span>
-              </div>
+              </li>
             {{ end }}
           </ol>
         {{ end }}

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -80,7 +80,9 @@ Design Tokens:
             {{ partial "components/media/lazyimg.html" (dict
               "src" $image
               "alt" $imageAlt
-              "class" (printf "w-full max-w-[%s] max-h-[%s] object-cover rounded-lg hover:opacity-90 transition-opacity duration-200" $imageMaxWidth $imageMaxHeight)
+              "class" (printf "max-w-[%s] max-h-[%s] object-cover rounded-lg hover:opacity-90 transition-opacity duration-200" $imageMaxWidth $imageMaxHeight)
+              "width" $imageMaxWidth
+              "height" $imageMaxHeight
             ) }}
         {{ if $link }}
           </a>

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -5,7 +5,7 @@ Responsive two-column layout with image and rich content.
 Parameters:
 - theme: "light" | "dark" | "alternate" (default: "light")
 - layout: "image-left" | "image-right" (default: "image-left")
-- image, imageAlt, imageBgColor: Image settings
+- image, imageAlt: Image settings
 - eyebrow, heading, description: Text content
 - link, linkText, buttonStyle: CTA button
 - markdownContent, contentAsHTML: Main content
@@ -49,7 +49,6 @@ Design Tokens:
 {{ $linkText := .linkText }}
 {{ $linkTarget := .linkTarget | default "_self" }}
 {{ $buttonStyle := .buttonStyle | default "primary" }}
-{{ $contentColor := .contentColor | default "text-gray-700" }}
 {{ $markdownContent := .markdownContent }}
 {{ $contentAsHTML := .contentAsHTML | default false }}
 {{ $features := .features | default (slice) }}
@@ -114,7 +113,7 @@ Design Tokens:
         {{ end }}
 
         {{/* Main content */}}
-        <div class="mt-10 max-w-full {{ $contentColor }} lg:max-w-full">
+        <div class="mt-10 max-w-full text-body lg:max-w-full">
           {{ if $markdownContent }}
             {{ if $contentAsHTML }}
                 {{ $markdownContent | safeHTML }}

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -3,12 +3,14 @@ split_with_image partial
 Responsive two-column layout with image and rich content.
 
 Parameters:
+- theme: "light" | "dark" | "alternate" (default: "light")
 - layout: "image-left" | "image-right" (default: "image-left")
 - image, imageAlt, imageBgColor: Image settings
 - eyebrow, heading, description: Text content
 - link, linkText, buttonStyle: CTA button
 - markdownContent, contentAsHTML: Main content
 - features: [{icon, title, description}]
+- numbered_features: [{title, description}] (features with numbers instead of icons)
 - stats: [{number, label}]
 - quote: {text, author, role, company, avatar}
 - Color classes: *Color parameters for styling
@@ -32,15 +34,17 @@ Design Tokens:
 - Typography tracking and sizing follow brand guidelines
 */}}
 
+{{ $theme := .theme | default "light" }}
+{{ $isDark := eq $theme "dark" }}
+{{ $isAlternate := eq $theme "alternate" }}
+
+{{/* Section parameters */}}
 {{ $layout := .layout | default "image-left" }}
 {{ $image := .image }}
 {{ $imageAlt := .imageAlt }}
 {{ $eyebrow := .eyebrow }}
-{{ $eyebrowColor := .eyebrowColor | default "text-primary" }}
 {{ $heading := .heading }}
-{{ $headingColor := .headingColor | default "text-heading" }}
 {{ $description := .description }}
-{{ $descriptionColor := .descriptionColor | default "text-gray-700" }}
 {{ $link := .link }}
 {{ $linkText := .linkText }}
 {{ $linkTarget := .linkTarget | default "_self" }}
@@ -49,6 +53,7 @@ Design Tokens:
 {{ $markdownContent := .markdownContent }}
 {{ $contentAsHTML := .contentAsHTML | default false }}
 {{ $features := .features | default (slice) }}
+{{ $numbered_features := .numbered_features | default (slice) }}
 {{ $stats := .stats | default (slice) }}
 {{ $quote := .quote }}
 
@@ -65,8 +70,7 @@ Design Tokens:
 {{ $contentMarginSpacingReverse := "lg:pl-0 lg:ml-0 lg:mr-8" }}
 {{ $headingTracking := "tracking-[-2.832px]" }}
 
-
-<div class="split-with-image-section section-bg-light {{ $sectionPaddingY }}">
+<div class="split-with-image-section {{ if $isDark }}dark section-bg-dark{{ else if $isAlternate }}section-bg-alternate{{ else }}section-bg-light{{ end }} {{ $sectionPaddingY }}">
   <div class="wrapper lg:flex lg:justify-between lg:items-stretch{{ if eq $layout "image-right" }} lg:flex-row-reverse{{ end }}">
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 {{ if eq $layout "image-right" }}xl:left-0{{ else }}xl:right-0{{ end }}">
       <div class="relative {{ $imageContainerPaddingY }} flex items-start justify-center w-full overflow-hidden mx-auto max-w-[{{ $imageContainerMaxWidth }}] max-h-[{{ $imageContainerMaxHeight }}]">
@@ -86,13 +90,13 @@ Design Tokens:
     <div class="lg:flex lg:w-1/2 lg:items-center">
       <div class="{{ $contentPaddingY }} lg:w-full lg:flex-none {{ if eq $layout "image-right" }}{{ $contentMarginSpacingReverse }}{{ else }}{{ $contentLeftPadding }} {{ $contentMarginSpacing }}{{ end }}">
         {{ if $eyebrow }}
-          <p class="text-base/7 font-semibold {{ $eyebrowColor }}">{{ $eyebrow }}</p>
+          <p class="text-base/7 font-semibold product-text">{{ $eyebrow }}</p>
         {{ end }}
         {{ if $heading}}
-          <h2 class="mt-3 text-4xl font-semibold {{ $headingTracking }} leading-none text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
+          <h2 class="mt-3 text-4xl font-semibold {{ $headingTracking }} text-heading leading-none text-pretty sm:text-5xl">{{ $heading }}</h2>
         {{ end }}
         {{ if $description }}
-          <p class="mt-6 text-lg/7 {{ $descriptionColor }}">{{ partial "utils/linkbuilding" (dict "content" $description "page" .) | safeHTML }}</p>
+          <p class="mt-6 text-lg/7 text-body">{{ partial "utils/linkbuilding" (dict "content" $description "page" .) | safeHTML }}</p>
         {{ end }}
 
         {{/* Button */}}
@@ -135,6 +139,21 @@ Design Tokens:
           </div>
           {{ end }}
         </dl>
+        {{ end }}
+
+        {{/* Numbered Features */}}
+        {{ if $numbered_features }}
+          <ol class="mt-10 max-w-full space-y-3 text-lg/7 text-body lg:max-w-full">
+            {{ range $index, $feature := $numbered_features }}
+              <div class="relative pl-9">
+                <span class="inline text-heading font-bold">
+                  <span class="absolute left-1 top-2 w-5 h-5 text-[10px] flex justify-center items-center text-white rounded-full bg-primary">{{ add $index 1 }}</span>
+                  {{ .title }}.
+                </span>
+                <span class="inline">{{ .description }}</span>
+              </div>
+            {{ end }}
+          </ol>
         {{ end }}
 
         {{/* Stats */}}

--- a/layouts/shortcodes/content-split-with-image.html
+++ b/layouts/shortcodes/content-split-with-image.html
@@ -53,7 +53,7 @@
     <p class="text-gray-600 mt-4">This is a paragraph with <strong>bold</strong> and <em>italic</em> text.</p>
     {{< /content-split-with-image >}}
 
-    2. JSON DATA ONLY (structured data blocks):
+    2. JSON DATA ONLY (structured data blocks - no markers needed):
     {{< content-split-with-image
         heading="By the Numbers"
         image="/images/statistics.jpg"
@@ -103,7 +103,7 @@
     }
     {{< /content-split-with-image >}}
 
-    3. COMBINED (JSON data + content):
+    3. COMBINED (JSON data + markdown/HTML content - markers required):
     {{< content-split-with-image
         heading="Complete AI Solution"
         description="Everything you need in one platform"
@@ -207,9 +207,11 @@
     }
 
     NOTES:
+    - Use START_JSON_BLOCK/END_JSON_BLOCK markers ONLY when mixing JSON with markdown/HTML content
+    - For pure JSON content (no markdown/HTML), markers are not needed - just use the JSON directly
+    - For pure markdown/HTML content (no JSON), markers are not needed
     - If you don't need certain data blocks (features, numbered_features, stats, quote), simply omit them
-    - JSON blocks are completely optional - you can use just markdown/HTML content
-    - Content can be pure markdown, pure HTML, or mixed
+    - Content can be pure markdown, pure HTML, pure JSON, or mixed
     - numbered_features work the same as features but display numbers (1, 2, 3...) instead of icons
 */}}
 
@@ -245,11 +247,14 @@
 {{ end }}
 {{ $rawInnerContent = trim $rawInnerContent " \n\r\t" }}
 
-{{/* Parse JSON block with START_JSON_BLOCK/END_JSON_BLOCK markers */}}
+{{/* Parse content - detect if it's pure JSON or mixed content with markers */}}
 {{ $jsonStartMarker := "START_JSON_BLOCK" }}
 {{ $jsonEndMarker := "END_JSON_BLOCK" }}
 
-{{ if and (in $rawInnerContent $jsonStartMarker) (in $rawInnerContent $jsonEndMarker) }}
+{{ $hasJsonMarkers := and (in $rawInnerContent $jsonStartMarker) (in $rawInnerContent $jsonEndMarker) }}
+
+{{ if $hasJsonMarkers }}
+    {{/* Mixed content: markdown/HTML + JSON with markers */}}
     {{ $parts := split $rawInnerContent $jsonStartMarker }}
     {{ if gt (len $parts) 1 }}
         {{ $beforeJson := index $parts 0 }}
@@ -264,25 +269,18 @@
             {{ $potentialJSON = trim $potentialJSON " \n\r\t" }}
             {{ if $potentialJSON }}
               {{ $parseResult := dict }}
-              {{ if $potentialJSON }}
-                {{ $jsonString := trim $potentialJSON " \n\r\t" }}
-                {{ if $jsonString }}
-                  {{ $unmarshalResult := dict }}
-                  {{ $errorOccurred := false }}
-                  {{/* Attempt to unmarshal JSON with error handling */}}
-                  {{ $unmarshalResult = unmarshal $jsonString }}
-                  {{ if not $unmarshalResult }}
-                    {{ warnf "JSON unmarshal returned empty result in inner-content-json-block. JSON content (first 200 chars): %s. Using empty fallback." (substr $jsonString 0 200) }}
-                    {{ $unmarshalResult = dict }}
-                  {{ end }}
+              {{ $jsonString := trim $potentialJSON " \n\r\t" }}
+              {{ if $jsonString }}
+                {{ $unmarshalResult := unmarshal $jsonString }}
+                {{ if $unmarshalResult }}
                   {{ $parseResult = $unmarshalResult }}
+                {{ else }}
+                  {{ warnf "Failed to parse JSON block. JSON content (first 200 chars): %s. Using empty fallback." (substr $jsonString 0 200) }}
                 {{ end }}
               {{ end }}
               
-              {{ if or $parseResult.features $parseResult.numbered_features $parseResult.stats $parseResult.quote $parseResult.markdownContent $parseResult.htmlContent $parseResult.contentAsHTML }}
+              {{ if or $parseResult.features $parseResult.numbered_features $parseResult.stats $parseResult.quote }}
                 {{ $innerData = $parseResult }}
-              {{ else }}
-                {{ warnf "JSON block found but contains no recognized data structures (features, numbered_features, stats, quote, markdownContent, htmlContent, contentAsHTML). Content: %s" (substr $potentialJSON 0 200) }}
               {{ end }}
             {{ end }}
 
@@ -295,7 +293,21 @@
         {{ $markdownContent = $rawInnerContent }}
     {{ end }}
 {{ else }}
-    {{ $markdownContent = $rawInnerContent }}
+    {{/* Check if content is pure JSON (no markers) */}}
+    {{ $trimmedContent := trim $rawInnerContent " \n\r\t" }}
+    {{ if and $trimmedContent (hasPrefix $trimmedContent "{") (hasSuffix $trimmedContent "}") }}
+        {{/* Pure JSON content */}}
+        {{ $unmarshalResult := unmarshal $trimmedContent }}
+        {{ if $unmarshalResult }}
+            {{ $innerData = $unmarshalResult }}
+        {{ else }}
+            {{ warnf "Failed to parse pure JSON content. Content (first 200 chars): %s. Treating as markdown." (substr $trimmedContent 0 200) }}
+            {{ $markdownContent = $rawInnerContent }}
+        {{ end }}
+    {{ else }}
+        {{/* Pure markdown/HTML content */}}
+        {{ $markdownContent = $rawInnerContent }}
+    {{ end }}
 {{ end }}
 
 

--- a/layouts/shortcodes/content-split-with-image.html
+++ b/layouts/shortcodes/content-split-with-image.html
@@ -21,8 +21,6 @@
     - linkText: CTA button text (default (i18n "learnMore"))
     - linkTarget: Link target "_self" or "_blank" (default: "_self")
     - buttonStyle: "primary" or "secondary" (default: "primary")
-    - contentColor: Content text color (default: "text-gray-700")
-    - imageBgColor: Image container background (default: "bg-gray-50")
     - contentAsHTML: Render content as HTML instead of markdown (default: false)
     - features: JSON string or "features" to use page params
     - numbered_features: JSON string or "numbered_features" to use page params (features with numbers instead of icons)
@@ -229,7 +227,6 @@
 {{ $linkTarget := .Get "linkTarget" | default "_self" }}
 {{ $buttonStyle := .Get "buttonStyle" | default "primary" }}
 {{ $theme := .Get "theme" | default "light" }}
-{{ $contentColor := .Get "contentColor" | default "text-gray-700" }}
 {{ $contentAsHTML := .Get "contentAsHTML" | default false }}
 
 {{/* Initialize data */}}
@@ -415,7 +412,6 @@
   "buttonStyle" $buttonStyle
   "image" $image
   "imageAlt" $imageAlt
-  "contentColor" $contentColor
   "markdownContent" $markdownContent
   "contentAsHTML" $contentAsHTML
   "features" $features

--- a/layouts/shortcodes/content-split-with-image.html
+++ b/layouts/shortcodes/content-split-with-image.html
@@ -10,6 +10,7 @@
     - Graceful degradation when JSON is malformed or missing
 
     Parameters:
+    - theme: "light" | "dark" | "alternate" (default: "light")
     - heading: Main title for the section
     - eyebrow: Small text above heading (default: "")
     - description: Text below heading (default: "")
@@ -20,14 +21,11 @@
     - linkText: CTA button text (default (i18n "learnMore"))
     - linkTarget: Link target "_self" or "_blank" (default: "_self")
     - buttonStyle: "primary" or "secondary" (default: "primary")
-    - bgColor: Background color class (default: "bg-white")
-    - eyebrowColor: Eyebrow text color (default: "text-primary")
-    - headingColor: Heading color (default: "text-gray-900")
-    - descriptionColor: Description color (default: "text-gray-700")
     - contentColor: Content text color (default: "text-gray-700")
     - imageBgColor: Image container background (default: "bg-gray-50")
     - contentAsHTML: Render content as HTML instead of markdown (default: false)
     - features: JSON string or "features" to use page params
+    - numbered_features: JSON string or "numbered_features" to use page params (features with numbers instead of icons)
     - stats: JSON string or "stats" to use page params
     - quote: JSON string or "quote" to use page params
 
@@ -35,6 +33,7 @@
 
     1. CONTENT ONLY (markdown/HTML content):
     {{< content-split-with-image
+        theme="light"
         eyebrow="Automation Platform"
         heading="Transform Your Workflow"
         description="Discover the power of automation"
@@ -44,9 +43,6 @@
         link="/get-started"
         linkText="Start Free Trial"
         buttonStyle="primary"
-        eyebrowColor="text-purple-600"
-        headingColor="text-gray-900"
-        descriptionColor="text-gray-600"
     >}}
      ## Test markdown and HTML content
     Test **bold text**, *italic text*, and [links](https://example.com).
@@ -75,6 +71,20 @@
           "icon": "cog-solid",
           "title": "Flexible Configuration",
           "description": "Supports various layout options and styling configurations."
+        }
+      ],
+      "numbered_features": [
+        {
+          "title": "Setup Your Account",
+          "description": "Create your account and configure your preferences in just a few minutes."
+        },
+        {
+          "title": "Connect Your Data",
+          "description": "Integrate with your existing tools and import your data seamlessly."
+        },
+        {
+          "title": "Start Automating",
+          "description": "Begin creating workflows and watch your productivity soar."
         }
       ],
       "stats": [
@@ -119,6 +129,16 @@
           "description": "Supports various layout options and styling configurations."
         }
       ],
+      "numbered_features": [
+        {
+          "title": "Initial Setup",
+          "description": "Quick and easy setup process to get you started."
+        },
+        {
+          "title": "Data Integration",
+          "description": "Connect your existing data sources seamlessly."
+        }
+      ],
       "stats": [
         { "number": "95%", "label": "Accuracy Rate" },
         { "number": "< 100ms", "label": "Response Time" }
@@ -155,6 +175,16 @@
       ]
     }
 
+    Numbered Features List:
+    {
+      "numbered_features": [
+        {
+          "title": "Feature Title",   // Feature name (required)
+          "description": "Details"    // Feature description (required)
+        }
+      ]
+    }
+
     Stats List:
     {
       "stats": [
@@ -177,9 +207,10 @@
     }
 
     NOTES:
-    - If you don't need certain data blocks (features, stats, quote), simply omit them
+    - If you don't need certain data blocks (features, numbered_features, stats, quote), simply omit them
     - JSON blocks are completely optional - you can use just markdown/HTML content
     - Content can be pure markdown, pure HTML, or mixed
+    - numbered_features work the same as features but display numbers (1, 2, 3...) instead of icons
 */}}
 
 {{ $currentPage := .Page }}
@@ -195,15 +226,13 @@
 {{ $linkText := .Get "linkText" | default (i18n "learnMore") | default "Learn more" }}
 {{ $linkTarget := .Get "linkTarget" | default "_self" }}
 {{ $buttonStyle := .Get "buttonStyle" | default "primary" }}
-{{ $bgColor := .Get "bgColor" | default "bg-white" }}
-{{ $eyebrowColor := .Get "eyebrowColor" | default "text-primary" }}
-{{ $headingColor := .Get "headingColor" | default "text-gray-900" }}
-{{ $descriptionColor := .Get "descriptionColor" | default "text-gray-700" }}
+{{ $theme := .Get "theme" | default "light" }}
 {{ $contentColor := .Get "contentColor" | default "text-gray-700" }}
 {{ $contentAsHTML := .Get "contentAsHTML" | default false }}
 
 {{/* Initialize data */}}
 {{ $features := slice }}
+{{ $numbered_features := slice }}
 {{ $stats := slice }}
 {{ $quote := dict }}
 {{ $markdownContent := "" }}
@@ -250,10 +279,10 @@
                 {{ end }}
               {{ end }}
               
-              {{ if or $parseResult.features $parseResult.stats $parseResult.quote $parseResult.markdownContent $parseResult.htmlContent $parseResult.contentAsHTML }}
+              {{ if or $parseResult.features $parseResult.numbered_features $parseResult.stats $parseResult.quote $parseResult.markdownContent $parseResult.htmlContent $parseResult.contentAsHTML }}
                 {{ $innerData = $parseResult }}
               {{ else }}
-                {{ warnf "JSON block found but contains no recognized data structures (features, stats, quote, markdownContent, htmlContent, contentAsHTML). Content: %s" (substr $potentialJSON 0 200) }}
+                {{ warnf "JSON block found but contains no recognized data structures (features, numbered_features, stats, quote, markdownContent, htmlContent, contentAsHTML). Content: %s" (substr $potentialJSON 0 200) }}
               {{ end }}
             {{ end }}
 
@@ -272,6 +301,7 @@
 
 {{/* Data consolidation: inner JSON > shortcode params > page params */}}
 {{ $features = $innerData.features | default $features }}
+{{ $numbered_features = $innerData.numbered_features | default $numbered_features }}
 {{ $stats = $innerData.stats | default $stats }}
 {{ $quote = $innerData.quote | default $quote }}
 
@@ -288,6 +318,23 @@
         {{ $features = $unmarshalResult }}
       {{ else }}
         {{ warnf "Failed to parse features JSON from shortcode parameter. JSON content (first 200 chars): %s. Using fallback." (substr $jsonString 0 200) }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ with .Get "numbered_features" }}
+  {{ if eq . "numbered_features" }}
+    {{ $numbered_features = $currentPage.Params.numbered_features | default $numbered_features }}
+  {{ else }}
+    {{ $jsonString := trim . " \n\r\t" }}
+    {{ if $jsonString }}
+      {{ $unmarshalResult := dict }}
+      {{ $unmarshalResult = unmarshal $jsonString }}
+      {{ if $unmarshalResult }}
+        {{ $numbered_features = $unmarshalResult }}
+      {{ else }}
+        {{ warnf "Failed to parse numbered_features JSON from shortcode parameter. JSON content (first 200 chars): %s. Using fallback." (substr $jsonString 0 200) }}
       {{ end }}
     {{ end }}
   {{ end }}
@@ -345,6 +392,7 @@
 
 {{/* Render partial */}}
 {{ partial "sections/content/split_with_image.html" (dict
+  "theme" $theme
   "eyebrow" $eyebrow
   "heading" $heading
   "description" $description
@@ -355,14 +403,11 @@
   "buttonStyle" $buttonStyle
   "image" $image
   "imageAlt" $imageAlt
-  "bgColor" $bgColor
-  "eyebrowColor" $eyebrowColor
-  "headingColor" $headingColor
-  "descriptionColor" $descriptionColor
   "contentColor" $contentColor
   "markdownContent" $markdownContent
   "contentAsHTML" $contentAsHTML
   "features" $features
+  "numbered_features" $numbered_features
   "stats" $stats
   "quote" $quote
 ) }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Addes theme modes support
Added alternate background style and enhance split_with_image layout with numbered features support
Updated product-primary class and color for layouts/partials/sections/bentogrids/three_column_bento_grid.html

**Testing instructions**
- Go to any page with content-split-with-image shortcode and check theme modes (default light), number features (list)

QualityUnit/web-issues#3567
