### PR TITLE
feat: add custom-cards-slider shortcode

### DIFF
--- a/assets/css/components/custom-cards-slider.css
+++ b/assets/css/components/custom-cards-slider.css
@@ -1,0 +1,90 @@
+/**
+ * Custom Cards Slider
+ * Loaded as a standalone bundle from layouts/partials/sliders/custom-cards-slider.html
+ * (built by `gulp components`).
+ *
+ * Contains:
+ *   - Outline circular nav arrows (replaces Splide's default filled triangle)
+ *   - Right-layout positioning: heading on the left, slider extending to the right edge,
+ *     arrows pinned in the bottom-right corner of the section
+ */
+
+/* Arrow appearance — applies to both centered and right layouts */
+.content-slider--custom-cards .splide__arrow {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: transparent;
+  border: 1px solid rgb(229, 229, 234);
+  opacity: 1;
+  transition: border-color 0.2s, background-color 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.content-slider--custom-cards .splide__arrow svg {
+  display: none;
+}
+
+.content-slider--custom-cards .splide__arrow::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-top: 1.5px solid rgb(107, 107, 115);
+  border-right: 1.5px solid rgb(107, 107, 115);
+  display: block;
+}
+
+.content-slider--custom-cards .splide__arrow--prev::before {
+  transform: rotate(-135deg) translate(-1px, 1px);
+}
+
+.content-slider--custom-cards .splide__arrow--next::before {
+  transform: rotate(45deg) translate(-1px, 1px);
+}
+
+.content-slider--custom-cards .splide__arrow:hover:not(:disabled) {
+  border-color: rgb(180, 180, 187);
+  background: rgb(245, 245, 247);
+}
+
+.content-slider--custom-cards .splide__arrow:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Right-layout positioning — heading on left, slider extends right, arrows bottom-right */
+.custom-cards-slider--right.content-slider-splide .splide__track .splide__list {
+  padding: 0 !important;
+}
+
+.custom-cards-slider--right {
+  position: relative;
+  padding-bottom: 4.5rem;
+}
+
+.custom-cards-slider--right .splide__arrows {
+  position: absolute;
+  bottom: 0;
+  right: max(1rem, calc((100vw - 80rem) / 2 + 2rem));
+  display: flex;
+  gap: 0.75rem;
+}
+
+.custom-cards-slider--right .splide__arrow {
+  position: static;
+  transform: none;
+}
+
+@media (max-width: 1024px) {
+  .custom-cards-slider--right .splide__arrows {
+    right: 1.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .custom-cards-slider--right .splide__arrows {
+    right: 1rem;
+  }
+}

--- a/layouts/partials/sliders/custom-cards-slider.html
+++ b/layouts/partials/sliders/custom-cards-slider.html
@@ -1,0 +1,58 @@
+{{/* Renders the custom-cards-slider section. See layouts/shortcodes/custom-cards-slider.html for parameter docs. */}}
+
+{{ $cards := .cards | default slice }}
+{{ $layout := .layout | default "centered" }}
+{{ $heading := .heading | default "" }}
+{{ $description := .description | default "" }}
+{{ $buttonText := .buttonText | default "" }}
+{{ $buttonUrl := .buttonUrl | default "" }}
+{{ $sectionClass := .sectionClass | default "py-6 my-6" }}
+{{ $defaultLinkText := i18n "learnMore" | default "Learn more" }}
+
+{{ if eq (len $cards) 0 }}
+  {{ return }}
+{{ end }}
+
+{{ $isRight := eq $layout "right" }}
+{{ $sliderModifier := cond $isRight "custom-cards-slider--right" "" }}
+{{ $sliderId := printf "custom-cards-%d" now.UnixNano }}
+
+<section class="content-slider content-slider--custom-cards {{ $sectionClass }}">
+  {{ if or $heading $description }}
+  <div class="wrapper mb-10{{ if not $isRight }} text-center{{ end }}">
+    {{ with $heading }}
+      <h2 class="text-3xl font-semibold tracking-tight text-balance text-heading sm:text-4xl">{{ . }}</h2>
+    {{ end }}
+    {{ with $description }}
+      <p class="mt-4 {{ if not $isRight }}mx-auto {{ end }}max-w-2xl text-lg/7 text-secondary prose-links">{{ . | safeHTML }}</p>
+    {{ end }}
+    {{ if and $isRight $buttonText $buttonUrl }}
+      <div class="mt-6">
+        {{ partial "components/buttons/buttons.html" (dict
+          "text" $buttonText
+          "variant" "primary"
+          "element" "link"
+          "url" $buttonUrl
+        ) }}
+      </div>
+    {{ end }}
+  </div>
+  {{ end }}
+  <div class="overflow-hidden">
+    <div class="splide content-slider-splide {{ $sliderModifier }}" data-slider-id="{{ $sliderId }}" data-splide='{"type":"slide","perPage":3,"perMove":1,"gap":"24px","fixedWidth":"354px","focus":0,"arrows":true,"pagination":{{ if $isRight }}false{{ else }}true{{ end }},"trimSpace":{{ if $isRight }}"move"{{ else }}true{{ end }},"padding":{"left":"calc(max(1rem, (100vw - 80rem) / 2 + 2rem))","right":"calc(max(1rem, (100vw - 80rem) / 2 + 2rem))"},"breakpoints":{"1024":{"padding":{"left":"1.5rem","right":"1.5rem"}},"480":{"fixedWidth":"280px","perMove":1,"padding":{"left":"1rem","right":"1rem"}}}}'>
+      <div class="splide__track">
+        <ul class="splide__list">
+          {{- range $cards -}}
+            {{ partial "sliders/custom-cards-slider/card.html" (dict "card" . "defaultLinkText" $defaultLinkText) }}
+          {{- end -}}
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+{{/* Slider assets — bundled by gulp components, browser-deduplicated when the partial is used twice */}}
+<link rel="stylesheet" href="{{ "/css/splide.css" | relURL }}">
+<link rel="stylesheet" href="{{ "/css/splide-custom.css" | relURL }}">
+<link rel="stylesheet" href="{{ "/css/custom-cards-slider.css" | relURL }}">
+<script src="{{ "/js/splide.js" | relURL }}" defer></script>

--- a/layouts/partials/sliders/custom-cards-slider/card.html
+++ b/layouts/partials/sliders/custom-cards-slider/card.html
@@ -1,0 +1,57 @@
+{{/*
+Single card for custom-cards-slider partial.
+
+PARAMETERS:
+- card: Dict with image, imageAlt, title, description, linkText, linkUrl
+- defaultLinkText: Fallback link text when card.linkText is empty
+*/}}
+
+{{ $card := .card }}
+{{ $defaultLinkText := .defaultLinkText | default "Learn more" }}
+{{ $image := index $card "image" }}
+{{ $imageAlt := index $card "imageAlt" | default (index $card "title") }}
+{{ $title := index $card "title" }}
+{{ $description := index $card "description" }}
+{{ $linkText := index $card "linkText" | default $defaultLinkText }}
+{{ $linkUrl := index $card "linkUrl" }}
+{{ $resolvedUrl := "" }}
+{{ if $linkUrl }}
+  {{ $resolvedUrl = partial "helpers/get-translated-url.html" (dict "url" $linkUrl) }}
+{{ end }}
+
+<li class="splide__slide">
+  <article class="flex flex-col h-full">
+    {{ if $resolvedUrl }}
+    <a href="{{ $resolvedUrl }}" class="block group" tabindex="-1" aria-hidden="true">
+    {{ end }}
+      {{ with $image }}
+      <div class="relative w-full aspect-[354/500] rounded-xl overflow-hidden bg-gray-100">
+        {{ partial "components/media/lazyimg.html" (dict "src" . "alt" $imageAlt "class" "absolute inset-0 w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" "figureClass" "absolute inset-0" "width" "354" "height" "500" "nativeLazy" true) }}
+      </div>
+      {{ end }}
+    {{ if $resolvedUrl }}
+    </a>
+    {{ end }}
+    <div class="mt-4 flex flex-col">
+      {{ if or $title $description }}
+        <div class="text-sm prose-links">
+          {{- with $title -}}<h3 class="inline text-sm font-semibold text-heading">{{ . }}</h3>{{- if $description }} {{ end -}}{{- end -}}
+          {{- with $description -}}<span class="text-secondary">{{ . | safeHTML }}</span>{{- end -}}
+        </div>
+      {{ end }}
+      {{ if $linkUrl }}
+        <div class="mt-3">
+          {{ partial "components/buttons/buttons.html" (dict
+            "text" $linkText
+            "url" $linkUrl
+            "variant" "text"
+            "size" "empty"
+            "showArrow" true
+            "classes" "font-normal inline-flex items-center"
+            "ariaLabel" (printf "%s: %s" $linkText $title)
+          ) }}
+        </div>
+      {{ end }}
+    </div>
+  </article>
+</li>

--- a/layouts/shortcodes/custom-cards-slider.html
+++ b/layouts/shortcodes/custom-cards-slider.html
@@ -1,0 +1,61 @@
+{{/*
+@shortcode: custom-cards-slider
+@description: Carousel of custom cards with image on top and title/description/"Learn more" link below the card. Card data is passed as a JSON array in the shortcode body — not pulled from page collections.
+
+USAGE:
+  {{< custom-cards-slider
+      layout="right"
+      heading="The story behind LiveAgent"
+      description="Find out more about the team..."
+      buttonText="Learn about us"
+      buttonUrl="/about/"
+  >}}
+  [
+    {
+      "image": "/img/about/hero.jpg",
+      "imageAlt": "Team photo",
+      "title": "How LiveAgent starts",
+      "description": "Born in 2004, LiveAgent has an inspiring story...",
+      "linkText": "Learn about us",
+      "linkUrl": "/about/"
+    },
+    { "...": "..." }
+  ]
+  {{< /custom-cards-slider >}}
+
+PARAMETERS:
+  - layout: "centered" (default) or "right" (heading+CTA on the left, slider on the right)
+  - heading: Section heading (optional)
+  - description: Section description (optional)
+  - buttonText: CTA button text (optional, used with layout="right")
+  - buttonUrl: CTA button URL (optional, used with layout="right")
+  - sectionClass: Wrapper class overrides (default: "py-6 my-6")
+
+CARD JSON FIELDS:
+  - image (required): Image src
+  - imageAlt (optional): Alt text — falls back to title
+  - title (required): Card title
+  - description (optional): Card description
+  - linkText (optional): Link text — falls back to i18n "learnMore" / "Learn more"
+  - linkUrl (required): Link URL
+*/}}
+
+{{ $cards := slice }}
+{{ with .Inner }}
+  {{ if . }}
+    {{ $cards = . | unmarshal }}
+  {{ end }}
+{{ end }}
+
+{{ if $cards }}
+  {{ partial "sliders/custom-cards-slider.html" (dict
+      "cards" $cards
+      "Page" .Page
+      "layout" (.Get "layout")
+      "heading" (.Get "heading")
+      "description" (.Get "description")
+      "buttonText" (.Get "buttonText")
+      "buttonUrl" (.Get "buttonUrl")
+      "sectionClass" (.Get "sectionClass")
+  ) }}
+{{ end }}


### PR DESCRIPTION
## Summary

Adds a new reusable slider component for custom cards driven by an inline JSON array. The slider is fully generic — no page-collection coupling, no business-logic — so it can be dropped into any QualityUnit site that uses this boilerplate.

**Each card** has an image (with explicit `width`/`height` for CLS), a title (`<h3>`), description, and a "Learn more →" link. The image card is `aspect-[354/500]` (portrait) and links wrap the image (`tabindex=-1 aria-hidden=true` so screen readers don't double-announce the card).

**Two layouts** via the `layout=` shortcode arg:
- `centered` (default): heading + description above, slider below with pagination dots
- `right`: heading + description + optional CTA pinned on the left, slider extends to the right edge of the viewport, navigation arrows in the bottom-right corner

## Files

```
layouts/shortcodes/custom-cards-slider.html
layouts/partials/sliders/custom-cards-slider.html
layouts/partials/sliders/custom-cards-slider/card.html
assets/css/components/custom-cards-slider.css
```

The CSS lives in `assets/css/components/` so it's bundled by `gulp components` into a standalone `static/css/custom-cards-slider.css` (loaded via `<link>` only on pages that use the shortcode).

## Usage

```hugo
{{< custom-cards-slider
    layout="right"
    heading="The story behind LiveAgent"
    description="Find out more about the team behind LiveAgent..."
    buttonText="Learn about us"
    buttonUrl="/about/"
>}}
[
  {
    "image": "/images/01-hero.jpg",
    "imageAlt": "Team photo",
    "title": "How LiveAgent starts",
    "description": "Born in 2004, LiveAgent has an inspiring story...",
    "linkText": "Learn about us",
    "linkUrl": "/about/"
  }
]
{{< /custom-cards-slider >}}
```

**Card JSON fields:** `image` (required), `imageAlt` (optional, falls back to title), `title` (required), `description` (optional), `linkText` (optional, defaults to i18n `learnMore` or "Learn more"), `linkUrl` (required).

**Shortcode params:** `layout` (`"centered"` / `"right"`), `heading`, `description`, `buttonText`, `buttonUrl`, `sectionClass`.

## Dependencies (already in theme)

- `components/buttons/buttons.html` (variant=`text`, `showArrow=true`)
- `components/media/lazyimg.html`
- `helpers/get-translated-url.html` (URL translation per language)

No new theme primitives.

## Test plan

- [ ] Build passes in this repo (no consumer config — change is additive)
- [ ] Consumer site (e.g. `LiveAgent-hugo`) can use the shortcode after bumping submodule pointer — separate PR there ([WIP](https://github.com/qualityunit/LiveAgent-hugo) — will be linked)
- [ ] Visual check on home page: arrows centered with chevron icons, "Learn more →" not bold, card image renders at 354×500 aspect, no console errors
- [ ] Mobile (≤ 480px): slider switches to fixed 280 px cards, padding reduces to 1 rem
