### PR TITLE
Fix Flash of Unstyled Content

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,9 +14,8 @@
 {{ partialCached "head/variables.html" . }}
 <!-- Preload fonts early -->
 <link rel="preload" href="/fonts/inter/Inter-VariableFont_opsz,wght.woff2" as="font" type="font/woff2" crossorigin="anonymous">
-<!-- Non-blocking CSS loading pattern -->
-<link rel="preload" href="/css/main.css?v={{ partialCached "helpers/build-timestamp.html" . }}" as="style" onload="this.onload=null;this.rel='stylesheet'" crossorigin="anonymous">
-<noscript><link rel="stylesheet" href="/css/main.css?v={{ partialCached "helpers/build-timestamp.html" . }}" crossorigin="anonymous"></noscript>
+<!-- Classic CSS loading for immediate styling -->
+<link rel="stylesheet" href="/css/main.css?v={{ partialCached "helpers/build-timestamp.html" . }}" crossorigin="anonymous">
 <!-- Critical theme JS - loaded early with defer -->
 <script src="/js/main.js?v={{ partialCached "helpers/build-timestamp.html" . }}" defer></script>
 {{ partialCached "utils/analytics/google-analytics-consent.html" . }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed CSS loading in head.html from `non-blocking` to classic `<link rel="stylesheet">` for immediate style application and to prevent FOUC (Flash of Unstyled Content).

