### PR TITLE
fix: handle leading whitespace in frontmatter regex

### DIFF
--- a/scripts/sync_content_attributes.py
+++ b/scripts/sync_content_attributes.py
@@ -55,7 +55,7 @@ def extract_front_matter(file_path):
         content = f.read()
     
     # Look for front matter between +++ delimiters
-    match = re.match(r'^\+\+\+\s*\n*(.*?)\n*\+\+\+\s*\n*', content, re.DOTALL)
+    match = re.match(r'^\s*\+\+\+\s*\n*(.*?)\n*\+\+\+\s*\n*', content, re.DOTALL)
     if match:
         front_matter_text = match.group(1)
         try:


### PR DESCRIPTION
## Summary
- `sync_content_attributes.py` regex `^\+\+\+` required `+++` at byte 0 of the file
- Files with a leading blank line before `+++` were parsed as having no frontmatter
- This caused the script to prepend a duplicate `+++` block (with only `date`), breaking 7 EN knowledge-base overview articles
- Fix: `^\s*\+\+\+` to tolerate leading whitespace

Relates to QualityUnit/web-issues#4141

## Test plan
- [ ] Run `sync_content_attributes.py` on a file with leading whitespace before `+++` — should parse correctly
- [ ] Run on a normal file (no leading whitespace) — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)