### PR TITLE
fix: use CDN URL for mini banner logo images

### DIFF
--- a/layouts/partials/sections/banners/mini-banner-cta.html
+++ b/layouts/partials/sections/banners/mini-banner-cta.html
@@ -40,7 +40,8 @@
       <div class="bg-gray-100 p-2 flex-shrink-0 rounded-l-lg">
         {{ $logo := site.Params.logo_icon }}
         {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
-          <img src="/images/{{ $logo }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
+          {{ $logoUrl := partial "functions/get-static-url.html" (dict "path" (printf "/images/%s" $logo)) }}
+          <img src="{{ $logoUrl }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
         {{ else }}
           {{ partial "icons/rocket-launch-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}

--- a/layouts/partials/sections/banners/mini-banner-newsletter.html
+++ b/layouts/partials/sections/banners/mini-banner-newsletter.html
@@ -38,7 +38,8 @@
       <div class="bg-gray-100 p-2 flex-shrink-0 rounded-l-lg">
         {{ $logo := site.Params.logo_icon }}
         {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
-          <img src="/images/{{ $logo }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
+          {{ $logoUrl := partial "functions/get-static-url.html" (dict "path" (printf "/images/%s" $logo)) }}
+          <img src="{{ $logoUrl }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
         {{ else }}
           {{ partial "icons/envelope-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}


### PR DESCRIPTION
## Summary
- Mini banner logo images used hardcoded `/images/` path instead of `get-static-url` partial
- This caused logos to not load in production because the URL wasn't rewritten to `images.liveagent.com`
- Fixed both `mini-banner-cta.html` and `mini-banner-newsletter.html`

## Test plan
- [ ] Hugo build passes
- [ ] Verify mini banner logos load on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)