### PR TITLE
fix: replace hugo.Data with site.Data

### DIFF
--- a/layouts/index.robots.txt
+++ b/layouts/index.robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 {{ $hasMultipleLanguages := gt (len site.Home.AllTranslations) 1 }}
 {{ if $hasMultipleLanguages }}
-{{ range hugo.Sites }}
+{{ range site.Sites }}
 Sitemap: {{ .BaseURL | replaceRE "/$" "" }}{{ if .LanguagePrefix }}{{ .LanguagePrefix }}{{ end }}/sitemap.xml
 {{ end }}
 {{ else }}

--- a/layouts/partials/components/cards/icon_card.html
+++ b/layouts/partials/components/cards/icon_card.html
@@ -48,7 +48,7 @@ bg-[#b28b5d] bg-[#611f69] bg-[#95bf47] bg-[#2684fc] bg-[#00ac47] bg-[#0066da] bg
 {{ $buttonLink := .url }}
 {{ $cardClass := .cardClass | default "" }}
 {{ $iconCategory := .iconBackgroundCategory }}
-{{ $iconColors := hugo.Data.components.iconColors }}
+{{ $iconColors := site.Data.components.iconColors }}
 {{ $iconBackground := "bg-red-900" }}
 {{ if .iconBackground }}
   {{ $iconBackground = .iconBackground }}

--- a/layouts/partials/components/navigation/language-selector.html
+++ b/layouts/partials/components/navigation/language-selector.html
@@ -7,7 +7,7 @@
   {{ partial "components/navigation/language-selector.html" . }}
 @note: The component will show either:
   1. Page translations if available (Hugo's built-in .Translations)
-  2. All languages from hugo.Data.all_languages.languages if configured
+  2. All languages from site.Data.all_languages.languages if configured
   3. Nothing if neither is available or the site is monolingual
 */}}
 
@@ -18,13 +18,13 @@
 {{ end }}
 
 {{ $hasMultipleLanguages := gt (len site.Home.AllTranslations) 1 }}
-{{ $useAllLanguagesData := isset hugo.Data "all_languages" }}
+{{ $useAllLanguagesData := isset site.Data "all_languages" }}
 
 <div class="language-selector">
   <div class="flex flex-wrap items-center lg:justify-center gap-3">
     {{ if $useAllLanguagesData }}
       <!-- Use unified language data when available -->
-      {{ with hugo.Data }}
+      {{ with site.Data }}
         {{ range $code, $langData := .all_languages.languages }}
           <!-- Get country code for flag -->
           {{ $countryCode := partial "helpers/get-country-code.html" (dict "code" $code) }}

--- a/layouts/partials/helpers/generate-hreflang-links.html
+++ b/layouts/partials/helpers/generate-hreflang-links.html
@@ -50,9 +50,9 @@
 <!-- Check if current page has a meaningful path (not just root) -->
 {{ $currentPageHasPath := and (ne $pagePath "") (ne $pagePath "/") }}
 
-{{ if isset hugo.Data "all_languages" }}
+{{ if isset site.Data "all_languages" }}
   <!-- Use unified language data when available -->
-  {{ with hugo.Data }}
+  {{ with site.Data }}
     {{ range $code, $langData := .all_languages.languages }}
       <!-- Use get-language-url helper to get the correct URL for this language -->
       {{ $href := partial "helpers/get-language-url.html" (dict 
@@ -131,9 +131,9 @@
 {{ $xDefaultURL := $currentPage.Permalink }}
 {{ $found := false }}
 
-{{ if isset hugo.Data "all_languages" }}
+{{ if isset site.Data "all_languages" }}
   <!-- Use all_languages data to find default language -->
-  {{ with hugo.Data }}
+  {{ with site.Data }}
     {{ $defaultLangData := index .all_languages.languages $defaultLang }}
     {{ if $defaultLangData }}
       {{ $xDefaultURL = partial "helpers/get-language-url.html" (dict 

--- a/layouts/partials/helpers/get-language-url.html
+++ b/layouts/partials/helpers/get-language-url.html
@@ -47,7 +47,7 @@
     
     {{/* Load translation URLs directly without partialCached to avoid issues */}}
     {{ $folderKey := replace $folder "-" "_" }}
-    {{ $translationUrls := hugo.Data.translation_urls }}
+    {{ $translationUrls := site.Data.translation_urls }}
     {{ if $translationUrls }}
       {{ $folderData := index $translationUrls $folderKey }}
       {{ if $folderData }}

--- a/layouts/partials/helpers/load-translation-urls.html
+++ b/layouts/partials/helpers/load-translation-urls.html
@@ -13,7 +13,7 @@
 {{ $folderKey := replace $folder "-" "_" }}
 
 {{/* Access the translation_urls data */}}
-{{ $translationUrls := hugo.Data.translation_urls }}
+{{ $translationUrls := site.Data.translation_urls }}
 {{ $folderData := dict }}
 {{ if $translationUrls }}
   {{ $folderData = index $translationUrls $folderKey }}

--- a/layouts/partials/helpers/show-promo-banner.html
+++ b/layouts/partials/helpers/show-promo-banner.html
@@ -4,7 +4,7 @@
 */}}
 
 {{- $currentPath := .RelPermalink -}}
-{{- $excludedPages := hugo.Data.promo_banner_pages.excluded_pages -}}
+{{- $excludedPages := site.Data.promo_banner_pages.excluded_pages -}}
 {{- $showBanner := true -}}
 
 {{/* Clean the path - remove query parameters and fragments */}}

--- a/layouts/partials/related_content.html
+++ b/layouts/partials/related_content.html
@@ -16,7 +16,7 @@
   {{ $lang := $currentPage.Language.Lang }}
 
   {{/* New structure: data/related_content/{lang}/{section}.json */}}
-  {{ $langData := index hugo.Data.related_content $lang }}
+  {{ $langData := index site.Data.related_content $lang }}
   {{ $sectionData := index $langData $section | default dict }}
   {{ $pageRelatedContent := index $sectionData $slug | default slice }}
 

--- a/layouts/partials/schemaorg/article.html
+++ b/layouts/partials/schemaorg/article.html
@@ -30,7 +30,7 @@
 {{ $authorImage := "" }}
 {{ if $page.Params.author }}
   {{ $authorKey := $page.Params.author }}
-  {{ $authors := hugo.Data.authors }}
+  {{ $authors := site.Data.authors }}
   {{ if and $authors (index $authors $authorKey) }}
     {{ $author := index $authors $authorKey }}
     {{ $authorName = $author.name }}

--- a/layouts/partials/schemaorg/author.html
+++ b/layouts/partials/schemaorg/author.html
@@ -12,7 +12,7 @@
 
 {{ $authorKey := .Params.author }}
 {{ if $authorKey }}
-    {{ $authors := hugo.Data.authors }}
+    {{ $authors := site.Data.authors }}
     {{ if and $authors (index $authors $authorKey) }}
         {{ $author := index $authors $authorKey }}
         {{ $authorName := $author.name }}

--- a/layouts/partials/schemaorg/webpage.html
+++ b/layouts/partials/schemaorg/webpage.html
@@ -58,7 +58,7 @@
 {{- end -}}
 {{- with $page.Params.author -}}
   {{- $authorKey := . -}}
-  {{- $authors := hugo.Data.authors -}}
+  {{- $authors := site.Data.authors -}}
   {{- if and $authors (index $authors $authorKey) -}}
     {{- $author := index $authors $authorKey -}}
     {{- $schema = merge $schema (dict "author" (dict "@type" "Person" "name" $author.name)) -}}

--- a/layouts/partials/sections/pricing/section.html
+++ b/layouts/partials/sections/pricing/section.html
@@ -37,7 +37,7 @@
   - .featuresNote: (optional) Additional note text for features
   
   Usage example:
-  {{ partial "sections/pricing/section.html" (dict "tiers" hugo.Data.pricing.tiers "startColumn" 2 "columnsInt" 3) }}
+  {{ partial "sections/pricing/section.html" (dict "tiers" site.Data.pricing.tiers "startColumn" 2 "columnsInt" 3) }}
    
 @note: The center tier can be highlighted as the popular option and will be visually elevated. Colors for all elements are fully customizable through parameters.
 */}}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -2,7 +2,7 @@ User-agent: *
 Allow: /
 {{ $hasMultipleLanguages := gt (len site.Home.AllTranslations) 1 }}
 {{ if $hasMultipleLanguages }}
-{{ range hugo.Sites }}
+{{ range site.Sites }}
 Sitemap: {{ .BaseURL | replaceRE "/$" "" }}{{ if .LanguagePrefix }}{{ .LanguagePrefix }}{{ end }}/sitemap.xml
 {{ end }}
 {{ else }}

--- a/layouts/shortcodes/dynamic-bento-grid.html
+++ b/layouts/shortcodes/dynamic-bento-grid.html
@@ -37,7 +37,7 @@
 {{ $taglineColor := .Get "taglineColor" | default "indigo-400" }}
 
 {{/* Get cards from data file */}}
-{{ $cardsData := index hugo.Data "bento_grid_cards" }}
+{{ $cardsData := index site.Data "bento_grid_cards" }}
 {{ $cards := $cardsData.cards }}
 
 {{ partial "sections/bentogrids/dynamic_bento_grid_on_dark.html" (dict 

--- a/layouts/shortcodes/logos-with-heading.html
+++ b/layouts/shortcodes/logos-with-heading.html
@@ -50,7 +50,7 @@
   {{ if hasPrefix $logosReference "data." }}
     {{ $dataPath := strings.TrimPrefix "data." $logosReference }}
     {{ $dataPathParts := split $dataPath "." }}
-    {{ $dataValue := index hugo.Data (index $dataPathParts 0) }}
+    {{ $dataValue := index site.Data (index $dataPathParts 0) }}
     
     {{ range $i, $part := after 1 $dataPathParts }}
       {{ $dataValue = index $dataValue $part }}

--- a/layouts/shortcodes/pricing-base-centralized.html
+++ b/layouts/shortcodes/pricing-base-centralized.html
@@ -19,7 +19,7 @@
 {{ $tiers := slice }}
 {{ if $useDataFile }}
   {{/* Use centralized data file */}}
-  {{ $pricingData := index hugo.Data $dataFile }}
+  {{ $pricingData := index site.Data $dataFile }}
   {{ if $pricingData }}
     {{ $tiers = $pricingData.tiers }}
   {{ else }}

--- a/layouts/shortcodes/pricing-base.html
+++ b/layouts/shortcodes/pricing-base.html
@@ -17,7 +17,7 @@
 
 {{/* Try to use centralized data first, fallback to page params */}}
 {{ $tiers := slice }}
-{{ $pricingData := hugo.Data.pricing }}
+{{ $pricingData := site.Data.pricing }}
 {{ if and $pricingData $pricingData.tiers }}
   {{/* Use centralized data */}}
   {{ $tiers = $pricingData.tiers }}

--- a/layouts/shortcodes/pricing-section.html
+++ b/layouts/shortcodes/pricing-section.html
@@ -18,7 +18,7 @@
 
 {{/* Try to use centralized data first, fallback to page params */}}
 {{ $tiers := slice }}
-{{ $pricingData := hugo.Data.pricing }}
+{{ $pricingData := site.Data.pricing }}
 {{ if and $pricingData $pricingData.tiers }}
   {{/* Use centralized data */}}
   {{ $tiers = $pricingData.tiers }}

--- a/layouts/shortcodes/pricing-with-comparison-table-centralized.html
+++ b/layouts/shortcodes/pricing-with-comparison-table-centralized.html
@@ -21,7 +21,7 @@
 
 {{ if $useDataFile }}
   {{/* Use centralized data file */}}
-  {{ $pricingData := index hugo.Data $dataFile }}
+  {{ $pricingData := index site.Data $dataFile }}
   {{ if $pricingData }}
     {{ $tiersComparison = $pricingData.tiersComparison }}
     {{ $featureCategories = $pricingData.featureCategories }}

--- a/layouts/shortcodes/pricing-with-comparison-table.html
+++ b/layouts/shortcodes/pricing-with-comparison-table.html
@@ -17,7 +17,7 @@
 {{ $tiersComparison := .Get "tiersComparison" | default $params.tiersComparison }}
 {{ $featureCategories := .Get "featureCategories" | default $params.featureCategories }}
 
-{{ $pricingData := hugo.Data.pricing }}
+{{ $pricingData := site.Data.pricing }}
 {{ if and $pricingData $pricingData.tiersComparison $pricingData.featureCategories }}
   {{/* Use centralized data as fallback */}}
   {{ $tiersComparison = $tiersComparison | default $pricingData.tiersComparison }}


### PR DESCRIPTION
## Summary
- `hugo.Data` returns `interface{}` causing build failure: *can't evaluate field Data in type interface {}*
- `site.Data` is the correct Hugo API for accessing files from the `data/` directory
- Affects 18 layout/shortcode files introduced in commit `1972179`

## Test plan
- [ ] `hugo --gc --minify --configDir ./config_en` builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)