### PR TITLE
feat: make mini banner logo configurable via site params

### DIFF
--- a/layouts/partials/sections/banners/mini-banner-cta.html
+++ b/layouts/partials/sections/banners/mini-banner-cta.html
@@ -38,15 +38,9 @@
   <div class="bg-gray-100 min-h-[72px] flex flex-col lg:flex-row lg:items-center gap-4 p-3 md:p-4 lg:py-3">
     <div class="flex items-center gap-3 lg:mr-auto">
       <div class="bg-gray-100 p-2 flex-shrink-0 rounded-l-lg">
-        {{ if fileExists "cdn-assets/logo-icon.png" }}
-          {{ partial "components/media/lazyimg_internal.html" (dict
-            "src" "/images/logo-icon.png"
-            "alt" "Logo"
-            "width" 36
-            "class" "w-8 md:w-9 object-contain !my-0 !block"
-            "classPicture" "!my-0 !block"
-            "noLazy" false
-          ) }}
+        {{ $logo := site.Params.logo_icon }}
+        {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
+          <img src="/images/{{ $logo }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
         {{ else }}
           {{ partial "icons/rocket-launch-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}

--- a/layouts/partials/sections/banners/mini-banner-newsletter.html
+++ b/layouts/partials/sections/banners/mini-banner-newsletter.html
@@ -36,15 +36,9 @@
   <div class="bg-gray-100 min-h-[72px] flex flex-col lg:flex-row lg:items-center gap-4 p-3 md:p-4 lg:py-3">
     <div class="flex items-center gap-3 lg:mr-auto">
       <div class="bg-gray-100 p-2 flex-shrink-0 rounded-l-lg">
-        {{ if fileExists "cdn-assets/logo-icon.png" }}
-          {{ partial "components/media/lazyimg_internal.html" (dict
-            "src" "/images/logo-icon.png"
-            "alt" "Logo"
-            "width" 36
-            "class" "w-8 md:w-9 object-contain !my-0 !block"
-            "classPicture" "!my-0 !block"
-            "noLazy" false
-          ) }}
+        {{ $logo := site.Params.logo_icon }}
+        {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
+          <img src="/images/{{ $logo }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
         {{ else }}
           {{ partial "icons/envelope-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}


### PR DESCRIPTION
## Summary
- Replace hardcoded `logo-icon.png` with configurable `site.Params.logo_icon` in both mini banner partials (CTA + newsletter)
- Supports SVG and PNG — each project sets the filename in `params.toml`
- Falls back to default icon (rocket/envelope) if param not set or file missing

### Usage
Add to project's `params.toml`:
```toml
logo_icon = "logo-short-primary.svg"
```

The file must exist in `cdn-assets/` and be served at `/images/`.

## Test plan
- [ ] Verify logo renders when `logo_icon` param is set and file exists
- [ ] Verify fallback icon renders when param is not set
- [ ] Verify fallback icon renders when param is set but file doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)