### PR TITLE
[3850] - video support to hero split with image

### DIFF
--- a/assets/css/lazy-videos.css
+++ b/assets/css/lazy-videos.css
@@ -16,10 +16,13 @@
 .lazy-video-thumbnail {
   position: relative;
   width: 100%;
-  height: 0;
-  padding-bottom: 56.25%; /* 16:9 aspect ratio */
   overflow: hidden;
   cursor: pointer;
+}
+
+.lazy-video-thumbnail.aspect-ratio {
+  height: 0;
+  padding-bottom: 56.25%; /* 16:9 aspect ratio */
 }
 
 .lazy-video-wrapper {

--- a/layouts/partials/components/media/video.html
+++ b/layouts/partials/components/media/video.html
@@ -16,6 +16,8 @@
   - muted: Enable muted (optional, default: false)
   - controls: Show video controls (optional, default: true for custom, false for YouTube)
   - poster: Poster image URL for HTML5 video or custom YouTube thumbnail (optional)
+  - posterHeight: Height classes for YouTube video poster (optional, e.g. "h-96")
+  - useAspectRatio: Use 16:9 aspect ratio for YouTube videos (optional, default: true, adds 'aspect-ratio' CSS class)
   - useLightbox: Use lightbox for custom videos (optional, default: false)
   - showPlayOverlay: Show play button overlay on custom videos (optional, default: true)
   - showPlayButton: Show play button overlay on YouTube videos (optional, default: true)
@@ -67,6 +69,7 @@
 {{ $noLazy := .noLazy | default false }}
 {{ $showPlayOverlay := .showPlayOverlay | default true }}
 {{ $showPlayButton := .showPlayButton | default true }}
+{{ $useAspectRatio := .useAspectRatio | default true }}
 
 <!-- First determine the provider if not explicitly set -->
 {{ if not $provider }}
@@ -107,6 +110,7 @@
       "noLazy" $noLazy
       "poster" $poster
       "posterHeight" $posterHeight
+      "useAspectRatio" $useAspectRatio
       "playBtnClass" .playBtnClass
       "playBtnInnerClass" .playBtnInnerClass
       "svgClass" .svgClass

--- a/layouts/partials/components/media/video.html
+++ b/layouts/partials/components/media/video.html
@@ -18,6 +18,7 @@
   - poster: Poster image URL for HTML5 video or custom YouTube thumbnail (optional)
   - useLightbox: Use lightbox for custom videos (optional, default: false)
   - showPlayOverlay: Show play button overlay on custom videos (optional, default: true)
+  - showPlayButton: Show play button overlay on YouTube videos (optional, default: true)
   - playBtnClass: CSS classes for YouTube play button (optional)
   - playBtnInnerClass: CSS classes for YouTube inner play button element (optional)
   - svgClass: CSS classes for YouTube play icon SVG (optional)
@@ -65,6 +66,7 @@
 {{ $provider := .provider | default "" }}
 {{ $noLazy := .noLazy | default false }}
 {{ $showPlayOverlay := .showPlayOverlay | default true }}
+{{ $showPlayButton := .showPlayButton | default true }}
 
 <!-- First determine the provider if not explicitly set -->
 {{ if not $provider }}
@@ -108,6 +110,7 @@
       "playBtnClass" .playBtnClass
       "playBtnInnerClass" .playBtnInnerClass
       "svgClass" .svgClass
+      "showPlayButton" $showPlayButton
   ) }}
 {{ else if eq $provider "custom" }}
   <!-- Load video helper partial for resource management -->

--- a/layouts/partials/components/media/video/youtube.html
+++ b/layouts/partials/components/media/video/youtube.html
@@ -14,6 +14,7 @@
   - posterHeight: Additional CSS classes for poster height (optional, e.g. "h-64", "h-80", "h-96", "h-[450px]")
   - playBtnClass: CSS classes for play button (optional)
   - playBtnInnerClass: CSS classes for inner play button element (optional)
+  - showPlayButton: Show/hide play button overlay (optional, default: true)
 @note: This partial should be called through the main video.html partial, not directly.
 */}}
 
@@ -35,6 +36,7 @@
 {{ $playBtnClass := .playBtnClass | default "w-16 h-12 bg-red-600 rounded-lg hover:bg-red-700 hover:scale-110" }}
 {{ $playBtnInnerClass := .playBtnInnerClass | default "" }}
 {{ $svgClass := .svgClass | default "size-6 text-white ml-1" }}
+{{ $showPlayButton := .showPlayButton | default true }}
 
 <!-- Determine thumbnail URL: use custom poster if provided, otherwise use YouTube default -->
 {{ $thumbnailUrl := cond $poster $poster (print "https://img.youtube.com/vi/" $videoID "/maxresdefault.jpg") }}
@@ -80,6 +82,7 @@
       {{ if not $poster }}onload="this.onload=null; if(this.dataset.src === this.src) findBestThumbnail(this);"{{ end }}
     />
   </div>
+  {{ if $showPlayButton }}
   <div class="lazy-video-play-button absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 flex items-center justify-center transition-all duration-300 z-10 {{ $playBtnClass }}">
     {{ if $playBtnInnerClass }}
       <div class="{{ $playBtnInnerClass }}">
@@ -89,4 +92,5 @@
       {{ partial "icons/play-solid" $svgClass }}
     {{ end }}
   </div>
+  {{ end }}
 </div>

--- a/layouts/partials/components/media/video/youtube.html
+++ b/layouts/partials/components/media/video/youtube.html
@@ -12,6 +12,7 @@
   - autoplay: Enable autoplay when opened in lightbox (optional, default: false)
   - poster: Custom poster/thumbnail image URL (optional, defaults to YouTube thumbnail)
   - posterHeight: Additional CSS classes for poster height (optional, e.g. "h-64", "h-80", "h-96", "h-[450px]")
+  - useAspectRatio: Use 16:9 aspect ratio constraint (optional, default: true, adds 'aspect-ratio' class with height: 0; padding-bottom: 56.25%;)
   - playBtnClass: CSS classes for play button (optional)
   - playBtnInnerClass: CSS classes for inner play button element (optional)
   - showPlayButton: Show/hide play button overlay (optional, default: true)
@@ -32,6 +33,7 @@
 {{ $noLazy := .noLazy | default false }}
 {{ $poster := .poster }}
 {{ $posterHeight := .posterHeight | default "" }}
+{{ $useAspectRatio := .useAspectRatio | default true }}
 {{ $loading := cond $noLazy "eager" "lazy" }}
 {{ $playBtnClass := .playBtnClass | default "w-16 h-12 bg-red-600 rounded-lg hover:bg-red-700 hover:scale-110" }}
 {{ $playBtnInnerClass := .playBtnInnerClass | default "" }}
@@ -68,7 +70,7 @@
   data-video-fallback-url="https://www.youtube.com/watch?v={{ $videoID }}"
   {{ with $id }}id="{{ . }}"{{ end }}
 >
-  <div class="lazy-video-thumbnail relative w-full video-aspect-ratio overflow-hidden cursor-pointer{{ if $posterHeight }} {{ $posterHeight }}{{ end }}" data-video-trigger="true">
+  <div class="lazy-video-thumbnail{{ if $useAspectRatio }} aspect-ratio video-aspect-ratio {{ else }} min-h-[35rem] {{ end }} relative w-full overflow-hidden cursor-pointer{{ if $posterHeight }} {{ $posterHeight }}{{ end }}" data-video-trigger="true">
     <img 
       src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 9'%3E%3C/svg%3E"
       data-src="{{ $thumbnailUrl }}"

--- a/layouts/partials/sections/hero/split_with_image.html
+++ b/layouts/partials/sections/hero/split_with_image.html
@@ -1,9 +1,13 @@
 {{/*
-Responsive hero section with split layout - content left, image right.
+Responsive hero section with split layout - content left, image/video right.
 
 Parameters:
 - theme: "light" | "dark" | "alternate" (default: "light")
 - image, imageAlt: Image settings
+- video: Video object with properties (optional, takes priority over image if enabled):
+  - enabled: Boolean to enable video mode (default: false)
+  - src: YouTube URL for the video
+  - poster: Custom poster/thumbnail image for the video (falls back to imageUrl if not provided)
 - eyebrow, heading, description: Text content
 - cta: Call-to-action buttons
   - primary: Primary button (text, url)
@@ -35,12 +39,14 @@ Usage Guidelines:
 - Use text-primary for brand accents, links, and call-to-action elements
 - Use text-secondary for regular paragraph text and descriptions
 - Ensure color contrast meets accessibility standards (WCAG AA)
+- When video.enabled is true, video will be displayed with popup functionality
+- Video supports YouTube URLs and will open in lightbox popup on click
 
 Design Tokens:
 - Image dimensions are configurable via variables for easy maintenance
 - Spacing values use consistent design system tokens
 - Typography tracking and sizing follow brand guidelines
-- Image is always positioned on the right side
+- Media (image/video) is always positioned on the right side
 */}}
 
 {{ $theme := .theme | default "light" }}
@@ -51,6 +57,7 @@ Design Tokens:
 {{/* Section parameters */}}
 {{ $image := .image }}
 {{ $imageAlt := .imageAlt }}
+{{ $video := .video | default (dict "enabled" false) }}
 {{ $eyebrow := .eyebrow }}
 {{ $heading := .heading }}
 {{ $description := .description }}
@@ -99,12 +106,30 @@ Design Tokens:
   <div class="wrapper lg:flex lg:justify-between lg:items-stretch gap-x-8 lg:flex-row-reverse">
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 xl:left-0">
       <div class="max-md:hidden relative rounded-lg {{ $imageContainerPaddingY }} flex items-start justify-center w-full overflow-hidden mx-auto max-w-[38rem] max-h-[35rem]">
-        {{ partial "components/media/lazyimg.html" (dict
-          "src" $imageSrc
-          "alt" $finalImageAlt
-          "class" "object-contain rounded-lg"
-          "noLazy" true
-        ) }}
+        {{ if and $video $video.enabled }}
+          {{/* Display video with popup */}}
+          {{ partial "components/media/video.html" (dict 
+              "src" $video.src 
+              "poster" $video.poster 
+              "title" $heading
+              "class" "object-contain rounded-lg w-full h-auto"
+              "provider" "youtube"
+              "playBtnClass" ""
+              "posterHeight" "h-full"
+              "useAspectRatio" false
+              "showPlayButton" $video.showPlayButton
+              "useLightbox" true
+              "noLazy" true
+          ) }}
+        {{ else }}
+          {{/* Display regular image */}}
+          {{ partial "components/media/lazyimg.html" (dict
+            "src" $imageSrc
+            "alt" $finalImageAlt
+            "class" "object-contain rounded-lg"
+            "noLazy" true
+          ) }}
+        {{ end }}
       </div>
     </div>
     <div class="lg:flex lg:w-1/2 lg:items-center">

--- a/layouts/shortcodes/hero-split-with-image.html
+++ b/layouts/shortcodes/hero-split-with-image.html
@@ -5,6 +5,10 @@ Example usage of Split Hero with Image Shortcode:
   "description"="Discover tools and insights to drive growth and success." 
   "imageUrl"="https://example.com/hero-image.jpg" 
   "imageAlt"="An inspiring hero image" 
+  "videoUrl"="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+  "videoPoster"="https://example.com/video-poster.jpg"
+  "videoEnabled"="true"
+  "showVideoPlayButton"="false"
   "primaryCTAText"="Start Now" 
   "primaryCTAUrl"="/get-started" 
   "secondaryCTAText"="Learn More" 
@@ -29,6 +33,10 @@ Parameters:
 - description: Description text below the heading
 - imageUrl: URL of the hero image
 - imageAlt: Alt text for the hero image
+- videoUrl: YouTube URL for video popup (optional, takes priority over image if enabled)
+- videoPoster: Custom poster image for the video (optional, if not provided uses imageUrl)
+- videoEnabled: Enable video mode instead of image (true/false, default: false)
+- showVideoPlayButton: Show play button overlay on video (true/false, default: false)
 - primaryCTAText: Text for the primary call-to-action button
 - primaryCTAUrl: URL for the primary call-to-action button
 - secondaryCTAText: Text for the secondary call-to-action button
@@ -53,6 +61,13 @@ Parameters:
 {{ $description := .Get "description" | default "" }}
 {{ $imageUrl := .Get "imageUrl" | default "" }}
 {{ $imageAlt := .Get "imageAlt" | default "" }}
+
+{{/* Video parameters */}}
+{{ $videoUrl := .Get "videoUrl" | default "" }}
+{{ $videoPoster := .Get "videoPoster" | default "" }}
+{{ $videoEnabled := .Get "videoEnabled" | default "false" }}
+{{ $showVideoPlayButton := .Get "showVideoPlayButton" | default "false" }}
+
 {{ $primaryCTAText := .Get "primaryCTAText" }}
 {{ $primaryCTAUrl := .Get "primaryCTAUrl" }}
 {{ $secondaryCTAText := .Get "secondaryCTAText" }}
@@ -98,6 +113,19 @@ Parameters:
   "alt" $imageAlt
 }}
 
+{{/* Video object for popup functionality */}}
+{{ $video := dict }}
+{{ if and (eq $videoEnabled "true") $videoUrl }}
+  {{ $video = dict
+    "enabled" true
+    "src" $videoUrl
+    "poster" (or $videoPoster $imageUrl)
+    "showPlayButton" (eq $showVideoPlayButton "true")
+  }}
+{{ else }}
+  {{ $video = dict "enabled" false }}
+{{ end }}
+
 {{ $typewriter := dict
   "enabled" (eq $typewriterEnabled "true")
   "words" $typewriterWords
@@ -123,6 +151,7 @@ Parameters:
   "description" ( $description | markdownify )
   "cta" $cta
   "image" $image
+  "video" $video
   "typewriter" $typewriter
   "yPadding" $yPadding
   "contentLeftPadding" $contentLeftPadding


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added video support to hero split with image component, added aspect ratio and enabled button on video component

**Testing instructions**
- Go to homepage and check hero section (should be video popup after click)

QualityUnit/web-issues#3850
