### PR TITLE
[3806] - added optional url parameter to card data for clickable links

### DIFF
--- a/layouts/partials/sections/content/three_columns_base.html
+++ b/layouts/partials/sections/content/three_columns_base.html
@@ -14,6 +14,7 @@
     - description: Card description text (required)
     - image: URL to image (required)
     - imageAlt: Alt text for the image (optional)
+    - url: URL to link the card to, making the entire card clickable (optional)
 @example:
   {{ partial "sections/content/three_column_content.html" (dict 
       "theme" "light"
@@ -28,18 +29,21 @@
               "description" "Our platform automatically adapts to any device or screen size."
               "image" "/images/features/responsive.png"
               "imageAlt" "Responsive design illustration"
+              "url" "/features/responsive"
           )
           (dict
               "title" "Analytics" 
               "description" "Detailed insights into your user behavior and application performance."
               "image" "/images/features/analytics.png"
               "imageAlt" "Analytics dashboard"
+              "url" "/features/analytics"
           )
           (dict
               "title" "Security" 
               "description" "Enterprise-grade security with end-to-end encryption."
               "image" "/images/features/security.png"
               "imageAlt" "Security shield"
+              "url" "/features/security"
           )
       )
   ) }}
@@ -87,9 +91,14 @@
             "descriptionMargin" $descriptionMargin
             ) }}
         {{ end }}
-      <div class="mt-20 grid gap-8 lg:gap-16 md:grid-cols-3">
+            <div class="mt-20 grid gap-8 lg:gap-16 md:grid-cols-3">
         {{ range $index, $card := $cards }}
           <div class="relative flex flex-col overflow-hidden">
+            {{ if $card.url }}
+              <a href="{{ $card.url }}" class="absolute inset-0 z-10 hover:opacity-90 transition-opacity">
+                <span class="sr-only">{{ $card.title }}</span>
+              </a>
+            {{ end }}
             <div class="flex items-center justify-centerl">
                 {{ partial "components/media/lazyimg.html" (dict "src" $card.image "alt" ($card.imageAlt | default "") "class" "rounded-xl") }}
             </div>
@@ -98,10 +107,12 @@
               {{ if $card.title }}
                 <p class="text-base/8 font-semibold tracking-tight text-heading">
                   {{ $card.title }}
-                  {{ if $card.description }}
-                    <span class="max-w-lg text-sm/6 text-secondary font-normal">{{ $card.description }}</span>
-                  {{ end }}
                 </p>
+              {{ end }}
+              {{ if $card.title }}
+                {{ if $card.description }}
+                  <span class="max-w-lg text-sm/6 text-secondary font-normal">{{ $card.description }}</span>
+                {{ end }}
               {{ else }}
                 {{ if $card.description }}
                   <span class="max-w-lg text-sm/6 text-secondary">{{ $card.description }}</span>

--- a/layouts/partials/sections/content/three_columns_base.html
+++ b/layouts/partials/sections/content/three_columns_base.html
@@ -15,6 +15,7 @@
     - image: URL to image (required)
     - imageAlt: Alt text for the image (optional)
     - url: URL to link the card to, making the entire card clickable (optional)
+    - target: Link target attribute for the card (optional, default: "_self")
 @example:
   {{ partial "sections/content/three_column_content.html" (dict 
       "theme" "light"
@@ -29,21 +30,24 @@
               "description" "Our platform automatically adapts to any device or screen size."
               "image" "/images/features/responsive.png"
               "imageAlt" "Responsive design illustration"
-              "url" "/features/responsive"
+              "url" "/features/responsive",
+              "target": "_self"
           )
           (dict
               "title" "Analytics" 
               "description" "Detailed insights into your user behavior and application performance."
               "image" "/images/features/analytics.png"
               "imageAlt" "Analytics dashboard"
-              "url" "/features/analytics"
+              "url" "/features/analytics",
+              "target": "_self"
           )
           (dict
               "title" "Security" 
               "description" "Enterprise-grade security with end-to-end encryption."
               "image" "/images/features/security.png"
               "imageAlt" "Security shield"
-              "url" "/features/security"
+              "url" "/features/security",
+              "target": "_blank"
           )
       )
   ) }}
@@ -95,7 +99,7 @@
         {{ range $index, $card := $cards }}
           <div class="relative flex flex-col overflow-hidden">
             {{ if $card.url }}
-              <a href="{{ $card.url }}" class="absolute inset-0 z-10 hover:opacity-90 transition-opacity">
+              <a href="{{ $card.url }}" target="{{ $card.target | default "_self" }}" class="absolute inset-0 z-10 hover:opacity-90 transition-opacity">
                 <span class="sr-only">{{ $card.title }}</span>
               </a>
             {{ end }}

--- a/layouts/shortcodes/content-three-column.html
+++ b/layouts/shortcodes/content-three-column.html
@@ -19,19 +19,22 @@
         "title": "Responsive Design",
         "description": "Our components are fully responsive and work on all devices, from mobile to desktop.",
         "image": "/images/responsive-design.webp",
-        "imageAlt": "Responsive design illustration"
+        "imageAlt": "Responsive design illustration",
+        "url": "/features/responsive"
       },
       {
         "title": "Performance",
         "description": "Optimized for speed and efficiency to ensure your website loads quickly.",
         "image": "/images/performance-metrics.webp",
-        "imageAlt": "Performance chart"
+        "imageAlt": "Performance chart",
+        "url": "/features/performance"
       },
       {
         "title": "Security",
         "description": "Built with security in mind to protect your data and your users' information.",
         "image": "/images/security-shield.webp",
-        "imageAlt": "Security shield icon"
+        "imageAlt": "Security shield icon",
+        "url": "/features/security"
       }
     ]
   {{< /content-three-column >}}
@@ -53,6 +56,7 @@
     - description: Card description
     - image: URL to the image for the card
     - imageAlt: Alt text for the image
+    - url: URL to link the card to, making the entire card clickable (optional)
 
   If inner content is not provided, default cards will be used.
 */}}

--- a/layouts/shortcodes/content-three-column.html
+++ b/layouts/shortcodes/content-three-column.html
@@ -20,21 +20,24 @@
         "description": "Our components are fully responsive and work on all devices, from mobile to desktop.",
         "image": "/images/responsive-design.webp",
         "imageAlt": "Responsive design illustration",
-        "url": "/features/responsive"
+        "url": "/features/responsive",
+        "target": "_self"
       },
       {
         "title": "Performance",
         "description": "Optimized for speed and efficiency to ensure your website loads quickly.",
         "image": "/images/performance-metrics.webp",
         "imageAlt": "Performance chart",
-        "url": "/features/performance"
+        "url": "/features/performance",
+        "target": "_self"
       },
       {
         "title": "Security",
         "description": "Built with security in mind to protect your data and your users' information.",
         "image": "/images/security-shield.webp",
         "imageAlt": "Security shield icon",
-        "url": "/features/security"
+        "url": "/features/security",
+        "target": "_blank"
       }
     ]
   {{< /content-three-column >}}
@@ -57,6 +60,7 @@
     - image: URL to the image for the card
     - imageAlt: Alt text for the image
     - url: URL to link the card to, making the entire card clickable (optional)
+    - target: Link target attribute for the card (optional, default: "_self")
 
   If inner content is not provided, default cards will be used.
 */}}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added optional "url" and "target" parameters to card data for clickable links for whole card

**Testing instructions**
- Go to any page with "content-three-column" section and add "url" parameter to check working link, should be for whole card

QualityUnit/web-issues#3806