### PR TITLE
fix: translate URLs across theme partials (audit follow-up)

### DIFF
--- a/layouts/partials/components/items/single_column_with_images.html
+++ b/layouts/partials/components/items/single_column_with_images.html
@@ -161,11 +161,11 @@
           <div>
             <div class="flex items-center gap-x-4 text-xs">
               {{ if .date }}<time datetime="{{ .date }}" class="{{ $dateColor }}">{{ .dateDisplay }}</time>{{ end }}
-              {{ if .category }}<a href="{{ .categoryLink }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
+              {{ if .category }}<a href="{{ partial "helpers/get-translated-url.html" (dict "url" .categoryLink) }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
             </div>
             <div class="group relative max-w-xl">
               <h3 class="mt-3 text-lg/6 font-semibold {{ $titleColor }} {{ $titleHoverColor }}">
-                <a href="{{ .titleLink }}">
+                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
                   <span class="absolute inset-0"></span>
                   {{ .title }}
                 </a>
@@ -187,7 +187,7 @@
                 {{ end }}
                 <div class="text-sm/6">
                   <p class="font-semibold {{ $authorNameColor }}">
-                    <a href="{{ .authorLink }}">
+                    <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .authorLink) }}">
                       <span class="absolute inset-0"></span>
                       {{ .authorName }}
                     </a>

--- a/layouts/partials/components/items/single_column_with_images_on_dark.html
+++ b/layouts/partials/components/items/single_column_with_images_on_dark.html
@@ -176,11 +176,11 @@
           <div>
             <div class="flex items-center gap-x-4 text-xs">
               {{ if .date }}<time datetime="{{ .date }}" class="{{ $dateColor }}">{{ .dateDisplay }}</time>{{ end }}
-              {{ if .category }}<a href="{{ .categoryLink }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
+              {{ if .category }}<a href="{{ partial "helpers/get-translated-url.html" (dict "url" .categoryLink) }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
             </div>
             <div class="group relative max-w-xl">
               <h3 class="mt-3 text-lg/6 font-semibold {{ $titleColor }} {{ $titleHoverColor }}">
-                <a href="{{ .titleLink }}">
+                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
                   <span class="absolute inset-0"></span>
                   {{ .title }}
                 </a>
@@ -200,7 +200,7 @@
                 {{ end }}
                 <div class="text-sm/6">
                   <p class="font-semibold {{ $authorNameColor }}">
-                    <a href="{{ .authorLink }}">
+                    <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .authorLink) }}">
                       <span class="absolute inset-0"></span>
                       {{ .authorName }}
                     </a>

--- a/layouts/partials/components/items/three_column.html
+++ b/layouts/partials/components/items/three_column.html
@@ -140,11 +140,11 @@
       <article class="flex max-w-xl flex-col items-start justify-between">
         <div class="flex items-center gap-x-4 text-xs">
           {{ if .date }}<time datetime="{{ .date }}" class="{{ $dateColor }}">{{ .dateDisplay }}</time>{{ end }}
-          {{ if .category }}<a href="{{ .categoryLink }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
+          {{ if .category }}<a href="{{ partial "helpers/get-translated-url.html" (dict "url" .categoryLink) }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
         </div>
         <div class="group relative">
           <h3 class="mt-3 text-lg/6 font-semibold {{ $titleColor }} {{ $titleHoverColor }}">
-            <a href="{{ .titleLink }}">
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
               <span class="absolute inset-0"></span>
               {{ .title }}
             </a>
@@ -162,7 +162,7 @@
           {{ end }}
           <div class="text-sm/6">
             <p class="font-semibold {{ $authorNameColor }}">
-              <a href="{{ .authorLink }}">
+              <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .authorLink) }}">
                 <span class="absolute inset-0"></span>
                 {{ .authorName }}
               </a>

--- a/layouts/partials/components/items/three_column_on_dark.html
+++ b/layouts/partials/components/items/three_column_on_dark.html
@@ -154,11 +154,11 @@
       <article class="flex max-w-xl flex-col items-start justify-between">
         <div class="flex items-center gap-x-4 text-xs">
           {{ if .date }}<time datetime="{{ .date }}" class="{{ $dateColor }}">{{ .dateDisplay }}</time>{{ end }}
-          {{ if .category }}<a href="{{ .categoryLink }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
+          {{ if .category }}<a href="{{ partial "helpers/get-translated-url.html" (dict "url" .categoryLink) }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
         </div>
         <div class="group relative">
           <h3 class="mt-3 text-lg/6 font-semibold {{ $titleColor }} {{ $titleHoverColor }}">
-            <a href="{{ .titleLink }}">
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
               <span class="absolute inset-0"></span>
               {{ .title }}
             </a>
@@ -177,7 +177,7 @@
           {{ end }}
           <div class="text-sm/6">
             <p class="font-semibold {{ $authorNameColor }}">
-              <a href="{{ .authorLink }}">
+              <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .authorLink) }}">
                 <span class="absolute inset-0"></span>
                 {{ .authorName }}
               </a>

--- a/layouts/partials/components/items/three_column_with_background_images.html
+++ b/layouts/partials/components/items/three_column_with_background_images.html
@@ -144,7 +144,7 @@
           {{ end }}
         </div>
         <h3 class="mt-3 text-lg/6 font-semibold {{ $titleColor }}">
-          <a href="{{ .titleLink }}">
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
             <span class="absolute inset-0"></span>
             {{ .title }}
           </a>

--- a/layouts/partials/components/items/three_column_with_background_images_on_dark.html
+++ b/layouts/partials/components/items/three_column_with_background_images_on_dark.html
@@ -158,7 +158,7 @@
           {{ end }}
         </div>
         <h3 class="mt-3 text-lg/6 font-semibold {{ $titleColor }}">
-          <a href="{{ .titleLink }}">
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
             <span class="absolute inset-0"></span>
             {{ .title }}
           </a>

--- a/layouts/partials/components/items/three_column_with_images.html
+++ b/layouts/partials/components/items/three_column_with_images.html
@@ -162,11 +162,11 @@
         <div class="max-w-xl">
           <div class="mt-8 flex items-center gap-x-4 text-xs">
             {{ if .date }}<time datetime="{{ .date }}" class="{{ $dateColor }}">{{ .dateDisplay }}</time>{{ end }}
-            {{ if .category }}<a href="{{ .categoryLink }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
+            {{ if .category }}<a href="{{ partial "helpers/get-translated-url.html" (dict "url" .categoryLink) }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
           </div>
           <div class="group relative">
             <h3 class="mt-3 text-lg/6 font-semibold {{ $titleColor }} {{ $titleHoverColor }}">
-              <a href="{{ .titleLink }}">
+              <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
                 <span class="absolute inset-0"></span>
                 {{ .title }}
               </a>
@@ -185,7 +185,7 @@
             {{ end }}
             <div class="text-sm/6">
               <p class="font-semibold {{ $authorNameColor }}">
-                <a href="{{ .authorLink }}">
+                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .authorLink) }}">
                   <span class="absolute inset-0"></span>
                   {{ .authorName }}
                 </a>

--- a/layouts/partials/components/items/three_column_with_images_on_dark.html
+++ b/layouts/partials/components/items/three_column_with_images_on_dark.html
@@ -175,11 +175,11 @@
         <div class="max-w-xl">
           <div class="mt-8 flex items-center gap-x-4 text-xs">
             {{ if .date }}<time datetime="{{ .date }}" class="{{ $dateColor }}">{{ .dateDisplay }}</time>{{ end }}
-            {{ if .category }}<a href="{{ .categoryLink }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
+            {{ if .category }}<a href="{{ partial "helpers/get-translated-url.html" (dict "url" .categoryLink) }}" class="relative z-10 rounded-full {{ .categoryBg }} px-3 py-1.5 font-medium {{ .categoryColor }} {{ .categoryHoverBg }}">{{ .category }}</a>{{ end }}
           </div>
           <div class="group relative">
             <h3 class="mt-3 text-lg/6 font-semibold {{ $titleColor }} {{ $titleHoverColor }}">
-              <a href="{{ .titleLink }}">
+              <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
                 <span class="absolute inset-0"></span>
                 {{ .title }}
               </a>
@@ -197,7 +197,7 @@
             {{ end }}
             <div class="text-sm/6">
               <p class="font-semibold {{ $authorNameColor }}">
-                <a href="{{ .authorLink }}">
+                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .authorLink) }}">
                   <span class="absolute inset-0"></span>
                   {{ .authorName }}
                 </a>

--- a/layouts/partials/components/items/with_photo_and_list.html
+++ b/layouts/partials/components/items/with_photo_and_list.html
@@ -132,7 +132,7 @@
             <dl class="relative flex flex-wrap gap-x-3">
               <dt class="sr-only">Role</dt>
               <dd class="w-full flex-none text-lg font-semibold tracking-tight {{ $itemTitleColor }}">
-                <a href="{{ .titleLink }}">
+                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
                   {{ .title }}
                   <span class="absolute inset-0" aria-hidden="true"></span>
                 </a>

--- a/layouts/partials/components/items/with_photo_and_list_on_dark.html
+++ b/layouts/partials/components/items/with_photo_and_list_on_dark.html
@@ -146,7 +146,7 @@
             <dl class="relative flex flex-wrap gap-x-3">
               <dt class="sr-only">Role</dt>
               <dd class="w-full flex-none text-lg font-semibold tracking-tight {{ $itemTitleColor }}">
-                <a href="{{ .titleLink }}">
+                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .titleLink) }}">
                   {{ .title }}
                   <span class="absolute inset-0" aria-hidden="true"></span>
                 </a>

--- a/layouts/partials/components/menus/flyout_menu_full_width_two_columns.html
+++ b/layouts/partials/components/menus/flyout_menu_full_width_two_columns.html
@@ -131,7 +131,7 @@
           <div>
             <div class="flex items-center gap-x-4">
               <time datetime="{{ .date }}" class="text-sm/6 {{ $blogDateColor }}">{{ dateFormat "Jan 2, 2006" .date }}</time>
-              <a href="{{ .categoryUrl }}" class="relative z-10 rounded-full {{ $blogCategoryBgColor }} px-3 py-1.5 text-xs font-medium {{ $blogCategoryTextColor }} {{ $blogCategoryHoverColor }}">{{ .category }}</a>
+              <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .categoryUrl) }}" class="relative z-10 rounded-full {{ $blogCategoryBgColor }} px-3 py-1.5 text-xs font-medium {{ $blogCategoryTextColor }} {{ $blogCategoryHoverColor }}">{{ .category }}</a>
             </div>
             <h4 class="mt-2 text-sm/6 font-semibold {{ $blogTitleColor }}">
               <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .url) }}">

--- a/layouts/partials/sections/bentogrids/three_column_bento_grid.html
+++ b/layouts/partials/sections/bentogrids/three_column_bento_grid.html
@@ -136,7 +136,7 @@ interest. Card heights are dynamically calculated based on their content.
             {{ end }}
             <li class="relative group splide__slide md:h-full rounded-2xl {{ $cornerClass }}">
               {{ if $card.url }}
-              <a class="absolute size-full z-10" href="{{ $card.url }}" aria-label="{{ $card.title }}"></a>
+              <a class="absolute size-full z-10" href="{{ partial "helpers/get-translated-url.html" (dict "url" $card.url) }}" aria-label="{{ $card.title }}"></a>
               {{ end }}
               <div
                 class="relative md:h-full rounded-2xl inset-px border border-gray-200 dark:border-gray-700 group-hover:border-primary-400 shadow-md dark:shadow-none flex flex-col overflow-hidden {{ if not $isDark }}bg-white{{ end }} transition-colors duration-300 {{ $cornerClass }}">

--- a/layouts/partials/sections/contact/simple-centered.html
+++ b/layouts/partials/sections/contact/simple-centered.html
@@ -53,7 +53,7 @@
           <h3 class="text-base/7 font-semibold text-gray-900">{{ .title }}</h3>
           <p class="mt-2 text-base/7 text-gray-600">{{ .description }}</p>
           <p class="mt-4 text-sm/6 font-semibold">
-            <a href="{{ .linkUrl }}" class="text-indigo-600">{{ .linkText }} <span aria-hidden="true">&rarr;</span></a>
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .linkUrl) }}" class="text-indigo-600">{{ .linkText }} <span aria-hidden="true">&rarr;</span></a>
           </p>
         </div>
       </div>

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -160,7 +160,7 @@ Design Tokens:
           {{/* Display image */}}
           <div class="relative w-full">
               {{ if $link }}
-                <a href="{{ $link }}" target="{{ $linkTarget }}"{{ if eq $linkTarget "_blank" }} rel="noopener noreferrer"{{ end }} class="block">
+                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $link) }}" target="{{ $linkTarget }}"{{ if eq $linkTarget "_blank" }} rel="noopener noreferrer"{{ end }} class="block">
               {{ end }}
                   {{ partial "components/media/lazyimg.html" (dict
                     "src" $image

--- a/layouts/partials/sections/content/split_with_image_grid.html
+++ b/layouts/partials/sections/content/split_with_image_grid.html
@@ -61,7 +61,7 @@
               {{/* Image with frame */}}
               <div class="relative bg-white p-2 rounded-xl shadow-2xl ring-1 ring-gray-900/10 dark:bg-gray-800 dark:ring-white/10">
                 {{ if $link }}
-                  <a href="{{ $link }}" target="{{ $linkTarget }}"{{ if eq $linkTarget "_blank" }} rel="noopener noreferrer"{{ end }} class="block">
+                  <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $link) }}" target="{{ $linkTarget }}"{{ if eq $linkTarget "_blank" }} rel="noopener noreferrer"{{ end }} class="block">
                 {{ end }}
                     {{ partial "components/media/lazyimg.html" (dict
                       "src" $image

--- a/layouts/partials/sections/faq/centered_accordion_grid.html
+++ b/layouts/partials/sections/faq/centered_accordion_grid.html
@@ -53,7 +53,7 @@
             {{ end }}
             {{ if and $ctaText $ctaUrl }}
             <p class="mt-6 text-base text-secondary">
-              {{ $ctaText }} <a href="{{ $ctaUrl }}" class="text-primary font-medium hover:underline">{{ $ctaLinkText }}</a>
+              {{ $ctaText }} <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="text-primary font-medium hover:underline">{{ $ctaLinkText }}</a>
             </p>
             {{ end }}
           </div>

--- a/layouts/partials/sections/features/simple_three_column_with_large_icons_dark.html
+++ b/layouts/partials/sections/features/simple_three_column_with_large_icons_dark.html
@@ -45,7 +45,7 @@
             <p class="flex-auto">{{ .description | safeHTML }}</p>
             {{ if .link }}
             <p class="mt-6">
-              <a href="{{ .link.url }}" class="text-sm/6 font-semibold text-indigo-400">{{ .link.text }} <span aria-hidden="true">→</span></a>
+              <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .link.url) }}" class="text-sm/6 font-semibold text-indigo-400">{{ .link.text }} <span aria-hidden="true">→</span></a>
             </p>
             {{ end }}
           </dd>

--- a/layouts/partials/sections/features/simple_three_column_with_small_icons.html
+++ b/layouts/partials/sections/features/simple_three_column_with_small_icons.html
@@ -45,7 +45,7 @@
             <p class="flex-auto">{{ .description | safeHTML }}</p>
             {{ if .link }}
             <p class="mt-6">
-              <a href="{{ .link.url }}" class="text-sm/6 font-semibold text-indigo-600">{{ .link.text }} <span aria-hidden="true">→</span></a>
+              <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .link.url) }}" class="text-sm/6 font-semibold text-indigo-600">{{ .link.text }} <span aria-hidden="true">→</span></a>
             </p>
             {{ end }}
           </dd>

--- a/layouts/partials/sections/features/simple_three_column_with_small_icons_dark.html
+++ b/layouts/partials/sections/features/simple_three_column_with_small_icons_dark.html
@@ -45,7 +45,7 @@
             <p class="flex-auto">{{ .description | safeHTML }}</p>
             {{ if .link }}
             <p class="mt-6">
-              <a href="{{ .link.url }}" class="text-sm/6 font-semibold text-indigo-400">{{ .link.text }} <span aria-hidden="true">→</span></a>
+              <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .link.url) }}" class="text-sm/6 font-semibold text-indigo-400">{{ .link.text }} <span aria-hidden="true">→</span></a>
             </p>
             {{ end }}
           </dd>


### PR DESCRIPTION
## Summary

Companion PR to [#345](https://github.com/QualityUnit/hugo-boilerplate/pull/345) which fixed the URL-translation bug in `split_with_image_cards.html`. After auditing **all** `<a href=\"{{ ... }}\">` emissions in the theme, found 22 more places with the same bug pattern — partials emitting raw user-supplied URLs verbatim, so on non-EN languages the link kept the EN slug and 404'd.

The fix is identical to #345: wrap the URL in `helpers/get-translated-url.html`. The helper safely passes through external URLs (`http://`, `https://`, `#anchor`) so it's a drop-in change with no risk for non-internal links.

## Files fixed (19 files, 22 line changes)

### Sections
- `sections/contact/simple-centered.html` — `.linkUrl`
- `sections/faq/centered_accordion_grid.html` — `$ctaUrl`
- `sections/features/simple_three_column_with_small_icons.html` — `.link.url`
- `sections/features/simple_three_column_with_small_icons_dark.html` — `.link.url`
- `sections/features/simple_three_column_with_large_icons_dark.html` — `.link.url`
- `sections/content/split_with_image.html` — `$link`
- `sections/content/split_with_image_grid.html` — `$link`
- `sections/bentogrids/three_column_bento_grid.html` — `$card.url` (full-card overlay anchor — same pattern as the original bug)

### Components
- `components/menus/flyout_menu_full_width_two_columns.html` — `.categoryUrl`
- `components/items/three_column_with_images.html` — `.categoryLink`, `.titleLink`, `.authorLink`
- `components/items/three_column_with_images_on_dark.html` — same trio
- `components/items/single_column_with_images.html` — same trio
- `components/items/single_column_with_images_on_dark.html` — same trio
- `components/items/three_column.html` — same trio
- `components/items/three_column_on_dark.html` — same trio
- `components/items/three_column_with_background_images.html` — `.titleLink`
- `components/items/three_column_with_background_images_on_dark.html` — `.titleLink`
- `components/items/with_photo_and_list.html` — `.titleLink`
- `components/items/with_photo_and_list_on_dark.html` — `.titleLink`

## Verified safe-as-is (intentionally NOT changed)

| Category | Files | Reason |
|---|---|---|
| Hugo paginator | `pagination/pagination.html`, `categories/term.html` | `$paginator.X.URL` is Hugo-generated, language-aware |
| Page permalinks | `cards/post_card[_with_image].html`, `cards/row_card.html`, `cards/post_card.html` | `RelPermalink` is Hugo-translated |
| Pre-wrapped at assignment | `mini-banner-cta.html`, `floating-cta.html` | `$primaryUrl` / `$secondaryUrl` already wrapped via `get-translated-url.html` at variable assignment |
| External | team `twitter` / `linkedin` (8 files), `award-badge.html`, `products/with_tabs.html` social share | External URLs (twitter.com, linkedin.com, …) — helper would pass through anyway, but explicit is fine |
| Protocol-prefixed | `contact/split-with-pattern.html` | `tel:` / `mailto:` |
| Per-language helper | `navigation/language-selector.html` | Already uses `helpers/get-language-url.html` for explicit per-language URLs |
| Hugo menu | `navigation/menu.html`, `header/menu-item.html` | `site.Menus` URL is Hugo-managed |
| Markdown render | `_default/_markup/render-link.html` | Already wraps with helper at line 50 |
| Pass-through wrapper | `components/media/lazyimg.html` | Caller's responsibility (image link wrap) |
| Video download | `media/video/custom.html` | `$videoSrc` is a media file URL, not page nav |

## Impact

These partials are used widely across consumer sites. In LiveAgent-hugo for example:
- `bentogrids/three_column_bento_grid.html` is the home page \"Explore why LiveAgent is the best choice\" + \"Explore LiveAgent resources\" sections — every card-overlay click 404'd on non-EN
- `items/*` is used across blog listings, category pages
- `features/simple_three_column_with_*_icons` appears on many feature pages
- `flyout_menu_full_width_two_columns` is in the header dropdowns

Multiplied by 26 languages × hundreds of pages = **thousands of broken links** in production.

## Test plan

- [ ] Build passes in hugo-boilerplate
- [ ] Consumer sites (LiveAgent, PAP) bump submodule pointer post-merge → click any internal link in a non-EN language, verify it lands on the correct translated page
- [ ] EN behaviour unchanged
- [ ] External links (twitter, linkedin, mailto, …) unchanged

## Related

- [#344](https://github.com/QualityUnit/hugo-boilerplate/pull/344) — feat: custom-cards-slider (independent)
- [#345](https://github.com/QualityUnit/hugo-boilerplate/pull/345) — fix: split_with_image_cards URL translation (the original bug, found and fixed first)

All three PRs are independent and target `main`.