### PR TITLE
[3644] - added link for whole card

### DIFF
--- a/layouts/partials/sections/content/split_with_image_cards.html
+++ b/layouts/partials/sections/content/split_with_image_cards.html
@@ -67,6 +67,12 @@ Example:
                     {{ $cardImageAlt := .imageAlt | default .title }}
 
                     <div class="relative overflow-hidden rounded-xl min-h-[453px] bg-cover bg-center" {{ with $cardBackgroundImage }}style="background-image: url('{{ partial "functions/get-static-url.html" (dict "path" .) }}');"{{ end }}>
+                        {{ if .cta.url }}
+                            <a href="{{ .cta.url }}" class="absolute inset-0 z-20" aria-label="{{ .title }}">
+                                <span class="sr-only">{{ .title }}</span>
+                            </a>
+                        {{ end }}
+                        
                         <div class="relative z-10 flex flex-col h-full bg-[#F9FAFB]">
                             {{ with $cardSchemaImage }}
                                 <div class="pt-12 px-12 flex-shrink-0">


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Added link for whole card

**Testing instructions**
- Go to /tour/ page and check "Become an affiliate marketing superhero" section (should be link on whole cards)

QualityUnit/web-issues#3644
