### PR TITLE
feat: add list with icon component and update split_with_image layout

### DIFF
--- a/layouts/partials/components/lists/with_icon.html
+++ b/layouts/partials/components/lists/with_icon.html
@@ -1,7 +1,7 @@
-{{ $lists := .lists }}
+{{ $listItems := .lists }}
 
 <dl class="mt-10 max-w-full space-y-8 text-lg/7 text-body lg:max-w-full">
-    {{ range $index, $item := $lists }}
+    {{ range $index, $item := $listItems }}
     <div class="relative pl-9">
         <dt class="inline font-bold text-heading">
             {{ if $item.icon }}

--- a/layouts/partials/components/lists/with_icon.html
+++ b/layouts/partials/components/lists/with_icon.html
@@ -1,0 +1,21 @@
+{{ $lists := .lists }}
+
+<dl class="mt-10 max-w-full space-y-8 text-lg/7 text-body lg:max-w-full">
+    {{ range $index, $item := $lists }}
+    <div class="relative pl-9">
+        <dt class="inline font-bold text-heading">
+            {{ if $item.icon }}
+                <span class="absolute left-1 top-1 size-5 text-primary">
+                    {{ if $item.icon }}
+                        {{ partial "components/media/icon.html" (dict "icon" $item.icon "class" "h-5 w-5") }}
+                    {{ else }}
+                        {{ partial "components/media/icon.html" (dict "icon" "check-circle-solid" "class" "h-5 w-5") }}
+                    {{ end }}
+                </span>
+            {{ end }}
+            {{ $item.title }}.
+        </dt>
+        <dd class="inline pl-0">{{ $item.description }}</dd>
+    </div>
+    {{ end }}
+</dl>

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -87,7 +87,7 @@ Design Tokens:
           <p class="text-base/7 font-semibold {{ $eyebrowColor }}">{{ $eyebrow }}</p>
         {{ end }}
         {{ if $heading}}
-          <h2 class="mt-3 text-4xl font-semibold {{ $headingTracking }} leading-none text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
+          <h2 class="mt-3 mb-0 text-4xl font-semibold {{ $headingTracking }} leading-none text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
         {{ end }}
         {{ if $description }}
           <p class="mt-6 text-lg/7 {{ $descriptionColor }}">{{ partial "utils/linkbuilding" (dict "content" $description "page" .) | safeHTML }}</p>

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -61,13 +61,11 @@ Design Tokens:
 {{ $imageContainerPaddingY := "py-6" }}
 {{ $contentPaddingY := "py-4" }}
 {{ $contentLeftPadding := "lg:pl-20" }}
-{{ $contentMarginSpacing := "lg:mr-0 lg:ml-8" }}
-{{ $contentMarginSpacingReverse := "lg:pl-0 lg:ml-0 lg:mr-8" }}
 {{ $headingTracking := "tracking-[-2.832px]" }}
 
 
 <div class="split-with-image-section section-bg-light {{ $sectionPaddingY }}">
-  <div class="wrapper lg:flex lg:justify-between lg:items-stretch{{ if eq $layout "image-right" }} lg:flex-row-reverse{{ end }}">
+  <div class="wrapper lg:flex lg:justify-between lg:items-stretch gap-x-8{{ if eq $layout "image-right" }} lg:flex-row-reverse{{ end }}">
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 {{ if eq $layout "image-right" }}xl:left-0{{ else }}xl:right-0{{ end }}">
       <div class="relative {{ $imageContainerPaddingY }} flex items-start justify-center w-full overflow-hidden mx-auto max-w-[{{ $imageContainerMaxWidth }}] max-h-[{{ $imageContainerMaxHeight }}]">
         {{ if $link }}
@@ -84,7 +82,7 @@ Design Tokens:
       </div>
     </div>
     <div class="lg:flex lg:w-1/2 lg:items-center">
-      <div class="{{ $contentPaddingY }} lg:w-full lg:flex-none {{ if eq $layout "image-right" }}{{ $contentMarginSpacingReverse }}{{ else }}{{ $contentLeftPadding }} {{ $contentMarginSpacing }}{{ end }}">
+      <div class="{{ $contentPaddingY }} lg:w-full lg:flex-none {{ if eq $layout "image-right" }}lg:pl-0{{ else }}{{ $contentLeftPadding }} {{ end }}">
         {{ if $eyebrow }}
           <p class="text-base/7 font-semibold {{ $eyebrowColor }}">{{ $eyebrow }}</p>
         {{ end }}

--- a/layouts/shortcodes/list_with_icon.html
+++ b/layouts/shortcodes/list_with_icon.html
@@ -1,0 +1,8 @@
+{{ $lists := slice }}
+{{ with .Inner }}
+    {{ if . }}
+        {{ $lists = . | unmarshal }}
+    {{ end }}
+{{ end }}
+
+{{ partial "components/lists/with_icon.html" (dict "lists" $lists) }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added list with icon component and update split_with_image layout
Created list-with-icons shortcode and /list/with_icon.html partial

**Testing instructions**
- Go to flow templates single page (e.g. /ai-flow-templates/ai-customer-support-agent-with-knowledge-base-and-api-enrichment/) and check "How the AI Flow works" section, should be changes by design

QualityUnit/web-issues#3569
