### PR TITLE
fix: remove unnecessary class from  in split_with_image

### DIFF
--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -86,7 +86,7 @@ Design Tokens:
           <p class="text-base/7 font-semibold product-text">{{ $eyebrow }}</p>
         {{ end }}
         {{ if $heading}}
-          <h2 class="mt-3  mb-0 text-4xl font-semibold {{ $headingTracking }}  text-heading leading-none text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
+          <h2 class="mt-3  mb-0 text-4xl font-semibold {{ $headingTracking }}  text-heading leading-none text-pretty sm:text-5xl">{{ $heading }}</h2>
         {{ end }}
         {{ if $description }}
           <p class="mt-6 text-lg/7 text-body">{{ partial "utils/linkbuilding" (dict "content" $description "page" .) | safeHTML }}</p>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Remove unnecessary class from heading element in split_with_image partial