### PR TITLE
fix: translate cta.url in split_with_image_cards overlay anchor

### DIFF
--- a/layouts/partials/sections/content/split_with_image_cards.html
+++ b/layouts/partials/sections/content/split_with_image_cards.html
@@ -75,7 +75,7 @@ Example:
 
                     <div class="relative overflow-hidden rounded-xl min-h-[453px] bg-cover bg-center {{ if $simple }} shadow-lg{{ end }}" {{ if and (not $cardVideoUrl) .cta.url }}aria-label="{{ .title }}"{{ else }}aria-label="{{ .title }}"{{ end }} {{ with $cardBackgroundImage }}style="background-image: url('{{ partial "functions/get-static-url.html" (dict "path" .) }}');"{{ end }}>
                         {{ if and (not $cardVideoUrl) .cta.url }}
-                            <a href="{{ .cta.url }}" class="absolute inset-0 z-20" aria-label="{{ .title }}"></a>
+                            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .cta.url) }}" class="absolute inset-0 z-20" aria-label="{{ .title }}"></a>
                         {{ end }}
                         
                         <div class="relative z-10 flex flex-col h-full bg-[#F9FAFB]">


### PR DESCRIPTION
## Summary

The full-card overlay anchor in `partials/sections/content/split_with_image_cards.html` was emitting `.cta.url` verbatim, so on non-EN languages (DE, FR, ES, … all 25 non-EN locales) the link kept the EN slug and 404'd when users clicked anywhere on a card.

The visible \"Select\" button rendered just below was already going through `components/buttons/buttons.html` (which auto-translates URLs internally), but the **invisible overlay anchor** that makes the whole card clickable bypassed translation.

## Fix

One-line change at line 78: wrap `.cta.url` in `helpers/get-translated-url.html`.

```diff
- <a href=\"{{ .cta.url }}\" class=\"absolute inset-0 z-20\" aria-label=\"{{ .title }}\"></a>
+ <a href=\"{{ partial \"helpers/get-translated-url.html\" (dict \"url\" .cta.url) }}\" class=\"absolute inset-0 z-20\" aria-label=\"{{ .title }}\"></a>
```

Same pattern as `buttons.html` — the helper resolves to the matching translated page when one exists, falls back to `relLangURL` otherwise. External URLs and anchors pass through unchanged.

## Impact

The `split-with-image-cards` shortcode is used widely across consumer sites:
- Migration pages: chaport, gist, otrs, supportbee, dashly, intercom, …
- Pricing
- Feature pages: customer-portal-software, customer-satisfaction-software, service-desk-software, softphone-software, …

In LiveAgent-hugo alone that's hundreds of pages × 26 languages = **thousands of pages** were 404-ing on the card-overlay click.

## Test plan

- [ ] Build passes in hugo-boilerplate repo
- [ ] After consumer sites bump submodule: click on cards in non-EN languages and confirm they land on the correct translated page (e.g. `/de/about/` instead of `/about/`)
- [ ] EN behaviour unchanged (helper passes EN URLs through `relLangURL` as before)

## Related

Independent of [#344](https://github.com/QualityUnit/hugo-boilerplate/pull/344) (custom-cards-slider). Both target `main` and can merge in any order.