### PR TITLE
fix: remove LanguagePrefix from sitemap URL in robots.txt

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -3,7 +3,7 @@ Allow: /
 {{ $hasMultipleLanguages := gt (len site.Home.AllTranslations) 1 }}
 {{ if $hasMultipleLanguages }}
 {{ range hugo.Sites }}
-Sitemap: {{ .BaseURL | replaceRE "/$" "" }}{{ if .LanguagePrefix }}{{ .LanguagePrefix }}{{ end }}/sitemap.xml
+Sitemap: {{ .BaseURL }}sitemap.xml
 {{ end }}
 {{ else }}
 Sitemap: {{ .Site.BaseURL }}sitemap.xml


### PR DESCRIPTION
## Summary
- robots.txt appended `.LanguagePrefix` (e.g. `/jp/`, `/sk/`, `/de/`) to sitemap URLs
- Each language has its own domain/baseURL, so sitemaps live at domain root (`/sitemap.xml`)
- All 28 non-English sitemap URLs in robots.txt returned **404**
- Fix: use `.BaseURL` directly (already includes trailing `/`)

## Affected
All 28 non-English domains (e.g. liveagent.jp, liveagent.sk, liveagent.de, ...)

**Before:** `Sitemap: https://www.liveagent.jp/jp/sitemap.xml` → 404
**After:** `Sitemap: https://www.liveagent.jp/sitemap.xml` → 200

## Test plan
- [ ] `hugo --gc --minify --configDir ./config_en` passes
- [ ] Full multi-language build generates correct sitemap URLs in robots.txt

Closes QualityUnit/web-issues#4130

🤖 Generated with [Claude Code](https://claude.com/claude-code)