### PR TITLE
Fix width for img in content-split-with-image

### DIFF
--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -99,7 +99,7 @@ Design Tokens:
             {{ partial "components/media/lazyimg.html" (dict
               "src" $image
               "alt" $imageAlt
-              "class" "w-[30.25rem] h-[32.625rem]  object-contain rounded-lg hover:opacity-90 transition-opacity duration-200"
+              "class" "object-contain rounded-lg"
             ) }}
         {{ if $link }}
           </a>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Remved max-width from partial
