### PR TITLE
feat: per-feature iconColor in content-split-with-image

### DIFF
--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -13,7 +13,7 @@ Parameters:
 - eyebrow, heading, description: Text content
 - link, linkText, buttonStyle: CTA button, showArrow (default: false)
 - markdownContent, contentAsHTML: Main content
-- features: [{icon, title, description}]
+- features: [{icon, iconColor, title, description}] (iconColor: semantic name "primary"|"success"|"danger"|"warning"|"info"|"muted", or raw Tailwind class. Default "primary")
 - numbered_features: [{title, description}] (features with numbers instead of icons)
 - stats: [{number, label}]
 - quote: {text, author, role, company, avatar}
@@ -188,12 +188,22 @@ Design Tokens:
 
         {{/* Features */}}
         {{ if $features }}
+        {{ $iconColorMap := dict
+          "primary" "text-primary"
+          "success" "text-green-500"
+          "danger"  "text-red-500"
+          "warning" "text-yellow-500"
+          "info"    "text-blue-500"
+          "muted"   "text-gray-400"
+        }}
         <dl class="mt-6 max-w-full space-y-3 text-normal text-secondary lg:max-w-full">
           {{ range $features }}
           <div class="relative pl-9">
             <dt class="inline {{ if .description }}font-bold{{ end }} text-heading">
               {{ if .icon }}
-                <span class="absolute left-1 top-1 size-5 text-primary">
+                {{ $rawColor := .iconColor | default "primary" }}
+                {{ $iconColorClass := index $iconColorMap $rawColor | default $rawColor }}
+                <span class="absolute left-1 top-1 size-5 {{ $iconColorClass }}">
                   {{ partial "components/media/icon.html" (dict "icon" .icon) }}
                 </span>
               {{ end }}

--- a/layouts/shortcodes/content-split-with-image.html
+++ b/layouts/shortcodes/content-split-with-image.html
@@ -249,6 +249,8 @@
       "features": [
         {
           "icon": "icon-name",        // Icon identifier (from /internal/design-system/#icons)
+          "iconColor": "primary",     // Optional. Semantic name: "primary" (default), "success", "danger", "warning", "info", "muted".
+                                      // Power users may pass a raw Tailwind class like "text-pink-500".
           "title": "Feature Title",   // Feature name
           "description": "Details"    // Feature description
         }


### PR DESCRIPTION
## Summary
- Each feature item in `content-split-with-image` can now set its own icon color via a new optional `iconColor` field.
- Accepts semantic names that map to Tailwind classes — `primary` (default), `success`, `danger`, `warning`, `info`, `muted`. Power users can also pass a raw Tailwind class (e.g. `text-pink-500`).
- Backwards compatible: omitting `iconColor` falls back to `text-primary`, so existing content renders unchanged.

## Why
Previously the icon color was hard-coded to `text-primary`, so a list could not mix e.g. green checkmarks with a red `x-mark`. Now editors can express comparison/exclusion patterns without touching CSS or knowing Tailwind.

## Usage
```json
{
  "features": [
    {"icon": "check-circle", "title": "Included"},
    {"icon": "check-circle", "title": "Included"},
    {"icon": "check-circle", "title": "Included"},
    {"icon": "x-mark", "iconColor": "danger", "title": "Not included"}
  ]
}
```

## Test plan
- [ ] Build a page with `content-split-with-image` and a `features` list containing 3 default-colored items + 1 with `iconColor: "danger"` — verify mixed colors render.
- [ ] Confirm existing pages without `iconColor` still render with brand-primary icons (no regression).
- [ ] Try a raw Tailwind class (e.g. `"iconColor": "text-pink-500"`) and confirm it applies.
- [ ] Try an unknown semantic name (typo) and confirm fallback behavior is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)