### PR TITLE
fix: remove LanguagePrefix from sitemap URL in index.robots.txt

### DIFF
--- a/layouts/index.robots.txt
+++ b/layouts/index.robots.txt
@@ -2,8 +2,13 @@ User-agent: *
 Allow: /
 {{ $hasMultipleLanguages := gt (len site.Home.AllTranslations) 1 }}
 {{ if $hasMultipleLanguages }}
+{{ $defaultBase := (index hugo.Sites 0).BaseURL | replaceRE "/$" "" -}}
 {{ range hugo.Sites }}
-Sitemap: {{ .BaseURL | replaceRE "/$" "" }}{{ if .LanguagePrefix }}{{ .LanguagePrefix }}{{ end }}/sitemap.xml
+{{ if strings.Contains .BaseURL "://" -}}
+Sitemap: {{ .BaseURL }}sitemap.xml
+{{ else -}}
+Sitemap: {{ $defaultBase }}{{ .LanguagePrefix }}/sitemap.xml
+{{ end -}}
 {{ end }}
 {{ else }}
 Sitemap: {{ .Site.BaseURL }}sitemap.xml


### PR DESCRIPTION
## Summary
- Previous fix (#338) edited `layouts/robots.txt`, but Hugo uses `layouts/index.robots.txt` (higher priority template lookup)
- `.LanguagePrefix` was being appended to sitemap URLs, producing 404s for all 28 non-English domains
- `.BaseURL` already returns the correct domain per language — no prefix needed

**Before:** `Sitemap: https://www.liveagent.sk/sk/sitemap.xml` → 404
**After:** `Sitemap: https://www.liveagent.sk/sitemap.xml` → 200

## Verified locally
```
DEBUG-BASE: https://www.liveagent.sk/
DEBUG-PREFIX: /sk
```
`.BaseURL` does NOT include the language prefix, so `{{ .BaseURL }}sitemap.xml` produces the correct URL.

Closes QualityUnit/web-issues#4130

🤖 Generated with [Claude Code](https://claude.com/claude-code)