### PR TITLE
[3847] - enhance styling for preformatted text in markdown content

### DIFF
--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -186,7 +186,7 @@ Design Tokens:
 
         {{/* Main content */}}
         {{ if $markdownContent }}
-          <div class="mt-10 max-w-full text-secondary prose-links lg:max-w-full [&_p]:mb-5 [&_h1]:mb-5 [&_h2]:mb-5 [&_h3]:mb-5 [&_h4]:mb-5 [&_h5]:mb-5 [&_h6]:mb-5 [&_ul]:mb-5 [&_ol]:mb-5 [&_*:last-child]:mb-0">
+          <div class="mt-10 max-w-full text-secondary prose-links lg:max-w-full [&_p]:mb-5 [&_h1]:mb-5 [&_h2]:mb-5 [&_h3]:mb-5 [&_h4]:mb-5 [&_h5]:mb-5 [&_h6]:mb-5 [&_ul]:mb-5 [&_ol]:mb-5 [&_*:last-child]:mb-0 [&_pre]:overflow-x-hidden [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:font-sans [&_code]:whitespace-pre-wrap [&_code]:break-words [&_code]:font-sans">
             {{ if $contentAsHTML }}
                 {{ $markdownContent | safeHTML }}
             {{ else }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Enhanced styling for preformatted text in markdown content for split_with_image component

**Testing instructions**
- Go to /affiliate-program/ page and check "How does our affiliate program work?" section

QualityUnit/web-issues#3847
