### PR TITLE
fix: add rounded corners to lazy image component

### DIFF
--- a/layouts/partials/sections/features/with_split_image.html
+++ b/layouts/partials/sections/features/with_split_image.html
@@ -45,7 +45,7 @@
             {{ partial "components/media/lazyimg.html" (dict 
               "src" $imageUrl
               "alt" $imageAlt
-              "class" "w-full object-cover"
+              "class" "w-full object-cover rounded-xl"
             ) }}
           </div>
           {{ if $features }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added rounded corners to lazy image component in features-with-split-image shortcode

**Testing instructions**
- Go to /photomatic-ai/ page and check border radius in "Why Choose Photomatic" section

QualityUnit/web-issues#3586
