### PR TITLE
[3801] - set number icons

### DIFF
--- a/layouts/partials/icons/tabler/number-1.html
+++ b/layouts/partials/icons/tabler/number-1.html
@@ -1,0 +1,22 @@
+{{/*
+@component: tabler/number-1 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-1" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-1" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-1" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M13 20v-16l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/layouts/partials/icons/tabler/number-1.html
+++ b/layouts/partials/icons/tabler/number-1.html
@@ -10,7 +10,7 @@
   {{ partial "icons/tabler/number-1" "w-8 h-8 text-blue-600" }}
 
   <!-- With responsive classes -->
-  {{ partial "icons/tabler/number-1" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+  {{ partial "icons/tabler/number-1" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-blue-500" }}
 */}}
 <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/layouts/partials/icons/tabler/number-10.html
+++ b/layouts/partials/icons/tabler/number-10.html
@@ -1,0 +1,23 @@
+{{/*
+@component: tabler/number-10 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-10" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-10" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-10" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M8 20v-16l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 20a4 4 0 0 0 4 -4v-8a4 4 0 1 0 -8 0v8a4 4 0 0 0 4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/layouts/partials/icons/tabler/number-2.html
+++ b/layouts/partials/icons/tabler/number-2.html
@@ -1,0 +1,22 @@
+{{/*
+@component: tabler/number-2 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-2" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-2" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-2" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M8 8a4 4 0 1 1 8 0c0 1.098 -.564 2.025 -1.159 2.815l-6.841 9.185h8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/layouts/partials/icons/tabler/number-3.html
+++ b/layouts/partials/icons/tabler/number-3.html
@@ -1,0 +1,23 @@
+{{/*
+@component: tabler/number-3 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-3" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-3" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-3" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M12 12a4 4 0 1 0 -4 -4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 16a4 4 0 1 0 4 -4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/layouts/partials/icons/tabler/number-4.html
+++ b/layouts/partials/icons/tabler/number-4.html
@@ -1,0 +1,22 @@
+{{/*
+@component: tabler/number-4 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-4" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-4" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-4" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M15 20v-15l-8 11h10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/layouts/partials/icons/tabler/number-5.html
+++ b/layouts/partials/icons/tabler/number-5.html
@@ -1,0 +1,22 @@
+{{/*
+@component: tabler/number-5 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-5" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-5" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-5" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M8 20h4a4 4 0 1 0 0 -8h-4v-8h8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/layouts/partials/icons/tabler/number-6.html
+++ b/layouts/partials/icons/tabler/number-6.html
@@ -1,0 +1,23 @@
+{{/*
+@component: tabler/number-6 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-6" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-6" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-6" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M8 16a4 4 0 1 0 8 0v-1a4 4 0 1 0 -8 0" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16 8a4 4 0 1 0 -8 0v8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/layouts/partials/icons/tabler/number-7.html
+++ b/layouts/partials/icons/tabler/number-7.html
@@ -1,0 +1,22 @@
+{{/*
+@component: tabler/number-7 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-7" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-7" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-7" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M8 4h8l-4 16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/layouts/partials/icons/tabler/number-8.html
+++ b/layouts/partials/icons/tabler/number-8.html
@@ -1,0 +1,23 @@
+{{/*
+@component: tabler/number-8 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-8" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-8" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-8" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M12 8m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 16m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/layouts/partials/icons/tabler/number-9.html
+++ b/layouts/partials/icons/tabler/number-9.html
@@ -1,0 +1,23 @@
+{{/*
+@component: tabler/number-9 (outline) Icon
+@params:
+  - class: CSS classes to apply to the SVG element (optional, default: "w-6 h-6 text-gray-500")
+@examples:
+  <!-- Basic usage with default classes -->
+  {{ partial "icons/tabler/number-9" . }}
+
+  <!-- With custom size and color classes -->
+  {{ partial "icons/tabler/number-9" "w-8 h-8 text-blue-600" }}
+
+  <!-- With responsive classes -->
+  {{ partial "icons/tabler/number-9" "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8 text-indigo-500" }}
+*/}}
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24" 
+    class="{{ if . }}{{ . }}{{ else }}w-6 h-6 text-gray-500{{ end }}"
+    fill="none"
+>
+<path d="M16 8a4 4 0 1 0 -8 0v1a4 4 0 1 0 8 0" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 16a4 4 0 1 0 8 0v-8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added  1-10 numbers icons of tambler.io

**Testing instructions**
- Go to any page with "features-three-column" component and add "icon", e.g. "tabler/number-1" and check view, analogy we can use 1-10 numbers icons

QualityUnit/web-issues#3801
