### PR TITLE
[3672] - added video support and parameters to content-split-with-image

### DIFF
--- a/layouts/partials/components/media/video.html
+++ b/layouts/partials/components/media/video.html
@@ -61,6 +61,7 @@
 {{ $useLightbox := .useLightbox | default false }}
 {{ $controls := (and (not $useLightbox) (.controls | default true)) }}
 {{ $poster := .poster }}
+{{ $posterHeight := .posterHeight | default "" }}
 {{ $provider := .provider | default "" }}
 {{ $noLazy := .noLazy | default false }}
 {{ $showPlayOverlay := .showPlayOverlay | default true }}
@@ -103,8 +104,10 @@
       "autoplay" $autoplay
       "noLazy" $noLazy
       "poster" $poster
+      "posterHeight" $posterHeight
       "playBtnClass" .playBtnClass
       "playBtnInnerClass" .playBtnInnerClass
+      "svgClass" .svgClass
   ) }}
 {{ else if eq $provider "custom" }}
   <!-- Load video helper partial for resource management -->

--- a/layouts/partials/components/media/video/youtube.html
+++ b/layouts/partials/components/media/video/youtube.html
@@ -11,6 +11,7 @@
   - id: Optional ID attribute (optional)
   - autoplay: Enable autoplay when opened in lightbox (optional, default: false)
   - poster: Custom poster/thumbnail image URL (optional, defaults to YouTube thumbnail)
+  - posterHeight: Additional CSS classes for poster height (optional, e.g. "h-64", "h-80", "h-96", "h-[450px]")
   - playBtnClass: CSS classes for play button (optional)
   - playBtnInnerClass: CSS classes for inner play button element (optional)
 @note: This partial should be called through the main video.html partial, not directly.
@@ -29,9 +30,11 @@
 {{ $duration := .duration | default "PT0M0S" }}
 {{ $noLazy := .noLazy | default false }}
 {{ $poster := .poster }}
+{{ $posterHeight := .posterHeight | default "" }}
 {{ $loading := cond $noLazy "eager" "lazy" }}
 {{ $playBtnClass := .playBtnClass | default "w-16 h-12 bg-red-600 rounded-lg hover:bg-red-700 hover:scale-110" }}
 {{ $playBtnInnerClass := .playBtnInnerClass | default "" }}
+{{ $svgClass := .svgClass | default "size-6 text-white ml-1" }}
 
 <!-- Determine thumbnail URL: use custom poster if provided, otherwise use YouTube default -->
 {{ $thumbnailUrl := cond $poster $poster (print "https://img.youtube.com/vi/" $videoID "/maxresdefault.jpg") }}
@@ -63,7 +66,7 @@
   data-video-fallback-url="https://www.youtube.com/watch?v={{ $videoID }}"
   {{ with $id }}id="{{ . }}"{{ end }}
 >
-  <div class="lazy-video-thumbnail relative w-full video-aspect-ratio overflow-hidden cursor-pointer" data-video-trigger="true">
+  <div class="lazy-video-thumbnail relative w-full video-aspect-ratio overflow-hidden cursor-pointer{{ if $posterHeight }} {{ $posterHeight }}{{ end }}" data-video-trigger="true">
     <img 
       src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3C/svg%3E"
       data-src="{{ $thumbnailUrl }}"
@@ -80,10 +83,10 @@
   <div class="lazy-video-play-button absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 flex items-center justify-center transition-all duration-300 z-10 {{ $playBtnClass }}">
     {{ if $playBtnInnerClass }}
       <div class="{{ $playBtnInnerClass }}">
-        {{ partial "icons/play-solid" "size-12 ml-1 text-primary" }}
+        {{ partial "icons/play-solid" $svgClass }}
       </div>
     {{ else }}
-      {{ partial "icons/play-solid" "size-6 text-white ml-1" }}
+      {{ partial "icons/play-solid" $svgClass }}
     {{ end }}
   </div>
 </div>

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -5,6 +5,11 @@ Parameters:
 - theme: "light" | "dark" | "alternate" (default: "light")
 - layout: "image-left" | "image-right" (default: "image-left")
 - image, imageAlt: Image settings
+- videoUrl: Video URL for embedding (default: "")
+- poster: Video poster image URL (default: "")
+- videoTitle: Video title text (default: "")
+- videoDescription: Video description text (default: "")
+- videoLinkUrl: Link to page on site from video overlay (default: "")
 - eyebrow, heading, description: Text content
 - link, linkText, buttonStyle: CTA button
 - markdownContent, contentAsHTML: Main content
@@ -49,6 +54,12 @@ Design Tokens:
 {{ $layout := .layout | default "image-left" }}
 {{ $image := .image }}
 {{ $imageAlt := .imageAlt }}
+{{ $videoUrl := .videoUrl | default "" }}
+{{ $poster := .poster | default "" }}
+{{ $posterHeight := .posterHeight | default "h-[32.625rem]" }}
+{{ $videoTitle := .videoTitle | default "" }}
+{{ $videoDescription := .videoDescription | default "" }}
+{{ $videoLinkUrl := .videoLinkUrl | default "" }}
 {{ $eyebrow := .eyebrow }}
 {{ $heading := .heading }}
 {{ $description := .description }}
@@ -73,7 +84,7 @@ Design Tokens:
 
 {{/* Design tokens and configurable dimensions */}}
 {{ $sectionPaddingY := .sectionPaddingY | default "py-24 lg:py-32" }}
-{{ $imageContainerPaddingY := "py-6" }}
+{{ $mediaContainerPaddingY := "py-6" }}
 {{ $contentPaddingY := "py-4" }}
 {{ $contentLeftPadding := "lg:pl-20" }}
 {{ $headingTracking := "tracking-[-2.832px]" }}
@@ -90,23 +101,66 @@ Design Tokens:
       "padding" $headerPadding
     ) }}
   {{ end }}
-  <div class="wrapper lg:flex lg:justify-between lg:items-stretch gap-x-8{{ if eq $layout "image-right" }} lg:flex-row-reverse{{ end }}">
+  <div class="wrapper lg:flex lg:justify-between lg:items-stretch {{ if not $videoUrl }}gap-x-8{{ end }}{{ if eq $layout "image-right" }} lg:flex-row-reverse{{ end }}">
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 {{ if eq $layout "image-right" }}xl:left-0{{ else }}xl:right-0{{ end }}">
-      <div class="relative rounded-lg {{ $imageContainerPaddingY }} flex items-start justify-center w-full overflow-hidden mx-auto max-w-[38rem] max-h-[35rem]">
-        {{ if $link }}
-          <a href="{{ $link }}" target="{{ $linkTarget }}" class="w-full flex items-center justify-center">
-        {{ end }}
-            {{ partial "components/media/lazyimg.html" (dict
-              "src" $image
-              "alt" $imageAlt
-              "class" "object-contain rounded-lg"
-            ) }}
-        {{ if $link }}
-          </a>
+      <div class="relative rounded-lg {{ $mediaContainerPaddingY }} flex items-start justify-center w-full overflow-hidden mx-auto max-w-[38rem] max-h-[35rem] {{ if $videoUrl }}h-full{{ end }}">
+        {{ if $videoUrl }}
+          <div class="relative flex w-full h-full">
+            {{/* Display video */}}
+            {{ partial "components/media/video.html" (dict 
+                  "src" $videoUrl 
+                  "poster" $poster
+                  "posterHeight" $posterHeight
+                  "title" $videoTitle
+                  "class" "rounded-xl h-full"
+                  "provider" "youtube"
+                  "useLightbox" true
+                  "showPlayOverlay" true
+                  "playBtnClass" "white-circle-bounce w-[7.75rem] h-[7.75rem] rounded-full backdrop-blur-sm"
+                  "playBtnInnerClass" "bg-white relative w-24 h-24 rounded-full hover:scale-105 transition-transform duration-300"
+                  "svgClass" "size-12 ml-1 text-primary absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+              ) }}
+              {{ if or $videoTitle $videoDescription }}
+              <div class="absolute left-5 bottom-5 flex items-end z-30">
+                  <div class="text-white">
+                  {{ if $videoTitle }}
+                      <h3 class="font-semibold text-opacity-75">{{ $videoTitle }}</h3>
+                  {{ end }}
+                  {{ if $videoDescription }}
+                      <p class="text-sm mt-1.5 tracking-[-0.28px]">
+                          {{ if $videoLinkUrl }}
+                          <a href="{{ $videoLinkUrl }}" class="flex items-center text-white hover:underline">
+                              {{ $videoDescription }}
+                              <span class="ml-1 btn-arrow">
+                                  {{ partial "components/media/icon.html" (dict "icon" "arrow-up-right" "class" "w-5 h-5 p-0.5") }}
+                              </span>
+                          </a>
+                          {{ else }}
+                              {{ $videoDescription }}
+                          {{ end }}
+                      </p>
+                  {{ end }}
+                  </div>
+              </div>
+            {{ end }}
+          </div>
+        {{ else if $image }}
+          {{/* Display image */}}
+          {{ if $link }}
+            <a href="{{ $link }}" target="{{ $linkTarget }}" class="w-full flex items-center justify-center">
+          {{ end }}
+              {{ partial "components/media/lazyimg.html" (dict
+                "src" $image
+                "alt" $imageAlt
+                "class" "object-contain rounded-lg"
+              ) }}
+          {{ if $link }}
+            </a>
+          {{ end }}
         {{ end }}
       </div>
     </div>
-    <div class="lg:flex lg:w-1/2 lg:items-center">
+    <div class="lg:flex lg:w-1/2 lg:items-center {{ if $videoUrl }}lg:pr-8{{ end }}">
       <div class="{{ $contentPaddingY }} lg:w-full lg:flex-none {{ if eq $layout "image-right" }}lg:pl-0{{ else }}{{ $contentLeftPadding }} {{ end }}">
         {{ if $eyebrow }}
           <p class="text-base/7 font-semibold product-text">{{ $eyebrow }}</p>
@@ -131,15 +185,15 @@ Design Tokens:
         {{ end }}
 
         {{/* Main content */}}
-        <div class="mt-10 max-w-full text-body lg:max-w-full">
-          {{ if $markdownContent }}
+        {{ if $markdownContent }}
+          <div class="mt-10 max-w-full text-body lg:max-w-full"></div>
             {{ if $contentAsHTML }}
                 {{ $markdownContent | safeHTML }}
             {{ else }}
                 {{ $markdownContent | markdownify }}
             {{ end }}
-          {{ end }}
-        </div>
+          </div>
+        {{ end }}
 
         {{/* Features */}}
         {{ if $features }}

--- a/layouts/partials/sections/content/two_columns_with_videos.html
+++ b/layouts/partials/sections/content/two_columns_with_videos.html
@@ -108,7 +108,8 @@
                         "useLightbox" true
                         "showPlayOverlay" true
                         "playBtnClass" "white-circle-bounce w-[7.75rem] h-[7.75rem] rounded-full backdrop-blur-sm"
-                        "playBtnInnerClass" "bg-white w-24 h-24 rounded-full flex items-center justify-center hover:scale-105 transition-transform duration-300"
+                        "playBtnInnerClass" "bg-white relative w-24 h-24 rounded-full hover:scale-105 transition-transform duration-300"
+                        "svgClass" "size-12 ml-1 text-primary absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
                     ) }}
                   {{ else }}
                     {{/* Display poster image with text overlay if no video */}}

--- a/layouts/shortcodes/content-split-with-image.html
+++ b/layouts/shortcodes/content-split-with-image.html
@@ -18,6 +18,13 @@
     - layout: "image-left" or "image-right" (default: "image-left")
     - image: Image path (default: "")
     - imageAlt: Alt text for image (default: "")
+    - mediaContainerPaddingY: Additional CSS classes for media container padding (default: "py-6")
+    - videoUrl: Video URL for embedding (default: "")
+    - poster: Video poster image URL (default: "")
+    - posterHeight: Additional CSS classes for poster height (default: "h-[32.625rem]")
+    - videoTitle: Video title text (default: "")
+    - videoDescription: Video description text (default: "")
+    - videoLinkUrl: Link to page on site from video overlay (default: "")
     - link: CTA link URL (default: "")
     - linkText: CTA button text (default (i18n "learnMore"))
     - linkTarget: Link target "_self" or "_blank" (default: "_self")
@@ -95,7 +102,29 @@
     <p class="text-gray-600 mt-4">This is a paragraph with <strong>bold</strong> and <em>italic</em> text.</p>
     {{< /content-split-with-image >}}
 
-    3. JSON DATA ONLY (structured data blocks - no markers needed):
+    3. WITH VIDEO (video content instead of image):
+    {{< content-split-with-image
+        theme="light"
+        eyebrow="Video Tutorial"
+        heading="Watch Our Platform Demo"
+        description="See how easy it is to get started"
+        videoUrl="https://youtu.be/9bpwD8b2PbU"
+        poster="/images/video-poster.jpg"
+        posterHeight="h-[32.625rem]"
+        videoTitle="Platform Demo"
+        videoDescription="Learn how to get started"
+        videoLinkUrl="/tutorials"
+        mediaContainerPaddingY="py-5"
+        layout="image-left"
+        link="/get-started"
+        linkText="Start Free Trial"
+        buttonStyle="primary"
+    >}}
+     ## Learn more about our platform
+    This video tutorial will walk you through the key features and show you how to maximize your productivity.
+    {{< /content-split-with-image >}}
+
+    4. JSON DATA ONLY (structured data blocks - no markers needed):
     {{< content-split-with-image
         heading="By the Numbers"
         backgroundColor="bg-gradient-to-br from-blue-50 to-indigo-100"
@@ -146,7 +175,7 @@
     }
     {{< /content-split-with-image >}}
 
-    4. COMBINED (JSON data + markdown/HTML content - markers required):
+    5. COMBINED (JSON data + markdown/HTML content - markers required):
     {{< content-split-with-image
         heading="Complete AI Solution"
         description="Everything you need in one platform"
@@ -267,6 +296,12 @@
 {{ $layout := .Get "layout" | default "image-left" }}
 {{ $image := .Get "image" | default "" }}
 {{ $imageAlt := .Get "imageAlt" | default "" }}
+{{ $videoUrl := .Get "videoUrl" | default "" }}
+{{ $poster := .Get "poster" | default "" }}
+{{ $posterHeight := .Get "posterHeight" | default "h-[32.625rem]" }}
+{{ $videoTitle := .Get "videoTitle" | default "" }}
+{{ $videoDescription := .Get "videoDescription" | default "" }}
+{{ $videoLinkUrl := .Get "videoLinkUrl" | default "" }}
 {{ $link := .Get "link" | default "" }}
 {{ $linkText := .Get "linkText" | default (i18n "learnMore") | default "Learn more" }}
 {{ $linkTarget := .Get "linkTarget" | default "_self" }}
@@ -468,6 +503,11 @@
   "buttonStyle" $buttonStyle
   "image" $image
   "imageAlt" $imageAlt
+  "videoUrl" $videoUrl
+  "poster" $poster
+  "videoTitle" $videoTitle
+  "videoDescription" $videoDescription
+  "videoLinkUrl" $videoLinkUrl
   "markdownContent" $markdownContent
   "contentAsHTML" $contentAsHTML
   "features" $features


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added video support and parameters to content-split-with-image
Added additional parameters as posterHeight special for custom poster for youtube videos

**Testing instructions**
- Go to any page with content-split-with-image section with video (we don't have it for now) and check visual and functionality it

QualityUnit/web-issues#3672
