### PR TITLE
fix: adjust padding for mobile and default values across multiple sections

### DIFF
--- a/layouts/partials/sections/content/centered.html
+++ b/layouts/partials/sections/content/centered.html
@@ -37,7 +37,7 @@
 
 {{/* Configurable variables */}}
 {{ $bgColor := .bgColor | default "" }}
-{{ $padding := .padding | default "px-6 py-16 lg:px-8" }}
+{{ $padding := .padding | default "px-4 py-16 lg:px-8" }}
 
 {{/* Heading section */}}
 {{ $eyebrow := .eyebrow | default "" }}

--- a/layouts/partials/sections/courses/courses-content.html
+++ b/layouts/partials/sections/courses/courses-content.html
@@ -131,8 +131,8 @@
 {{ $gradientToColor := .gradientToColor | default "to-[#1a56db]" }}
 
 <section class="{{ $darkClass }}">
-    <div class="section-bg-light dark:section-bg-dark py-32">
-        <div class="wrapper surface-secondary p-16 lg:px-32 rounded-xl">
+    <div class="section-bg-light dark:section-bg-dark py-24 sm:py-32">
+        <div class="wrapper surface-secondary p-0 md:p-16 lg:px-32 rounded-xl">
         <!-- Icons Section - Technology Partners -->
         {{ if $icons}}
             <div class="flex flex-wrap justify-center items-center gap-12 md:gap-16 lg:gap-20 mb-5">

--- a/layouts/partials/sections/cta/simple_centered.html
+++ b/layouts/partials/sections/cta/simple_centered.html
@@ -25,8 +25,8 @@
   ) }}
 */}}
 
-{{ $heading := .heading | default "Boost your productivity. Start using our app today." }}
-{{ $description := .description | default "Incididunt sint fugiat pariatur cupidatat consectetur sit cillum anim id veniam aliqua proident excepteur commodo do ea." }}
+{{ $heading := .heading | default "" }}
+{{ $description := .description | default "" }}
 {{ $primaryCta := .primaryCta | default (dict 
   "text" "Get started"
   "url" "#"
@@ -41,7 +41,7 @@
 {{ $page := .page }}
 
 <div class="bg-white">
-  <div class="px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+  <div class="px-4 py-24 sm:px-6 sm:py-32 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
       <h2 class="text-4xl font-semibold tracking-tight text-balance text-heading sm:text-5xl">{{ $heading }}</h2>
       <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-secondary prose-links">{{ $description | safeHTML }}</p>

--- a/layouts/partials/sections/cta/simple_centered_on_brand.html
+++ b/layouts/partials/sections/cta/simple_centered_on_brand.html
@@ -28,8 +28,8 @@
 @note: This component provides a strong brand presence with its vibrant background color while maintaining a clean, focused layout for the call-to-action content.
 */}}
 
-{{ $heading := .heading | default "Boost your productivity. Start using our app today." }}
-{{ $description := .description | default "Incididunt sint fugiat pariatur cupidatat consectetur sit cillum anim id veniam aliqua proident excepteur commodo do ea." }}
+{{ $heading := .heading | default "" }}
+{{ $description := .description | default "" }}
 {{ $primaryCta := .primaryCta | default (dict 
   "text" "Get started"
   "url" "#"
@@ -44,7 +44,7 @@
 {{ $primaryCtaHoverColor := .primaryCtaHoverColor | default "indigo-50" }}
 
 <div class="bg-{{ $brandColor }}">
-  <div class="px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+  <div class="px-4 py-24 sm:px-6 sm:py-32 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
       <h2 class="text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">{{ $heading }}</h2>
       <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-{{ $brandLightColor }}">{{ $description }}</p>

--- a/layouts/partials/sections/cta/simple_centered_on_dark.html
+++ b/layouts/partials/sections/cta/simple_centered_on_dark.html
@@ -40,8 +40,8 @@
 {{ $gradientEndColor := .gradientEndColor | default "#1a56db" }}
 
 <div class="wrapper dark">
-  <div class="relative isolate overflow-hidden section-bg-light dark:section-bg-dark rounded-xl my-32">
-  <div class="px-6 py-24 sm:px-6 sm:py-32 lg:px-8">
+  <div class="relative isolate overflow-hidden section-bg-light dark:section-bg-dark rounded-xl my-24 sm:my-32">
+  <div class="px-4 py-24 sm:px-6 sm:py-32 lg:px-8">
     <div class="mx-auto max-w-2xl text-center">
       <h2 class="text-4xl font-semibold tracking-[−2.832px] text-balance text-white sm:text-5xl">{{ $heading }}</h2>
       <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-gray-300">{{ $description }}</p>

--- a/layouts/partials/sections/cta/split_with_image.html
+++ b/layouts/partials/sections/cta/split_with_image.html
@@ -44,7 +44,7 @@
 {{ $image := .image }}
 {{ $taglineColor := .taglineColor | default "primary-400" }}
 
-<div class="{{ $darkClass }} my-32">
+<div class="{{ $darkClass }} my-24 sm:my-32">
   <div class="relative section-bg-light dark:section-bg-dark">
     <div class="relative h-full overflow-hidden bg-primary not-prose md:absolute md:left-0 md:h-full md:w-1/3 lg:w-1/2">
       {{ partial "components/media/lazyimg.html" (dict 

--- a/layouts/partials/sections/features/offset_with_feature_list.html
+++ b/layouts/partials/sections/features/offset_with_feature_list.html
@@ -1,57 +1,24 @@
 {{/* Feature Section with Offset Feature List */}}
-{{ $tagline := .tagline | default "Everything you need" }}
-{{ $heading := .heading | default "All-in-one platform" }}
-{{ $description := .description | default "Lorem ipsum, dolor sit amet consectetur adipisicing elit. Maiores impedit perferendis suscipit eaque, iste dolor cupiditate blanditiis ratione." }}
-{{ $features := .features | default (slice
-  (dict 
-    "title" "Invite team members"
-    "description" "Rerum repellat labore necessitatibus reprehenderit molestiae praesentium."
-  )
-  (dict 
-    "title" "List view"
-    "description" "Corporis asperiores ea nulla temporibus asperiores non tempore assumenda aut."
-  )
-  (dict 
-    "title" "Keyboard shortcuts"
-    "description" "In sit qui aliquid deleniti et. Ad nobis sunt omnis. Quo sapiente dicta laboriosam."
-  )
-  (dict 
-    "title" "Calendars"
-    "description" "Sed rerum sunt dignissimos ullam. Iusto iure occaecati voluptate eligendi."
-  )
-  (dict 
-    "title" "Notifications"
-    "description" "Quos inventore harum enim nesciunt. Aut repellat rerum omnis adipisci."
-  )
-  (dict 
-    "title" "Boards"
-    "description" "Quae sit sunt excepturi fugit veniam voluptatem ipsum commodi."
-  )
-  (dict 
-    "title" "Reporting"
-    "description" "Eos laudantium repellat sed architecto earum unde incidunt."
-  )
-  (dict 
-    "title" "Mobile app"
-    "description" "Nulla est saepe accusamus nostrum est est fugit omnis."
-  )
-) }}
+{{ $tagline := .tagline | default "" }}
+{{ $heading := .heading | default "" }}
+{{ $description := .description | default "" }}
+{{ $features := .features | default (slice) }}
 {{ $iconColor := .iconColor | default "indigo-500" }}
 {{ $taglineColor := .taglineColor | default "indigo-600" }}
 {{ $page := .page }}
 
 <div class="bg-white py-24 sm:py-32">
-  <div class="mx-auto max-w-7xl px-6 lg:px-8">
-    <div class="mx-auto grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 sm:gap-y-20 lg:mx-0 lg:max-w-none lg:grid-cols-5">
+  <div class="wrapper lg:px-8">
+    <div class="mx-auto grid grid-cols-1 gap-x-8 gap-y-8 sm:gap-y-12 lg:mx-0 lg:max-w-none lg:grid-cols-5">
       <div class="col-span-2">
         <h2 class="text-base/7 font-semibold text-{{ $taglineColor }}">{{ $tagline }}</h2>
-        <p class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-5xl">{{ $heading }}</p>
-        <p class="mt-6 text-base/7 text-gray-600">{{ $description | safeHTML }}</p>
+        <p class="mt-2 text-4xl font-semibold tracking-tight text-pretty text-heading sm:text-5xl">{{ $heading }}</p>
+        <p class="mt-6 text-base/7 text-secondary">{{ $description | safeHTML }}</p>
       </div>
-      <dl class="col-span-3 grid grid-cols-1 gap-x-8 gap-y-10 text-base/7 text-gray-600 sm:grid-cols-2 lg:gap-y-16">
+      <dl class="col-span-3 grid grid-cols-1 gap-x-8 gap-y-10 text-base/7 text-secondary sm:grid-cols-2 lg:gap-y-16">
         {{ range $features }}
-        <div class="relative pl-9">
-          <dt class="font-semibold text-gray-900">
+        <div class="relative pl-0 lg:pl-9">
+          <dt class="font-semibold text-heading">
             <span class="inline-block align-middle mr-2 w-5 h-5 text-{{ $iconColor }}">{{ partial "components/media/icon.html" (dict "icon" (or .icon "arrow-right")) }}</span>{{ .title }}
           </dt>
           <dd class="mt-2">{{ .description | safeHTML }}</dd>

--- a/layouts/partials/sections/features/with_intro_and_tabs.html
+++ b/layouts/partials/sections/features/with_intro_and_tabs.html
@@ -147,10 +147,10 @@
 
 {{/* --- FINAL RENDER --- */}}
 <section aria-labelledby="{{ $uniqueID }}-heading" class="{{ $darkClass }}">
-  <div class="section-bg-light dark:section-bg-dark py-32">
-    <div class="mx-auto {{ if eq $widthContainer "narrow" }}wrapper-narrow{{ else }}wrapper{{ end }} surface-secondary rounded-xl sm:px-2 lg:px-8">
+  <div class="section-bg-light dark:section-bg-dark py-24 sm:py-32">
+    <div class="mx-auto {{ if eq $widthContainer "narrow" }}wrapper-narrow{{ else }}wrapper{{ end }} surface-secondary rounded-xl lg:px-8">
       <div class="max-w-none">
-        <div class="w-full pt-16 pb-8">
+        <div class="w-full py-8 md:pt-16 md:pb-8">
           {{ if $eyebrow }}
             <p class="text-base/6 font-semibold product-text">{{ $eyebrow }}</p>
           {{ end }}
@@ -161,9 +161,9 @@
         </div>
 
         <div class="w-full mx-auto">
-          <div class="flex overflow-x-auto w-full -mx-[2rem]">
+          <div class="flex overflow-x-auto w-full md:-mx-[2rem]">
             <div class="flex-auto border-b border-gray-primary w-full">
-              <div class="flex px-8 w-full" aria-orientation="horizontal" role="tablist">
+              <div class="flex md:px-8 w-full" aria-orientation="horizontal" role="tablist">
                 {{ range $index, $tab := $tabs }}
                   <button id="{{ $uniqueID }}-tab-{{ $tab.id }}" 
                     class="border-b-2 {{ if eq $tab.id $defaultActiveTabId }}border-brand product-primary{{ else }}border-transparent text-tertiary hover:border-brand hover:product-primary{{ end }} p-6 text-base font-semibold tracking-[-0.3px] whitespace-nowrap" 
@@ -181,7 +181,7 @@
 
           {{ range $index, $tab := $tabs }}
             <div id="{{ $uniqueID }}-panel-{{ $tab.id }}" 
-              class="pt-8 pb-32 {{ if ne $tab.id $defaultActiveTabId }}hidden{{ end }}" 
+              class="py-8 md:pt-8 md:pb-32 {{ if ne $tab.id $defaultActiveTabId }}hidden{{ end }}" 
               aria-labelledby="{{ $uniqueID }}-tab-{{ $tab.id }}" 
               role="tabpanel" 
               data-tabs-group="{{ $uniqueID }}"

--- a/layouts/shortcodes/latest-posts.html
+++ b/layouts/shortcodes/latest-posts.html
@@ -18,9 +18,9 @@ Usage:
 {{ $limit := .Get "limit" | default 3 }}
 {{ $type := .Get "type" | default "blog" }}
 
-<section class="{{ $darkClass }} my-32">
+<section class="{{ $darkClass }} my-24 sm:my-32">
     <div class="section-bg-light dark:section-bg-dark relative">
-        <div class="wrapper mx-auto max-w-2xl px-6 lg:max-w-7xl lg:px-8">
+        <div class="wrapper mx-auto max-w-2xl px-4 lg:max-w-7xl lg:px-8">
             <div class="mx-auto mb-[4.25rem] max-w-2xl text-center">
                 <h2 class="text-balance text-4xl font-semibold text-heading tracking-tight sm:text-5xl">{{ $heading }}</h2>
                 {{ if $description }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Adjust padding for mobile and default values across multiple sections
Removed default text values from layouts/partials/sections/features/offset_with_feature_list.html, layouts/partials/sections/cta/simple_centered_on_brand.html and layouts/partials/sections/cta/simple_centered.html

**Testing instructions**
- Go to homepage and check padding in "See What FlowHunt Can do"  and "latest posts" sections
- Go to ai-training-page and check paddings in courses-content.html component
- Go to pages where using offset_with_feature_list.html, simple_centered_on_brand.html, simple_centered.html and check correct view and functionality

QualityUnit/web-issues#3812
