### PR TITLE
fix: restore LanguagePrefix in robots.txt sitemap URLs

### DIFF
--- a/layouts/index.robots.txt
+++ b/layouts/index.robots.txt
@@ -2,13 +2,8 @@ User-agent: *
 Allow: /
 {{ $hasMultipleLanguages := gt (len site.Home.AllTranslations) 1 }}
 {{ if $hasMultipleLanguages }}
-{{ $defaultBase := (index hugo.Sites 0).BaseURL | replaceRE "/$" "" -}}
 {{ range hugo.Sites }}
-{{ if strings.Contains .BaseURL "://" -}}
-Sitemap: {{ .BaseURL }}sitemap.xml
-{{ else -}}
-Sitemap: {{ $defaultBase }}{{ .LanguagePrefix }}/sitemap.xml
-{{ end -}}
+Sitemap: {{ .BaseURL | replaceRE "/$" "" }}{{ if .LanguagePrefix }}{{ .LanguagePrefix }}{{ end }}/sitemap.xml
 {{ end }}
 {{ else }}
 Sitemap: {{ .Site.BaseURL }}sitemap.xml


### PR DESCRIPTION
## Summary
- Reverts the broken logic from #339 (ae21eeb) that used `strings.Contains .BaseURL "://"` — a condition that is always true, causing all subfolder-based language sites to output identical sitemap URLs
- Restores the original `.LanguagePrefix` approach which correctly generates `/de/sitemap.xml`, `/fr/sitemap.xml` etc.
- Projects with custom domains per language (LA, PAP) should override with a project-level `layouts/index.robots.txt`

## Test plan
- [x] Build a subfolder-based multilingual site (e.g. FlowHunt) and verify `robots.txt` contains unique sitemap URLs per language
- [x] Verify single-language sites still output one sitemap entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)