### PR TITLE
Removed breadcrumb from landing pages

### DIFF
--- a/layouts/_default/landing-page.html
+++ b/layouts/_default/landing-page.html
@@ -2,6 +2,10 @@
 
 {{ $image := .Params.image }}
 
+  {{ if .Params.showBreadcrumbs }}
+    {{ partial "breadcrumbs_default.html" . }}
+  {{ end }}
+
 <!-- Main Content -->
 <div class="bg-white dark:bg-gray-900">
     {{ .Content }}

--- a/layouts/_default/landing-page.html
+++ b/layouts/_default/landing-page.html
@@ -2,10 +2,6 @@
 
 {{ $image := .Params.image }}
 
-{{ if ne .Params.showBreadcrumbs false }}
-  {{ partial "breadcrumbs_default.html" . }}
-{{ end }}
-
 <!-- Main Content -->
 <div class="bg-white dark:bg-gray-900">
     {{ .Content }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
I rewrite role for breadcrumbs from layout for landing pages. We don't need breadcrumb for top level pages. Breadcrumbs are good only for deep structure. Now if we using landing page layout then we can use parameter for show breadcrumb
