### PR TITLE
Added Y Padding for Partial split_with_image.html

### DIFF
--- a/layouts/partials/sections/hero/split_with_image.html
+++ b/layouts/partials/sections/hero/split_with_image.html
@@ -23,6 +23,7 @@
     - deleteSpeed: Deleting speed in ms (default: 50)
     - pause: Pause duration in ms (default: 2000)
     - color: Color class for animated text (default: "text-indigo-600")
+  - yPadding: Custom y-padding value (optional, default: "sm:py-0 lg:py-24")
 @example:
   {{ partial "sections/hero/split_with_image.html" (dict 
       "logo" "/images/logo.svg"
@@ -67,7 +68,8 @@
 {{ end }}
 
   <div class="relative bg-white">
-    <div class="wrapper sm:py-0 lg:py-24">
+    {{ $yPadding := .yPadding | default "sm:py-0 lg:py-24" }}
+<div class="wrapper {{ $yPadding }}">
       <div class="lg:grid lg:grid-cols-12">
         <div class="lg:col-span-7 xl:col-span-6">
           {{ partial "sections/hero/split_left_side_helper.html" .}}

--- a/layouts/shortcodes/hero-split-with-image.html
+++ b/layouts/shortcodes/hero-split-with-image.html
@@ -20,6 +20,7 @@ Example usage of Split Hero with Image Shortcode:
   "typewriterDeleteSpeed"="60"
   "typewriterPause"="2500"
   "typewriterColor"="text-blue-600"
+  "yPadding"="py-8 md:py-16 lg:py-24"
 >}}
 
 Parameters:
@@ -42,6 +43,7 @@ Parameters:
 - typewriterDeleteSpeed: Deleting speed in milliseconds (default: 50)
 - typewriterPause: Pause duration between word cycles in milliseconds (default: 2000)
 - typewriterColor: Tailwind CSS color class for animated text (default: "text-indigo-600")
+- yPadding: Custom y-padding value using Tailwind classes (default: "sm:py-0 lg:py-24")
 */}}
 
 {{/* Split Hero with Image Shortcode */}}
@@ -66,6 +68,9 @@ Parameters:
 {{ $typewriterDeleteSpeed := .Get "typewriterDeleteSpeed" | default 50 }}
 {{ $typewriterPause := .Get "typewriterPause" | default 2000 }}
 {{ $typewriterColor := .Get "typewriterColor" | default "text-indigo-600" }}
+
+{{/* Custom y-padding */}}
+{{ $yPadding := .Get "yPadding" | default "sm:py-0 lg:py-24" }}
 
 {{ $announcement := dict 
   "enabled" (eq $announcementEnabled "true")
@@ -106,4 +111,5 @@ Parameters:
   "cta" $cta
   "image" $image
   "typewriter" $typewriter
+  "yPadding" $yPadding
 ) }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added configurable y padding for the `split_with_image.html` partial. We needed this for Integrations Post type. the paddings were too much.

