### PR TITLE
[3569] - fixed styles of text and layout in icon cards and lists

### DIFF
--- a/layouts/partials/components/cards/icon_card.html
+++ b/layouts/partials/components/cards/icon_card.html
@@ -54,7 +54,7 @@
     {{ end }}
 
     {{ if $description }}
-        <p class="mt-1 text-body text-base line-clamp-3 [&_a]:text-white [&_a:hover]:text-white [&_a:visited]:text-white">
+        <p class="mt-1 text-body text-base line-clamp-3">
             {{ $description }}
         </p>
     {{ end }}

--- a/layouts/partials/components/cards/icon_card.html
+++ b/layouts/partials/components/cards/icon_card.html
@@ -54,7 +54,7 @@
     {{ end }}
 
     {{ if $description }}
-        <p class="mt-1 text-body text-base line-clamp-3">
+        <p class="mt-1 text-body text-base line-clamp-3 not-prose">
             {{ $description }}
         </p>
     {{ end }}

--- a/layouts/partials/components/cards/icon_card.html
+++ b/layouts/partials/components/cards/icon_card.html
@@ -54,7 +54,7 @@
     {{ end }}
 
     {{ if $description }}
-        <p class="mt-1 text-body text-base line-clamp-3">
+        <p class="mt-1 text-body text-base line-clamp-3 [&_a]:text-white [&_a:hover]:text-white [&_a:visited]:text-white">
             {{ $description }}
         </p>
     {{ end }}

--- a/layouts/partials/components/lists/with_icon.html
+++ b/layouts/partials/components/lists/with_icon.html
@@ -2,7 +2,7 @@
 {{ $margin := .margin | default "mt-10" }}
 {{ $columnsClass := .columnsClass | default "" }}
 
-<dl class="{{ $margin }} max-w-full text-lg/7 text-body lg:max-w-full {{ $columnsClass }}">
+<dl class="{{ $margin }} max-w-full not-prose flex flex-col gap-y-8 text-lg/7 text-body lg:max-w-full {{ $columnsClass }}">
     {{ range $index, $item := $listItems }}
     <div class="relative pl-9">
         <dt class="inline font-bold text-heading">

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -167,8 +167,8 @@ Design Tokens:
           <ol class="mt-10 max-w-full space-y-3 text-lg/7 text-body lg:max-w-full">
             {{ range $index, $feature := $numbered_features }}
               <li class="relative pl-9">
-                <span class="inline text-heading font-bold">
-                  <span class="absolute left-1 top-2 w-5 h-5 text-[10px] flex justify-center items-center text-white rounded-full bg-primary">{{ add $index 1 }}</span>
+                <span class="inline-flex text-heading font-bold">
+                  <span class="absolute left-1 top-1/2 -translate-y-1/2 w-5 h-5 text-[10px] flex justify-center items-center text-white rounded-full bg-primary">{{ add $index 1 }}</span>
                   {{ .title }}.
                 </span>
                 <span class="inline">{{ .description }}</span>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixed styles of text and layout for better readability in icon cards and lists

**Testing instructions**
- Go to /services/mcp-server-development/ and check align number list of blue circle
- Go to /ai-flow-templates/gmail-manager/ and check gap between lists in "How the AI Flow works" section
- Go to /ai-flow-templates/gmail-manager/ and check link in deskription card in "Components used in this flow" section

QualityUnit/web-issues#3569
