### PR TITLE
[3800] - added prose-links classes for unify links inside content

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -428,4 +428,13 @@
   iframe {
     outline: none !important;
   }
+
+  /* ================================================================ */
+  /* 📝 PROSE STYLES */
+  /* ================================================================ */
+  
+  .prose-links {
+    @apply prose-a:text-secondary prose-a:font-normal prose-a:underline prose-a:hover:text-brand-text;
+    /* Standard prose with custom link styling */
+  }
 }

--- a/layouts/partials/components/lists/with_icon.html
+++ b/layouts/partials/components/lists/with_icon.html
@@ -2,10 +2,10 @@
 {{ $margin := .margin | default "mt-10" }}
 {{ $columnsClass := .columnsClass | default "" }}
 
-<dl class="{{ $margin }} max-w-full not-prose flex flex-col gap-y-8 text-lg/7 text-secondary lg:max-w-full {{ $columnsClass }}">
+<dl class="{{ $margin }} max-w-full flex flex-col gap-y-8 text-lg/7 text-secondary lg:max-w-full {{ $columnsClass }}">
     {{ range $index, $item := $listItems }}
     <div class="relative pl-9">
-        <dt class="inline font-bold text-heading">
+        <dt class="inline font-bold text-heading not-prose">
             <span class="absolute left-1 top-1 size-5 text-primary">
                 {{ if $item.icon }}
                     {{ partial "components/media/icon.html" (dict "icon" $item.icon "class" "h-5 w-5") }}
@@ -21,7 +21,7 @@
             </span>
             {{ $item.title }}.
         </dt>
-        <dd class="inline pl-0 prose-links">{{ $item.description }}</dd>
+        <dd class="inline pl-0 prose-links">{{ $item.description | safeHTML }}</dd>
     </div>
     {{ end }}
 </dl>

--- a/layouts/partials/components/lists/with_icon.html
+++ b/layouts/partials/components/lists/with_icon.html
@@ -21,7 +21,7 @@
             </span>
             {{ $item.title }}.
         </dt>
-        <dd class="inline pl-0">{{ $item.description }}</dd>
+        <dd class="inline pl-0 prose-links">{{ $item.description }}</dd>
     </div>
     {{ end }}
 </dl>

--- a/layouts/partials/components/logos/simple.html
+++ b/layouts/partials/components/logos/simple.html
@@ -82,7 +82,7 @@
         {{ if or $heading $description }}
         <div class="text-center mb-8 sm:mb-12 {{ if $heading }}pt-4{{ end }}">
           {{ if $heading }}<h2 class="text-heading text-3xl font-bold tracking-tight sm:text-4xl">{{ $heading }}</h2>{{ end }}
-          {{ if $description }}<p class="mt-4 text-lg text-secondary">{{ $description | markdownify }}</p>{{ end }}
+          {{ if $description }}<p class="mt-4 text-lg text-secondary prose-links">{{ $description | markdownify }}</p>{{ end }}
         </div>
         {{ end }}
 

--- a/layouts/partials/layout/headers/centered.html
+++ b/layouts/partials/layout/headers/centered.html
@@ -24,9 +24,9 @@
 
 {{/* Heading */}}
 {{ $heading := .heading | default "Support center" }}
-{{ $headingColor := .headingColor | default "text-gray-900" }}
-{{ $description := .description | default "Anim aute id magna aliqua ad ad non deserunt sunt. Qui irure qui lorem cupidatat commodo. Elit sunt amet fugiat veniam occaecat fugiat." }}
-{{ $descriptionColor := .descriptionColor | default "text-gray-500" }}
+{{ $headingColor := .headingColor | default "text-heading" }}
+{{ $description := .description | default "" }}
+{{ $descriptionColor := .descriptionColor | default "text-tertiary" }}
 
 {{/* Max width */}}
 {{ $maxWidth := .maxWidth | default "max-w-2xl" }}
@@ -34,6 +34,6 @@
 <div class="{{ $bgColor }} {{ $padding }}">
   <div class="mx-auto {{ $maxWidth }} text-center">
     <h2 class="text-5xl font-semibold tracking-tight {{ $headingColor }} sm:text-7xl">{{ $heading }}</h2>
-    <p class="mt-8 text-lg font-medium text-pretty {{ $descriptionColor }} sm:text-xl/8">{{ $description }}</p>
+    <p class="mt-8 text-lg font-medium text-pretty {{ $descriptionColor }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:{{ $descriptionColor }}">{{ $description }}</p>
   </div>
 </div>

--- a/layouts/partials/layout/headers/simple.html
+++ b/layouts/partials/layout/headers/simple.html
@@ -35,7 +35,7 @@
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto {{ $maxWidth }} lg:mx-0">
       <h2 class="text-5xl font-semibold tracking-tight {{ $headingColor }} sm:text-7xl">{{ $heading }}</h2>
-      <p class="mt-8 text-lg font-medium text-pretty {{ $descriptionColor }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:{{ $descriptionColor }}">{{ $description }}</p>
+      <p class="mt-8 text-lg font-medium text-pretty {{ $descriptionColor }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:{{ $descriptionColor }}">{{ $description | safeHTML }}</p>
     </div>
   </div>
 </div>

--- a/layouts/partials/layout/headers/simple.html
+++ b/layouts/partials/layout/headers/simple.html
@@ -5,9 +5,9 @@
   - bgColor: Background color class (optional, default: "bg-white")
   - padding: Padding classes (optional, default: "py-24 sm:py-32")
   - heading: Main heading text (optional, default: "Support center")
-  - headingColor: Heading text color (optional, default: "text-gray-900")
+  - headingColor: Heading text color (optional, default: "text-heading")
   - description: Description text (optional, default: provided placeholder text)
-  - descriptionColor: Description text color (optional, default: "text-gray-500")
+  - descriptionColor: Description text color (optional, default: "text-tertiary")
   - maxWidth: Max width class for the content container (optional, default: "max-w-2xl")
 @example:
   {{ partial "layout/headers/simple.html" (dict 
@@ -23,10 +23,10 @@
 {{ $padding := .padding | default "py-24 sm:py-32" }}
 
 {{/* Heading */}}
-{{ $heading := .heading | default "Support center" }}
-{{ $headingColor := .headingColor | default "text-gray-900" }}
-{{ $description := .description | default "Anim aute id magna aliqua ad ad non deserunt sunt. Qui irure qui lorem cupidatat commodo. Elit sunt amet fugiat veniam occaecat fugiat." }}
-{{ $descriptionColor := .descriptionColor | default "text-gray-500" }}
+{{ $heading := .heading | default "" }}
+{{ $headingColor := .headingColor | default "text-heading" }}
+{{ $description := .description | default "" }}
+{{ $descriptionColor := .descriptionColor | default "text-tertiary" }}
 
 {{/* Max width */}}
 {{ $maxWidth := .maxWidth | default "max-w-2xl" }}
@@ -35,7 +35,7 @@
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto {{ $maxWidth }} lg:mx-0">
       <h2 class="text-5xl font-semibold tracking-tight {{ $headingColor }} sm:text-7xl">{{ $heading }}</h2>
-      <p class="mt-8 text-lg font-medium text-pretty {{ $descriptionColor }} sm:text-xl/8">{{ $description }}</p>
+      <p class="mt-8 text-lg font-medium text-pretty {{ $descriptionColor }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:{{ $descriptionColor }}">{{ $description }}</p>
     </div>
   </div>
 </div>

--- a/layouts/partials/layout/headers/simple_with_eyebrow_base.html
+++ b/layouts/partials/layout/headers/simple_with_eyebrow_base.html
@@ -56,7 +56,7 @@
       {{ end }}
       <h2 class="{{ if $eyebrow }}{{ $headingMargin }}{{ end }} text-5xl font-semibold tracking-[-2.832px] text-heading">{{ $heading }}</h2>
       {{ if $description }}
-        <p class="{{ $descriptionMargin }} text-lg text-pretty text-secondary sm:text-xl/8">{{ $description }}</p>
+        <p class="{{ $descriptionMargin }} text-lg text-pretty text-secondary sm:text-xl/8 prose-links">{{ $description | safeHTML }}</p>
       {{ end }}
     </div>
   </div>

--- a/layouts/partials/sections/bentogrids/three_column_bento_grid.html
+++ b/layouts/partials/sections/bentogrids/three_column_bento_grid.html
@@ -77,7 +77,7 @@
         <p class="{{ if $tagline }}mt-2{{ end }} text-center text-4xl font-semibold tracking-tight text-balance text-heading sm:text-5xl">{{ $heading }}</p>
       {{ end }}
       {{ if $description }}
-        <p class="mt-6 mx-auto max-w-2xl text-center text-lg/9 text-secondary prose-links">{{ $description }}</p>
+        <p class="mt-6 mx-auto max-w-2xl text-center text-lg/9 text-secondary prose-links">{{ $description | safeHTML }}</p>
       {{ end }}
       <div class="mt-20 grid gap-8 lg:gap-16 md:grid-cols-3">
         {{ range $index, $card := $cards }}
@@ -97,7 +97,7 @@
                   {{ end }}
 
                 {{ if $card.description }}
-                  <p class="max-w-lg text-sm/8 text-secondary max-md:text-center prose-links">{{ $card.description }}</p>
+                  <p class="max-w-lg text-sm/8 text-secondary max-md:text-center prose-links">{{ $card.description | safeHTML }}</p>
                 {{ end }}
 
                 {{ if $card.url }}

--- a/layouts/partials/sections/bentogrids/three_column_bento_grid.html
+++ b/layouts/partials/sections/bentogrids/three_column_bento_grid.html
@@ -77,7 +77,7 @@
         <p class="{{ if $tagline }}mt-2{{ end }} text-center text-4xl font-semibold tracking-tight text-balance text-heading sm:text-5xl">{{ $heading }}</p>
       {{ end }}
       {{ if $description }}
-        <p class="mt-6 mx-auto max-w-2xl text-center text-lg/9 text-secondary">{{ $description }}</p>
+        <p class="mt-6 mx-auto max-w-2xl text-center text-lg/9 text-secondary prose-links">{{ $description }}</p>
       {{ end }}
       <div class="mt-20 grid gap-8 lg:gap-16 md:grid-cols-3">
         {{ range $index, $card := $cards }}
@@ -97,7 +97,7 @@
                   {{ end }}
 
                 {{ if $card.description }}
-                  <p class="max-w-lg text-sm/8 text-secondary max-md:text-center">{{ $card.description }}</p>
+                  <p class="max-w-lg text-sm/8 text-secondary max-md:text-center prose-links">{{ $card.description }}</p>
                 {{ end }}
 
                 {{ if $card.url }}

--- a/layouts/partials/sections/content/centered.html
+++ b/layouts/partials/sections/content/centered.html
@@ -63,7 +63,7 @@
     {{ end }}
     
     {{ if $description }}
-    <p class="mt-6 text-xl/8 {{ $descriptionColor }} prose-links">{{ $description }}</p>
+    <p class="mt-6 text-xl/8 {{ $descriptionColor }} prose-links">{{ $description | safeHTML }}</p>
     {{ end }}
     
     <!-- Apply Tailwind typography with custom processing for better heading styles -->

--- a/layouts/partials/sections/content/centered.html
+++ b/layouts/partials/sections/content/centered.html
@@ -63,11 +63,11 @@
     {{ end }}
     
     {{ if $description }}
-    <p class="mt-6 text-xl/8 {{ $descriptionColor }}">{{ $description }}</p>
+    <p class="mt-6 text-xl/8 {{ $descriptionColor }} prose-links">{{ $description }}</p>
     {{ end }}
     
     <!-- Apply Tailwind typography with custom processing for better heading styles -->
-    <div class=" mt-10 prose prose-lg prose-indigo max-w-none">
+    <div class=" mt-10 prose prose-lg prose-indigo prose-links max-w-none">
       {{ $content }}
     </div>
   </div>

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -169,7 +169,7 @@ Design Tokens:
           <h2 class="mt-3  mb-0 text-4xl font-semibold {{ $headingTracking }}  text-heading leading-none text-pretty sm:text-5xl">{{ $heading }}</h2>
         {{ end }}
         {{ if $description }}
-          <p class="mt-6 text-lg/7 text-secondary">{{ $description | safeHTML }}</p>
+          <p class="mt-6 text-lg/7 text-secondary prose-links">{{ $description | safeHTML }}</p>
         {{ end }}
 
         {{/* Button */}}
@@ -186,7 +186,7 @@ Design Tokens:
 
         {{/* Main content */}}
         {{ if $markdownContent }}
-          <div class="mt-10 max-w-full text-secondary lg:max-w-full">
+          <div class="mt-10 max-w-full text-secondary prose-links lg:max-w-full">
             {{ if $contentAsHTML }}
                 {{ $markdownContent | safeHTML }}
             {{ else }}
@@ -209,7 +209,7 @@ Design Tokens:
               {{ .title }}.
             </dt>
             {{ if .description }}
-              <dd class="inline">{{ .description }}</dd>
+              <dd class="inline prose-links">{{ .description }}</dd>
             {{ end }}
           </div>
           {{ end }}
@@ -225,7 +225,7 @@ Design Tokens:
                   <span class="absolute left-1 top-1/2 -translate-y-1/2 w-5 h-5 text-[10px] flex justify-center items-center text-white rounded-full bg-primary">{{ add $index 1 }}</span>
                   {{ .title }}.
                 </span>
-                <span class="inline">{{ .description }}</span>
+                <span class="inline prose-links">{{ .description }}</span>
               </li>
             {{ end }}
           </ol>
@@ -247,7 +247,7 @@ Design Tokens:
         {{ if $quote }}
           <div class="lg:max-w-full">
             <figure class="mt-10 border-l border-gray-200 pl-8 text-secondary">
-              <blockquote class="text-base/7">
+              <blockquote class="text-base/7 prose-links">
                 <p>"{{ $quote.text }}"</p>
               </blockquote>
               <figcaption class="mt-6 flex gap-x-4 text-sm/6">

--- a/layouts/partials/sections/content/two_columns_with_videos.html
+++ b/layouts/partials/sections/content/two_columns_with_videos.html
@@ -86,7 +86,7 @@
           
           {{ if $description }}
             <p class="text-lg text-secondary prose-links">
-              {{ $description }}
+              {{ $description | safeHTML }}
             </p>
           {{ end }}
         </div>

--- a/layouts/partials/sections/content/two_columns_with_videos.html
+++ b/layouts/partials/sections/content/two_columns_with_videos.html
@@ -85,7 +85,7 @@
           {{ end }}
           
           {{ if $description }}
-            <p class="text-lg text-secondary">
+            <p class="text-lg text-secondary prose-links">
               {{ $description }}
             </p>
           {{ end }}

--- a/layouts/partials/sections/content/workflow-section.html
+++ b/layouts/partials/sections/content/workflow-section.html
@@ -40,7 +40,7 @@ Parameters:
             <h1 class="text-4xl font-semibold sm:text-5xl {{ $headingTracking }} text-heading leading-none text-pretty">{{ $heading }}</h1>
             {{ end }}
             {{ if $description }}
-            <p class="mt-9 text-lg/7 text-tertiary sm:text-xl/8">{{ $description | safeHTML }}</p>
+            <p class="mt-9 text-lg/7 text-tertiary sm:text-xl/8 prose-links prose-a:text-tertiary">{{ $description | safeHTML }}</p>
             {{ end }}
 
             {{/* CTA Buttons */}}

--- a/layouts/partials/sections/courses/courses-content.html
+++ b/layouts/partials/sections/courses/courses-content.html
@@ -158,7 +158,7 @@
             {{ end }}
             
             {{ if $description }}
-                <div class="text-tertiary {{ $descriptionClass }}">
+                <div class="text-tertiary {{ $descriptionClass }} prose-links prose-a:text-tertiary">
                     {{ $description | safeHTML }}
                 </div>
             {{ end }}

--- a/layouts/partials/sections/courses/courses-video.html
+++ b/layouts/partials/sections/courses/courses-video.html
@@ -111,7 +111,7 @@
         {{ end }}
         
         {{ if $description }}
-        <div class="{{ $descriptionClass }} {{ $descriptionColor }}">
+        <div class="{{ $descriptionClass }} {{ $descriptionColor }} prose-links prose-a:{{ $descriptionColor }}">
             {{ $description | safeHTML }}
         </div>
         {{ end }}

--- a/layouts/partials/sections/cta/simple_centered.html
+++ b/layouts/partials/sections/cta/simple_centered.html
@@ -43,11 +43,11 @@
 <div class="bg-white">
   <div class="px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
-      <h2 class="text-4xl font-semibold tracking-tight text-balance text-gray-900 sm:text-5xl">{{ $heading }}</h2>
-      <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-gray-600">{{ $description | safeHTML }}</p>
+      <h2 class="text-4xl font-semibold tracking-tight text-balance text-heading sm:text-5xl">{{ $heading }}</h2>
+      <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-secondary price-links">{{ $description | safeHTML }}</p>
       <div class="mt-10 flex items-center justify-center gap-x-6">
         <a href="{{ $primaryCta.url }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
-        <a href="{{ $secondaryCta.url }}" class="text-sm/6 font-semibold text-gray-900">{{ $secondaryCta.text }} <span aria-hidden="true">→</span></a>
+        <a href="{{ $secondaryCta.url }}" class="text-sm/6 font-semibold text-heading">{{ $secondaryCta.text }} <span aria-hidden="true">→</span></a>
       </div>
     </div>
   </div>

--- a/layouts/partials/sections/cta/simple_centered.html
+++ b/layouts/partials/sections/cta/simple_centered.html
@@ -44,7 +44,7 @@
   <div class="px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
       <h2 class="text-4xl font-semibold tracking-tight text-balance text-heading sm:text-5xl">{{ $heading }}</h2>
-      <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-secondary price-links">{{ $description | safeHTML }}</p>
+      <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-secondary prose-links">{{ $description | safeHTML }}</p>
       <div class="mt-10 flex items-center justify-center gap-x-6">
         <a href="{{ $primaryCta.url }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
         <a href="{{ $secondaryCta.url }}" class="text-sm/6 font-semibold text-heading">{{ $secondaryCta.text }} <span aria-hidden="true">→</span></a>

--- a/layouts/partials/sections/cta/split_with_image.html
+++ b/layouts/partials/sections/cta/split_with_image.html
@@ -62,7 +62,7 @@
           <p class="mt-2.5 text-4xl not-prose font-semibold tracking-tight text-heading sm:text-5xl">{{ $heading }}</p>
         {{ end }}
         {{ if $description }}
-          <p class="mt-6 text-base/7 not-prose text-secondary">{{ $description }}</p>
+          <p class="mt-6 text-base/7 not-prose text-secondary price-links">{{ $description }}</p>
         {{ end }}
         {{ if and $cta $cta.text $cta.url }}
           <div class="mt-8">

--- a/layouts/partials/sections/cta/split_with_image.html
+++ b/layouts/partials/sections/cta/split_with_image.html
@@ -62,7 +62,7 @@
           <p class="mt-2.5 text-4xl not-prose font-semibold tracking-tight text-heading sm:text-5xl">{{ $heading }}</p>
         {{ end }}
         {{ if $description }}
-          <p class="mt-6 text-base/7 not-prose text-secondary price-links">{{ $description }}</p>
+          <p class="mt-6 text-base/7 not-prose text-secondary prose-links">{{ $description }}</p>
         {{ end }}
         {{ if and $cta $cta.text $cta.url }}
           <div class="mt-8">

--- a/layouts/partials/sections/features/simple_three_column_with_large_icons.html
+++ b/layouts/partials/sections/features/simple_three_column_with_large_icons.html
@@ -73,7 +73,7 @@
             <h2 class="text-4xl font-semibold tracking-tight text-pretty text-heading sm:text-5xl">{{ $heading }}</h2>
           {{ end }}
           {{ if $description }}
-            <p class="mt-6 text-lg/9 text-secondary price-links">{{ $description | safeHTML }}</p>
+            <p class="mt-6 text-lg/9 text-secondary prose-links">{{ $description | safeHTML }}</p>
           {{ end }}
         </div>
       {{ end }}
@@ -90,7 +90,7 @@
               <span>{{ .title }}</span>
             </dt>
             <dd class="mt-1 pl-0 text-base/7 text-secondary {{ if not .icon }} pl-0 {{ end }}">
-              <p class="price-links">{{ .description | safeHTML }}</p>
+              <p class="prose-links">{{ .description | safeHTML }}</p>
               {{ if .link }}
               <p class="mt-4">
                 {{ partial "components/buttons/buttons.html" (dict

--- a/layouts/partials/sections/features/simple_three_column_with_large_icons.html
+++ b/layouts/partials/sections/features/simple_three_column_with_large_icons.html
@@ -73,7 +73,7 @@
             <h2 class="text-4xl font-semibold tracking-tight text-pretty text-heading sm:text-5xl">{{ $heading }}</h2>
           {{ end }}
           {{ if $description }}
-            <p class="mt-6 text-lg/9 text-secondary">{{ $description | safeHTML }}</p>
+            <p class="mt-6 text-lg/9 text-secondary price-links">{{ $description | safeHTML }}</p>
           {{ end }}
         </div>
       {{ end }}
@@ -90,7 +90,7 @@
               <span>{{ .title }}</span>
             </dt>
             <dd class="mt-1 pl-0 text-base/7 text-secondary {{ if not .icon }} pl-0 {{ end }}">
-              <p>{{ .description | safeHTML }}</p>
+              <p class="price-links">{{ .description | safeHTML }}</p>
               {{ if .link }}
               <p class="mt-4">
                 {{ partial "components/buttons/buttons.html" (dict

--- a/layouts/partials/sections/features/with_intro_and_tabs.html
+++ b/layouts/partials/sections/features/with_intro_and_tabs.html
@@ -155,7 +155,7 @@
             <p class="text-base/6 font-semibold product-text">{{ $eyebrow }}</p>
           {{ end }}
           <h2 id="{{ $uniqueID }}-heading" class="mt-2.5 text-3xl font-semibold tracking-[-2.8px] text-heading sm:text-5xl">{{ $heading }}</h2>
-          <div class="mt-6 text-lg text-secondary">
+          <div class="mt-6 text-lg text-secondary prose-links">
             {{ template "renderDescription" (dict "description" $description "page" $page) }}
           </div>
         </div>
@@ -204,7 +204,7 @@
                         <h3 class="text-3xl font-bold text-heading">{{ $tab.content.title }}</h3>
                       {{ end }}
                       {{ if $tab.content.description }}
-                        <div class="mt-2 text-base/9 text-tertiary">
+                        <div class="mt-2 text-base/9 text-tertiary prose-links prose-a:text-tertiary">
                           {{ template "renderDescription" (dict "description" $tab.content.description "page" $page) }}
                         </div>
                       {{ end }}
@@ -217,7 +217,7 @@
                         <h3 class="text-3xl font-bold text-heading">{{ $tab.content.title }}</h3>
                       {{ end }}
                       {{ if $tab.content.description }}
-                        <div class="mt-2 text-base/9 text-tertiary">
+                        <div class="mt-2 text-base/9 text-tertiary prose-links prose-a:text-tertiary">
                           {{ template "renderDescription" (dict "description" $tab.content.description "page" $page) }}
                         </div>
                       {{ end }}

--- a/layouts/partials/sections/features/with_large_screenshot.html
+++ b/layouts/partials/sections/features/with_large_screenshot.html
@@ -8,15 +8,15 @@
 {{ $page := .page }}
 
 <div class="bg-white py-24 sm:py-32">
-  <div class="mx-auto max-w-7xl px-6 lg:px-8">
+  <div class="wrapper px-6 lg:px-8">
     <div class="mx-auto max-w-2xl sm:text-center">
       <h2 class="text-base/7 font-semibold text-primary">{{ $tagline }}</h2>
-      <p class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl sm:text-balance">{{ $heading }}</p>
-      <p class="mt-6 text-lg/8 text-gray-600">{{ $description | safeHTML }}</p>
+      <p class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-heading sm:text-5xl sm:text-balance">{{ $heading }}</p>
+      <p class="prose-links mt-6 text-lg/8 text-secondary">{{ $description | safeHTML }}</p>
     </div>
   </div>
   <div class="relative overflow-hidden pt-16">
-    <div class="mx-auto max-w-7xl px-6 lg:px-8">
+    <div class="wrapper px-6 lg:px-8">
       {{ partial "components/media/lazyimg.html" (dict 
         "src" $screenshot.url 
         "alt" $screenshot.alt
@@ -30,11 +30,11 @@
     </div>
   </div>
   {{ if $features }}
-  <div class="mx-auto mt-16 max-w-7xl px-6 sm:mt-20 md:mt-24 lg:px-8">
-    <dl class="mx-auto grid max-w-2xl grid-cols-1 gap-x-6 gap-y-10 text-base/7 text-gray-600 sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3 lg:gap-x-8 lg:gap-y-16">
+  <div class="wrapper mt-16 px-6 sm:mt-20 md:mt-24 lg:px-8">
+    <dl class="mx-auto grid max-w-2xl grid-cols-1 gap-x-6 gap-y-10 text-base/7 text-secondary sm:grid-cols-2 lg:mx-0 lg:max-w-none lg:grid-cols-3 lg:gap-x-8 lg:gap-y-16">
       {{ range $features }}
       <div class="relative pl-9">
-        <dt class="font-semibold text-gray-900">
+        <dt class="font-semibold text-heading">
           {{ if .icon }}
           <div class="absolute left-1 top-1 size-5 text-primary">
             {{ partial "components/media/icon.html" (dict "icon" .icon) }}
@@ -42,7 +42,7 @@
           {{ end }}
           {{ .title }}
         </dt>
-        <dd class="mt-1">{{ .description | safeHTML }}</dd>
+        <dd class="prose-links mt-1">{{ .description | safeHTML }}</dd>
       </div>
       {{ end }}
     </dl>

--- a/layouts/partials/sections/features/with_split_image.html
+++ b/layouts/partials/sections/features/with_split_image.html
@@ -39,7 +39,7 @@
             {{/* Subheading and heading */}}
             <h2 class="font-medium text-tertiary">{{ $subheading }}</h2>
             <p class="{{ if $subheading }}mt-4 {{ end }}text-5xl sm:text-7xl font-semibold tracking-tight text-heading">{{ $heading }}</p>
-            <p class="mt-9 text-tertiary">{{ $description | safeHTML }}</p>
+            <p class="mt-9 text-tertiary prose-links prose-a:text-tertiary">{{ $description | safeHTML }}</p>
           </div>
           <div class="mt-[4.5rem] rounded-xl">
             {{ partial "components/media/lazyimg.html" (dict 

--- a/layouts/partials/sections/hero/simple_base.html
+++ b/layouts/partials/sections/hero/simple_base.html
@@ -27,7 +27,7 @@
         <div class="wrapper {{ $padding }}">
             <div class="mx-auto lg:max-w-2xl lg:mx-0">
                 <h2 class="text-5xl font-semibold tracking-tight text-heading sm:text-7xl">{{ $heading }}</h2>
-                <p class="mt-8 text-pretty text-lg text-tertiary sm:text-xl/8 prose-links prose-a:text-tertiary">{{ $description }}</p>
+                <p class="mt-8 text-pretty text-lg text-tertiary sm:text-xl/8 prose-links prose-a:text-tertiary">{{ $description | safeHTML}}</p>
             </div>
         </div>
     </div>

--- a/layouts/partials/sections/hero/simple_base.html
+++ b/layouts/partials/sections/hero/simple_base.html
@@ -27,7 +27,7 @@
         <div class="wrapper {{ $padding }}">
             <div class="mx-auto lg:max-w-2xl lg:mx-0">
                 <h2 class="text-5xl font-semibold tracking-tight text-heading sm:text-7xl">{{ $heading }}</h2>
-                <p class="mt-8 text-pretty text-lg text-tertiary sm:text-xl/8">{{ $description }}</p>
+                <p class="mt-8 text-pretty text-lg text-tertiary sm:text-xl/8 prose-links prose-a:text-tertiary">{{ $description }}</p>
             </div>
         </div>
     </div>

--- a/layouts/partials/sections/hero/simple_centered.html
+++ b/layouts/partials/sections/hero/simple_centered.html
@@ -109,7 +109,7 @@
               <h1 class="text-5xl font-semibold tracking-[-4.248px] leading-none text-balance text-heading sm:text-7xl"{{ if $typewriter.enabled }} data-typewriter data-typewriter-words="{{ $typewriter.words }}" data-typewriter-word-alternatives="{{$typewriter.wordAlternatives}}" data-typewriter-speed="{{ $typewriter.speed }}" data-typewriter-delete-speed="{{ $typewriter.deleteSpeed }}" data-typewriter-pause="{{ $typewriter.pause }}" data-typewriter-color="{{ $typewriter.color }}"{{ end }}>{{ $heading }}</h1>
             {{ end }}
             {{ if $description }}
-              <p class="mt-9 text-lg font-medium text-pretty text-secondary sm:text-xl/8 prose-links prose-a:font-medium">{{ $description }}</p>
+              <p class="mt-9 text-lg font-medium text-pretty text-secondary sm:text-xl/8 prose-links prose-a:font-medium">{{ $description | safeHTML }}</p>
             {{ end }}
 
             {{ if $tags }}

--- a/layouts/partials/sections/hero/simple_centered.html
+++ b/layouts/partials/sections/hero/simple_centered.html
@@ -109,7 +109,7 @@
               <h1 class="text-5xl font-semibold tracking-[-4.248px] leading-none text-balance text-heading sm:text-7xl"{{ if $typewriter.enabled }} data-typewriter data-typewriter-words="{{ $typewriter.words }}" data-typewriter-word-alternatives="{{$typewriter.wordAlternatives}}" data-typewriter-speed="{{ $typewriter.speed }}" data-typewriter-delete-speed="{{ $typewriter.deleteSpeed }}" data-typewriter-pause="{{ $typewriter.pause }}" data-typewriter-color="{{ $typewriter.color }}"{{ end }}>{{ $heading }}</h1>
             {{ end }}
             {{ if $description }}
-              <p class="mt-9 text-lg font-medium text-pretty text-secondary sm:text-xl/8">{{ $description }}</p>
+              <p class="mt-9 text-lg font-medium text-pretty text-secondary sm:text-xl/8 prose-links prose-a:font-medium">{{ $description }}</p>
             {{ end }}
 
             {{ if $tags }}

--- a/layouts/partials/sections/hero/split_left_side_helper.html
+++ b/layouts/partials/sections/hero/split_left_side_helper.html
@@ -33,7 +33,7 @@
     {{ end }}
     {{ if $heading }}<h1 class="mt-6 text-5xl font-semibold tracking-[-2.832px] text-heading leading-none text-pretty sm:text-7xl"{{ if $typewriter.enabled }} data-typewriter data-typewriter-words="{{ $typewriter.words }}" data-typewriter-word-alternatives="{{$typewriter.wordAlternatives}}" data-typewriter-speed="{{ $typewriter.speed }}" data-typewriter-delete-speed="{{ $typewriter.deleteSpeed }}" data-typewriter-pause="{{ $typewriter.pause }}" data-typewriter-color="{{ $typewriter.color }}"{{ end }}>{{ $heading }}</h1>{{ end }}
     {{ if $description }}
-    <p class="mt-8 text-lg/7 text-secondary sm:text-xl/8">{{ $description | safeHTML }}</p>
+    <p class="mt-8 text-lg/7 text-secondary sm:text-xl/8 prose-links">{{ $description | safeHTML }}</p>
     {{ end }}
 
     <!-- Tags and Categories -->

--- a/layouts/partials/sections/hero/split_with_image.html
+++ b/layouts/partials/sections/hero/split_with_image.html
@@ -112,7 +112,7 @@ Design Tokens:
           <h1 class="mt-6 text-5xl font-semibold {{ $headingTracking }} text-heading leading-none text-pretty sm:text-7xl"{{ if $typewriter.enabled }} data-typewriter data-typewriter-words="{{ $typewriter.words }}" data-typewriter-word-alternatives="{{$typewriter.wordAlternatives}}" data-typewriter-speed="{{ $typewriter.speed }}" data-typewriter-delete-speed="{{ $typewriter.deleteSpeed }}" data-typewriter-pause="{{ $typewriter.pause }}" data-typewriter-color="{{ $typewriter.color }}"{{ end }}>{{ $heading }}</h1>
         {{ end }}
         {{ if $description }}
-          <p class="mt-8 text-lg/7 text-secondary sm:text-xl/8">{{ $description | safeHTML }}</p>
+          <p class="mt-8 text-lg/7 text-secondary sm:text-xl/8 prose-links">{{ $description | safeHTML }}</p>
         {{ end }}
 
         {{/* Tags and Categories */}}

--- a/layouts/partials/sections/pricing/base.html
+++ b/layouts/partials/sections/pricing/base.html
@@ -139,7 +139,7 @@
       <p class="text-base/7 font-semibold text-{{ $taglineColor }}">{{ $tagline }}</p>
       <h1 class="mt-2 not-prose text-5xl font-semibold tracking-tight text-balance text-{{ $headingColor }} sm:text-6xl">{{ $heading }}</h1>
     </div>
-    <p class="mx-auto mt-6 not-prose max-w-2xl text-pretty text-center text-lg font-medium text-{{ $descriptionColor }} sm:text-xl/8">{{ $description }}</p>
+    <p class="mx-auto mt-6 not-prose max-w-2xl text-pretty text-center text-lg font-medium text-{{ $descriptionColor }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:text-{{ $descriptionColor }}">{{ $description }}</p>
     <div class="isolate mx-auto mt-16 grid items-stretch grid-cols-1 {{ $columnsClass }} gap-y-8 sm:gap-x-4 sm:gap-y-4 sm:mt-20 lg:gap-x-5">
       {{ range $tier := $tiers }}
       <div class='flex flex-col h-full rounded-3xl p-8 {{ if $tier.darkTheme }}bg-slate-900 ring-1 ring-slate-700{{ else }}bg-white ring-1 ring-gray-200{{ end }} {{ if $tier.popular }}ring-2 ring-primary{{ end }} xl:p-10 w-full'>

--- a/layouts/partials/sections/pricing/base.html
+++ b/layouts/partials/sections/pricing/base.html
@@ -139,7 +139,7 @@
       <p class="text-base/7 font-semibold text-{{ $taglineColor }}">{{ $tagline }}</p>
       <h1 class="mt-2 not-prose text-5xl font-semibold tracking-tight text-balance text-{{ $headingColor }} sm:text-6xl">{{ $heading }}</h1>
     </div>
-    <p class="mx-auto mt-6 not-prose max-w-2xl text-pretty text-center text-lg font-medium text-{{ $descriptionColor }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:text-{{ $descriptionColor }}">{{ $description }}</p>
+    <p class="mx-auto mt-6 not-prose max-w-2xl text-pretty text-center text-lg font-medium text-{{ $descriptionColor }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:text-{{ $descriptionColor }}">{{ $description | safeHTML }}</p>
     <div class="isolate mx-auto mt-16 grid items-stretch grid-cols-1 {{ $columnsClass }} gap-y-8 sm:gap-x-4 sm:gap-y-4 sm:mt-20 lg:gap-x-5">
       {{ range $tier := $tiers }}
       <div class='flex flex-col h-full rounded-3xl p-8 {{ if $tier.darkTheme }}bg-slate-900 ring-1 ring-slate-700{{ else }}bg-white ring-1 ring-gray-200{{ end }} {{ if $tier.popular }}ring-2 ring-primary{{ end }} xl:p-10 w-full'>

--- a/layouts/partials/sections/pricing/with_comparison_table.html
+++ b/layouts/partials/sections/pricing/with_comparison_table.html
@@ -95,7 +95,7 @@
                 {{ end }}
                 <h2 class="mt-2 mb-2 text-5xl font-semibold tracking-tight text-balance text-{{ $headingColorComparison }} sm:text-6xl">{{ $headingComparison }}</h2>
             </div>
-            <p class="text-center text-lg font-medium text-pretty text-{{ $descriptionColorComparison }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:text-{{ $descriptionColorComparison }}">{{ $descriptionComparison }}</p>
+            <p class="text-center text-lg font-medium text-pretty text-{{ $descriptionColorComparison }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:text-{{ $descriptionColorComparison }}">{{ $descriptionComparison | safeHTML }}</p>
             <div class="mt-8 flex justify-center">
                 {{ if $togglePrice }}
                     <fieldset aria-label="Payment frequency">

--- a/layouts/partials/sections/pricing/with_comparison_table.html
+++ b/layouts/partials/sections/pricing/with_comparison_table.html
@@ -95,7 +95,7 @@
                 {{ end }}
                 <h2 class="mt-2 mb-2 text-5xl font-semibold tracking-tight text-balance text-{{ $headingColorComparison }} sm:text-6xl">{{ $headingComparison }}</h2>
             </div>
-            <p class="text-center text-lg font-medium text-pretty text-{{ $descriptionColorComparison }} sm:text-xl/8">{{ $descriptionComparison }}</p>
+            <p class="text-center text-lg font-medium text-pretty text-{{ $descriptionColorComparison }} sm:text-xl/8 prose-links prose-a:font-medium prose-a:text-{{ $descriptionColorComparison }}">{{ $descriptionComparison }}</p>
             <div class="mt-8 flex justify-center">
                 {{ if $togglePrice }}
                     <fieldset aria-label="Payment frequency">

--- a/layouts/partials/sections/stats/simple_grid.html
+++ b/layouts/partials/sections/stats/simple_grid.html
@@ -82,7 +82,7 @@
         {{ end }}
         {{ if $description }}
         <p class="mt-4 text-lg/8 {{ $descriptionColor }} prose-links prose-a:{{ $descriptionColor }}">
-          {{ $description }}
+          {{ $description | safeHTML }}
         </p>
         {{ end }}
       </div>

--- a/layouts/partials/sections/stats/simple_grid.html
+++ b/layouts/partials/sections/stats/simple_grid.html
@@ -10,14 +10,14 @@
   - mobileColumns: Number of columns on small screens (optional, default: 1)
   - showHeading: Whether to display the heading section (optional, default: true)
   - heading: Main section heading
-  - headingColor: Heading color class (optional, default: "text-gray-900")
+  - headingColor: Heading color class (optional, default: "text-heading")
   - description: Section description text
-  - descriptionColor: Description color class (optional, default: "text-gray-600")
+  - descriptionColor: Description color class (optional, default: "text-secondary")
   - stats: Array of statistic objects (required)
     - value: The statistic value to display
     - label: Description of what the value represents
-  - valueColor: Color class for statistic values (optional, default: "text-gray-900")
-  - labelColor: Color class for statistic labels (optional, default: "text-gray-600")
+  - valueColor: Color class for statistic values (optional, default: "text-heading")
+  - labelColor: Color class for statistic labels (optional, default: "text-secondary")
 @example:
   {{ partial "sections/stats/simple_grid.html" (dict 
       "heading" "Our Company in Numbers" 
@@ -59,16 +59,16 @@
 {{/* Heading */}}
 {{ $showHeading := .showHeading | default true }}
 {{ $heading := .heading }}
-{{ $headingColor := .headingColor | default "text-gray-900" }}
+{{ $headingColor := .headingColor | default "text-heading" }}
 {{ $description := .description }}
-{{ $descriptionColor := .descriptionColor | default "text-gray-600" }}
+{{ $descriptionColor := .descriptionColor | default "text-secondary" }}
 
 {{/* Stats */}}
 {{ $stats := .stats | default slice }}
 
 {{/* Text colors */}}
-{{ $valueColor := .valueColor | default "text-gray-900" }}
-{{ $labelColor := .labelColor | default "text-gray-600" }}
+{{ $valueColor := .valueColor | default "text-heading" }}
+{{ $labelColor := .labelColor | default "text-secondary" }}
 
 <div class="{{ $bgColor }} {{ $padding }}">
   <div class="wrapper">
@@ -81,7 +81,7 @@
         </h2>
         {{ end }}
         {{ if $description }}
-        <p class="mt-4 text-lg/8 {{ $descriptionColor }}">
+        <p class="mt-4 text-lg/8 {{ $descriptionColor }} prose-links prose-a:{{ $descriptionColor }}">
           {{ $description }}
         </p>
         {{ end }}

--- a/layouts/partials/sections/stats/stepped.html
+++ b/layouts/partials/sections/stats/stepped.html
@@ -55,7 +55,7 @@
     {{ if $showHeading }}
       <div class="mx-auto md:max-w-2xl md:mx-0">
         <h2 class="text-4xl font-semibold tracking-tight text-pretty text-heading sm:text-5xl">{{ $heading }}</h2>
-        <p class="mt-6 text-lg/7 text-secondary">{{ $description }}</p>
+        <p class="mt-6 text-lg/7 text-secondary prose-links">{{ $description }}</p>
       </div>
     {{ end }}
     <div class="mx-auto mt-16 flex flex-col gap-8 md:mx-0 md:mt-20 md:max-w-none md:flex-row md:items-end">

--- a/layouts/partials/sections/stats/stepped.html
+++ b/layouts/partials/sections/stats/stepped.html
@@ -55,7 +55,7 @@
     {{ if $showHeading }}
       <div class="mx-auto md:max-w-2xl md:mx-0">
         <h2 class="text-4xl font-semibold tracking-tight text-pretty text-heading sm:text-5xl">{{ $heading }}</h2>
-        <p class="mt-6 text-lg/7 text-secondary prose-links">{{ $description }}</p>
+        <p class="mt-6 text-lg/7 text-secondary prose-links">{{ $description | safeHTML }}</p>
       </div>
     {{ end }}
     <div class="mx-auto mt-16 flex flex-col gap-8 md:mx-0 md:mt-20 md:max-w-none md:flex-row md:items-end">

--- a/layouts/partials/sections/testimonials/grid.html
+++ b/layouts/partials/sections/testimonials/grid.html
@@ -87,7 +87,7 @@
                 <!-- Featured testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-{{ $index }}">
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -120,7 +120,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-{{ $index }}">
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -159,7 +159,7 @@
                 <!-- Featured testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-tablet-{{ $index }}">
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -192,7 +192,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-tablet-{{ $index }}">
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -231,7 +231,7 @@
                 <!-- Featured testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col1-desktop-{{ $index }}">
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -264,7 +264,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col1-desktop-{{ $index }}">
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -320,7 +320,7 @@
                       {{ with site.Params.operatingSystem }}<span itemprop="operatingSystem">{{ . }}</span>{{ end }}
                       {{ with site.Params.softwareAudience }}<span itemprop="audience">{{ . }}</span>{{ end }}
                     </div>
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <footer class="flex flex-wrap items-center gap-x-4 gap-y-4 border-t border-secondary px-6 py-4 sm:flex-nowrap" id="testimonial-author-col2-tablet-{{ $index }}">
                     {{/* Unified image logic: prefer personImage, fallback to companyLogo, then to icon */}}
@@ -345,7 +345,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-tablet-{{ $index }}">
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <footer class="flex items-center gap-x-4 pt-8" id="testimonial-author-col2-tablet-{{ $index }}">
                     {{/* Unified image logic: prefer personImage, fallback to companyLogo, then to icon */}}
@@ -376,7 +376,7 @@
                 <!-- Featured testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-desktop-{{ $index }}">
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -409,7 +409,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-desktop-{{ $index }}">
-                    <p itemprop="reviewBody">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>

--- a/layouts/partials/sections/testimonials/grid.html
+++ b/layouts/partials/sections/testimonials/grid.html
@@ -87,7 +87,7 @@
                 <!-- Featured testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-{{ $index }}">
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -120,7 +120,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-{{ $index }}">
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -159,7 +159,7 @@
                 <!-- Featured testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-tablet-{{ $index }}">
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -192,7 +192,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-tablet-{{ $index }}">
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -231,7 +231,7 @@
                 <!-- Featured testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col1-desktop-{{ $index }}">
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -264,7 +264,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col1-desktop-{{ $index }}">
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -320,7 +320,7 @@
                       {{ with site.Params.operatingSystem }}<span itemprop="operatingSystem">{{ . }}</span>{{ end }}
                       {{ with site.Params.softwareAudience }}<span itemprop="audience">{{ . }}</span>{{ end }}
                     </div>
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <footer class="flex flex-wrap items-center gap-x-4 gap-y-4 border-t border-secondary px-6 py-4 sm:flex-nowrap" id="testimonial-author-col2-tablet-{{ $index }}">
                     {{/* Unified image logic: prefer personImage, fallback to companyLogo, then to icon */}}
@@ -345,7 +345,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-tablet-{{ $index }}">
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <footer class="flex items-center gap-x-4 pt-8" id="testimonial-author-col2-tablet-{{ $index }}">
                     {{/* Unified image logic: prefer personImage, fallback to companyLogo, then to icon */}}
@@ -376,7 +376,7 @@
                 <!-- Featured testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-desktop-{{ $index }}">
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>
@@ -409,7 +409,7 @@
                 <!-- Regular testimonial -->
                 <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial" itemscope itemtype="https://schema.org/Review">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-desktop-{{ $index }}">
-                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote }}"</p>
+                    <p itemprop="reviewBody" class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
                   <div itemprop="itemReviewed" itemscope itemtype="https://schema.org/SoftwareApplication" style="display: none;">
                     <span itemprop="name">{{ site.Title }}</span>

--- a/layouts/partials/sections/testimonials/simple_centered.html
+++ b/layouts/partials/sections/testimonials/simple_centered.html
@@ -68,7 +68,7 @@
       {{ partial "components/media/lazyimg.html" (dict "src" $logo "alt" $logoAlt "class" "mx-auto {{ $logoHeight }}") }}
     {{ end }}
     <figure class="mt-10">
-      <blockquote class="text-center text-xl/8 font-semibold {{ $quoteColor }} sm:text-2xl/9">
+      <blockquote class="text-center text-xl/8 font-semibold {{ $quoteColor }} sm:text-2xl/9 prose-links prose-a:{{ $quoteColor }}">
         <p>"{{ $quote }}"</p>
       </blockquote>
       <figcaption class="mt-10">

--- a/layouts/partials/sections/testimonials/simple_centered.html
+++ b/layouts/partials/sections/testimonials/simple_centered.html
@@ -13,13 +13,13 @@
   - logoAlt: Alt text for the logo (optional)
   - logoHeight: Height class for logo (optional, default: "h-12")
   - quote: Testimonial text (optional, default: "Lorem ipsum dolor sit amet consectetur...")
-  - quoteColor: Quote text color class (optional, default: "text-gray-900")
+  - quoteColor: Quote text color class (optional, default: "text-heading")
   - personImage: URL to person's avatar image (optional)
   - personImageAlt: Alt text for the person's image (optional)
   - personName: Name of the person giving testimonial (optional, default: "Judith Black")
-  - personNameColor: Person name color class (optional, default: "text-gray-900")
+  - personNameColor: Person name color class (optional, default: "text-heading")
   - personRole: Role or title of the person (optional, default: "CEO of Workcation")
-  - personRoleColor: Person role color class (optional, default: "text-gray-600")
+  - personRoleColor: Person role color class (optional, default: "text-secondary")
   - dotColor: Color for the separator dot (optional, default: "fill-gray-900")
 @example:
   {{ partial "sections/testimonials/simple_centered.html" (dict 
@@ -47,17 +47,17 @@
 {{ $skewShadowColor := .skewShadowColor | default "shadow-indigo-600/10" }}
 
 {{/* Content */}}
-{{ $logo := .logo | default "https://tailwindcss.com/plus-assets/img/logos/workcation-logo-indigo-600.svg" }}
+{{ $logo := .logo | default "" }}
 {{ $logoAlt := .logoAlt | default "" }}
 {{ $logoHeight := .logoHeight | default "h-12" }}
-{{ $quote := .quote | default "Lorem ipsum dolor sit amet consectetur adipisicing elit. Nemo expedita voluptas culpa sapiente alias molestiae. Numquam corrupti in laborum sed rerum et corporis." }}
-{{ $quoteColor := .quoteColor | default "text-gray-900" }}
-{{ $personImage := .personImage | default "https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=facearea&facepad=2&w=256&h=256&q=80" }}
+{{ $quote := .quote | default "" }}
+{{ $quoteColor := .quoteColor | default "text-heading" }}
+{{ $personImage := .personImage | default "" }}
 {{ $personImageAlt := .personImageAlt | default "" }}
 {{ $personName := .personName | default "Judith Black" }}
-{{ $personNameColor := .personNameColor | default "text-gray-900" }}
-{{ $personRole := .personRole | default "CEO of Workcation" }}
-{{ $personRoleColor := .personRoleColor | default "text-gray-600" }}
+{{ $personNameColor := .personNameColor | default "text-heading" }}
+{{ $personRole := .personRole | default "" }}
+{{ $personRoleColor := .personRoleColor | default "text-secondary" }}
 {{ $dotColor := .dotColor | default "fill-gray-900" }}
 
 <section class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
@@ -69,7 +69,7 @@
     {{ end }}
     <figure class="mt-10">
       <blockquote class="text-center text-xl/8 font-semibold {{ $quoteColor }} sm:text-2xl/9 prose-links prose-a:{{ $quoteColor }}">
-        <p>"{{ $quote }}"</p>
+        <p>"{{ $quote | safeHTML }}"</p>
       </blockquote>
       <figcaption class="mt-10">
         {{ if $personImage }}

--- a/layouts/shortcodes/header-centered.html
+++ b/layouts/shortcodes/header-centered.html
@@ -6,8 +6,8 @@
   - description: The description text below the heading (default: "Anim aute id magna aliqua...")
   - bgColor: Background color class (default: "bg-white")
   - padding: Padding classes (default: "px-6 py-24 sm:py-32 lg:px-8")
-  - headingColor: Text color class for the heading (default: "text-gray-900")
-  - descriptionColor: Text color class for the description (default: "text-gray-500")
+  - headingColor: Text color class for the heading (default: "text-heading")
+  - descriptionColor: Text color class for the description (default: "text-tertiary")
   - maxWidth: Maximum width class for the content (default: "max-w-2xl")
   
   Usage example:
@@ -19,12 +19,12 @@
   >}}
 */}}
 
-{{ $heading := .Get "heading" | default "Support center" }}
-{{ $description := .Get "description" | default "Anim aute id magna aliqua ad ad non deserunt sunt. Qui irure qui lorem cupidatat commodo. Elit sunt amet fugiat veniam occaecat fugiat." }}
+{{ $heading := .Get "heading" | default "" }}
+{{ $description := .Get "description" | default "" }}
 {{ $bgColor := .Get "bgColor" | default "bg-white" }}
 {{ $padding := .Get "padding" | default "px-6 py-24 sm:py-32 lg:px-8" }}
-{{ $headingColor := .Get "headingColor" | default "text-gray-900" }}
-{{ $descriptionColor := .Get "descriptionColor" | default "text-gray-500" }}
+{{ $headingColor := .Get "headingColor" | default "text-heading" }}
+{{ $descriptionColor := .Get "descriptionColor" | default "text-tertiary" }}
 {{ $maxWidth := .Get "maxWidth" | default "max-w-2xl" }}
 
 {{ partial "layout/headers/centered.html" (dict 

--- a/layouts/shortcodes/header-simple.html
+++ b/layouts/shortcodes/header-simple.html
@@ -12,12 +12,12 @@ Usage:
 >}}
 */}}
 
-{{ $heading := .Get "heading" | default (.Get 0) | default "Support center" }}
-{{ $description := .Get "description" | default (.Get 1) | default "Anim aute id magna aliqua ad ad non deserunt sunt. Qui irure qui lorem cupidatat commodo. Elit sunt amet fugiat veniam occaecat fugiat." }}
+{{ $heading := .Get "heading" | default (.Get 0) | default "" }}
+{{ $description := .Get "description" | default (.Get 1) | default "" }}
 {{ $bgColor := .Get "bgColor" | default (.Get 2) | default "bg-white" }}
 {{ $padding := .Get "padding" | default (.Get 3) | default "py-24 sm:py-32" }}
-{{ $headingColor := .Get "headingColor" | default (.Get 4) | default "text-gray-900" }}
-{{ $descriptionColor := .Get "descriptionColor" | default (.Get 5) | default "text-gray-500" }}
+{{ $headingColor := .Get "headingColor" | default (.Get 4) | default "text-heading" }}
+{{ $descriptionColor := .Get "descriptionColor" | default (.Get 5) | default "text-tertiary" }}
 {{ $maxWidth := .Get "maxWidth" | default (.Get 6) | default "max-w-2xl" }}
 
 {{ partial "layout/headers/simple.html" (dict 

--- a/layouts/shortcodes/latest-posts.html
+++ b/layouts/shortcodes/latest-posts.html
@@ -24,7 +24,7 @@ Usage:
             <div class="mx-auto mb-[4.25rem] max-w-2xl text-center">
                 <h2 class="text-balance text-4xl font-semibold text-heading tracking-tight sm:text-5xl">{{ $heading }}</h2>
                 {{ if $description }}
-                    <p class="mt-2 text-lg/8 text-secondary">{{ $description | safeHTML }}</p>
+                    <p class="mt-2 text-lg/8 text-secondary prose-links">{{ $description | safeHTML }}</p>
                 {{ end }}
             </div>
             


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added prose-links classes for unify links inside content. Unify text-underline and color as in current text in block, for hover color changed to color "--color-brand-text"
Changed colors classes in few partials where used "text-gray-900" and "text-gray-600"
Removed default text values in "layouts/shortcodes/header-simple.html" component

**Testing instructions**
- Go to all pages and check all, should be links unify

Related PR https://github.com/QualityUnit/PostAffiliatePro-hugo/pull/119

QualityUnit/web-issues#3800
