### PR TITLE
Normalize SEO display titles in theme

### DIFF
--- a/i18n/af.yaml
+++ b/i18n/af.yaml
@@ -51,6 +51,8 @@ cookie_settings_analytics_description: "Hierdie koekies help ons om te verstaan 
 cookie_settings_cancel: "Kanselleer"
 cookie_settings_save: "Stoor Voorkeure"
 home_title: "Tuis"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "Woordelys"
 no_terms_available: "Geen terme beskikbaar nie"
 categories_title: "Kategorieë"

--- a/i18n/ar.yaml
+++ b/i18n/ar.yaml
@@ -5,6 +5,8 @@ language_selector_title: "اللغات المتاحة"
 glossary_subtitle: "قائمة شاملة بالمصطلحات والتعريفات"
 glossary_title: "المصطلحات"
 home_title: "الرئيسية"
+component_page_title: "مكون %s"
+integration_page_title: "تكامل %s"
 
 # Search translations
 search_placeholder: "البحث..."

--- a/i18n/at.yaml
+++ b/i18n/at.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Verfügbare Sprachen"
 glossary_subtitle: "Eine umfassende Liste von Begriffen und Definitionen"
 glossary_title: "Glossar"
 home_title: "Startseite"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Suchen..."

--- a/i18n/bg.yaml
+++ b/i18n/bg.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Налични езици"
 glossary_subtitle: "Изчерпателен списък на термини и определения"
 glossary_title: "Речник"
 home_title: "Начало"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Търсене..."

--- a/i18n/bn.yaml
+++ b/i18n/bn.yaml
@@ -5,6 +5,8 @@ language_selector_title: "উপলভ্য ভাষাসমূহ"
 glossary_subtitle: "শব্দ এবং সংজ্ঞার একটি বিস্তৃত তালিকা"
 glossary_title: "শব্দকোষ"
 home_title: "হোম"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "অনুসন্ধান..."

--- a/i18n/ca.yaml
+++ b/i18n/ca.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Idiomes Disponibles"
 glossary_subtitle: "Una llista completa de termes i definicions"
 glossary_title: "Glossari"
 home_title: "Inici"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Cercar..."

--- a/i18n/ch.yaml
+++ b/i18n/ch.yaml
@@ -33,6 +33,8 @@ cookie_settings_cancel: "Abbrechä"
 cookie_settings_save: "Präferenzä speicherä"
 
 home_title: "Dihei"
+component_page_title: "%s组件"
+integration_page_title: "%s集成"
 glossary_eyebrow: "Glossar"
 no_terms_available: "Kei Begriff verfuegbar"
 categories_title: "Kategorie"

--- a/i18n/cs.yaml
+++ b/i18n/cs.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Dostupné jazyky"
 glossary_subtitle: "Komplexní seznam termínů a definic"
 glossary_title: "Slovník"
 home_title: "Domů"
+component_page_title: "Komponenta %s"
+integration_page_title: "Integrace %s"
 
 # Search translations
 search_placeholder: "Hledat..."

--- a/i18n/cy.yaml
+++ b/i18n/cy.yaml
@@ -34,6 +34,8 @@ cookie_settings_cancel: "Canslo"
 cookie_settings_save: "Cadw Dewisiadau"
 
 home_title: "Cartref"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "Geirfa"
 no_terms_available: "Dim termau ar gael"
 categories_title: "Categorïau"

--- a/i18n/da.yaml
+++ b/i18n/da.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Tilgængelige Sprog"
 glossary_subtitle: "En omfattende liste over udtryk og definitioner"
 glossary_title: "Ordliste"
 home_title: "Hjem"
+component_page_title: "%s-komponent"
+integration_page_title: "%s-integration"
 
 # Search translations
 search_placeholder: "Søg..."

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Verfügbare Sprachen"
 glossary_subtitle: "Eine umfassende Liste von Begriffen und Definitionen"
 glossary_title: "Glossar"
 home_title: "Startseite"
+component_page_title: "%s-Komponente"
+integration_page_title: "%s-Integration"
 
 # Search translations
 search_placeholder: "Suchen..."

--- a/i18n/el.yaml
+++ b/i18n/el.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Διαθέσιμες Γλώσσες"
 glossary_subtitle: "Μία εκτενή λίστα όρων και ορισμών"
 glossary_title: "Γλωσσάριο"
 home_title: "Αρχική"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Αναζήτηση..."

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Available Languages"
 glossary_subtitle: "A comprehensive list of terms and definitions"
 glossary_title: "Glossary"
 home_title: "Home"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Search..."

--- a/i18n/es.yaml
+++ b/i18n/es.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Idiomas Disponibles"
 glossary_subtitle: "Una lista completa de términos y definiciones"
 glossary_title: "Glosario"
 home_title: "Inicio"
+component_page_title: "Componente %s"
+integration_page_title: "Integración %s"
 
 # Search translations
 search_placeholder: "Buscar..."

--- a/i18n/et.yaml
+++ b/i18n/et.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Saadaolevad Keeled"
 glossary_subtitle: "Põhjalik terminite ja definitsioonide loend"
 glossary_title: "Sõnastik"
 home_title: "Avaleht"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Otsi..."

--- a/i18n/eu.yaml
+++ b/i18n/eu.yaml
@@ -34,6 +34,8 @@ cookie_settings_cancel: "Utzi"
 cookie_settings_save: "Hobespenak Gorde"
 
 home_title: "Hasiera"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "Glosarioa"
 no_terms_available: "Ez dago terminos erabilgarri"
 categories_title: "Kategoriak"

--- a/i18n/fa.yaml
+++ b/i18n/fa.yaml
@@ -5,6 +5,8 @@ language_selector_title: "زبان‌های موجود"
 glossary_subtitle: "فهرستی جامع از اصطلاحات و تعاریف"
 glossary_title: "فرهنگ لغات"
 home_title: "خانه"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "جستجو..."

--- a/i18n/fi.yaml
+++ b/i18n/fi.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Saatavilla Olevat Kielet"
 glossary_subtitle: "Kattava lista termeistä ja määritelmistä"
 glossary_title: "Sanasto"
 home_title: "Etusivu"
+component_page_title: "%s-komponentti"
+integration_page_title: "%s-integraatio"
 
 # Search translations
 search_placeholder: "Haku..."

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Langues Disponibles"
 glossary_subtitle: "Une liste complète de termes et définitions"
 glossary_title: "Glossaire"
 home_title: "Accueil"
+component_page_title: "Composant %s"
+integration_page_title: "Intégration %s"
 
 # Search translations
 search_placeholder: "Rechercher..."

--- a/i18n/gl.yaml
+++ b/i18n/gl.yaml
@@ -34,6 +34,8 @@ cookie_settings_cancel: "Cancelar"
 cookie_settings_save: "Gardar preferencias"
 
 home_title: "Inicio"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "Glosario"
 no_terms_available: "Non hai termos dispoñibles"
 categories_title: "Categorías"

--- a/i18n/he.yaml
+++ b/i18n/he.yaml
@@ -5,6 +5,8 @@ language_selector_title: "שפות זמינות"
 glossary_subtitle: "רשימה מקיפה של מונחים והגדרות"
 glossary_title: "מילון מונחים"
 home_title: "בית"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "חיפוש..."

--- a/i18n/hi.yaml
+++ b/i18n/hi.yaml
@@ -34,6 +34,8 @@ cookie_settings_cancel: "रद्द करें"
 cookie_settings_save: "प्राथमिकताएँ सहेजें"
 
 home_title: "मुखपृष्ठ"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "शब्दावली"
 no_terms_available: "कोई शब्द उपलब्ध नहीं"
 categories_title: "श्रेणियाँ"

--- a/i18n/hr.yaml
+++ b/i18n/hr.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Dostupni jezici"
 glossary_subtitle: "Sveobuhvatan popis pojmova i definicija"
 glossary_title: "Rječnik"
 home_title: "Početna"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Pretraži..."

--- a/i18n/hu.yaml
+++ b/i18n/hu.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Elérhető Nyelvek"
 glossary_subtitle: "Átfogó lista szakmai kifejezésekkel és meghatározásokkal"
 glossary_title: "Szószedet"
 home_title: "Főoldal"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Keresés..."

--- a/i18n/id.yaml
+++ b/i18n/id.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Bahasa yang Tersedia"
 glossary_subtitle: "Daftar lengkap istilah dan definisi"
 glossary_title: "Glosarium"
 home_title: "Beranda"
+component_page_title: "Komponen %s"
+integration_page_title: "Integrasi %s"
 
 # Search translations
 search_placeholder: "Cari..."

--- a/i18n/is.yaml
+++ b/i18n/is.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Tiltæk Tungumál"
 glossary_subtitle: "Yfirgripsmikill listi af hugtökum og skilgreiningum"
 glossary_title: "Hugtakasafn"
 home_title: "Heim"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Glossary translations
 glossary_eyebrow: "Hugtakasafn"

--- a/i18n/it.yaml
+++ b/i18n/it.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Lingue Disponibili"
 glossary_subtitle: "Un elenco completo di termini e definizioni"
 glossary_title: "Glossario"
 home_title: "Home"
+component_page_title: "Componente %s"
+integration_page_title: "Integrazione %s"
 
 # Search translations
 search_placeholder: "Cerca..."

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -6,6 +6,8 @@ language_selector_title: "利用可能な言語"
 glossary_subtitle: "用語と定義の包括的なリスト"
 glossary_title: "用語集"
 home_title: "ホーム"
+component_page_title: "%sコンポーネント"
+integration_page_title: "%s統合"
 
 # Search translations
 search_placeholder: "検索..."

--- a/i18n/jp.yaml
+++ b/i18n/jp.yaml
@@ -6,6 +6,8 @@ language_selector_title: "利用可能な言語"
 glossary_subtitle: "用語と定義の包括的なリスト"
 glossary_title: "用語集"
 home_title: "ホーム"
+component_page_title: "%sコンポーネント"
+integration_page_title: "%s統合"
 
 # Search translations
 search_placeholder: "検索..."

--- a/i18n/ko.yaml
+++ b/i18n/ko.yaml
@@ -5,6 +5,8 @@ language_selector_title: "사용 가능한 언어"
 glossary_subtitle: "용어 및 정의의 종합 목록"
 glossary_title: "용어집"
 home_title: "홈"
+component_page_title: "%s 컴포넌트"
+integration_page_title: "%s 통합"
 
 # Search translations
 search_placeholder: "검색..."

--- a/i18n/lt.yaml
+++ b/i18n/lt.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Galimos kalbos"
 glossary_subtitle: "Išsamus terminų ir apibrėžimų sąrašas"
 glossary_title: "Žodynas"
 home_title: "Pagrindinis"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Ieškoti..."

--- a/i18n/lv.yaml
+++ b/i18n/lv.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Pieejamās valodas"
 glossary_subtitle: "Visaptverošs terminu un definīciju saraksts"
 glossary_title: "Glosārijs"
 home_title: "Sākums"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Meklēt..."

--- a/i18n/ms.yaml
+++ b/i18n/ms.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Bahasa Yang Tersedia"
 glossary_subtitle: "Senarai lengkap istilah dan definisi"
 glossary_title: "Glosari"
 home_title: "Laman Utama"
+component_page_title: "Komponen %s"
+integration_page_title: "Integrasi %s"
 
 # Search translations
 search_placeholder: "Cari..."

--- a/i18n/mt.yaml
+++ b/i18n/mt.yaml
@@ -34,6 +34,8 @@ cookie_settings_cancel: "Ikkanċella"
 cookie_settings_save: "Ħlief il-Preferenzi"
 
 home_title: "Dar"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "Glossarju"
 no_terms_available: "Ebda termini disponibbli"
 categories_title: "Kategoriji"

--- a/i18n/nl.yaml
+++ b/i18n/nl.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Beschikbare Talen"
 glossary_subtitle: "Een uitgebreide lijst van termen en definities"
 glossary_title: "Woordenlijst"
 home_title: "Home"
+component_page_title: "%s-component"
+integration_page_title: "%s-integratie"
 
 # Search translations
 search_placeholder: "Zoeken..."

--- a/i18n/no.yaml
+++ b/i18n/no.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Tilgjengelige språk"
 glossary_subtitle: "En omfattende liste over termer og definisjoner"
 glossary_title: "Ordliste"
 home_title: "Hjem"
+component_page_title: "%s-komponent"
+integration_page_title: "%s-integrasjon"
 
 # Search translations
 search_placeholder: "Søk..."

--- a/i18n/pl.yaml
+++ b/i18n/pl.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Dostępne Języki"
 glossary_subtitle: "Kompleksowa lista terminów i definicji"
 glossary_title: "Słownik"
 home_title: "Strona główna"
+component_page_title: "Komponent %s"
+integration_page_title: "Integracja %s"
 
 # Search translations
 search_placeholder: "Szukaj..."

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Idiomas Disponíveis"
 glossary_subtitle: "Uma lista abrangente de termos e definições"
 glossary_title: "Glossário"
 home_title: "Início"
+component_page_title: "Componente %s"
+integration_page_title: "Integração %s"
 
 # Search translations
 search_placeholder: "Pesquisar..."

--- a/i18n/ro.yaml
+++ b/i18n/ro.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Limbi disponibile"
 glossary_subtitle: "O listă cuprinzătoare de termeni și definiții"
 glossary_title: "Glosar"
 home_title: "Acasă"
+component_page_title: "Componenta %s"
+integration_page_title: "Integrarea %s"
 
 # Search translations
 search_placeholder: "Căutare..."

--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Доступные языки"
 glossary_subtitle: "Подробный список терминов и определений"
 glossary_title: "Глоссарий"
 home_title: "Главная"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Поиск..."

--- a/i18n/sk.yaml
+++ b/i18n/sk.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Dostupné jazyky"
 glossary_subtitle: "Komplexný zoznam pojmov a definícií"
 glossary_title: "Glosár"
 home_title: "Domov"
+component_page_title: "Komponent %s"
+integration_page_title: "Integrácia %s"
 
 # Search translations
 search_placeholder: "Vyhľadať..."

--- a/i18n/sl.yaml
+++ b/i18n/sl.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Razpoložljivi jeziki"
 glossary_subtitle: "Izčrpen seznam izrazov in definicij"
 glossary_title: "Slovar"
 home_title: "Domov"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Iskanje..."

--- a/i18n/sq.yaml
+++ b/i18n/sq.yaml
@@ -34,6 +34,8 @@ cookie_settings_cancel: "Anulo"
 cookie_settings_save: "Ruaj Preferencat"
 
 home_title: "Kreu"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "Fjalori"
 no_terms_available: "Nuk ka terma të disponueshëm"
 categories_title: "Kategoritë"

--- a/i18n/sr.yaml
+++ b/i18n/sr.yaml
@@ -34,6 +34,8 @@ cookie_settings_cancel: "Otkaži"
 cookie_settings_save: "Sačuvaj Preferencije"
 
 home_title: "Početna"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "Rečnik"
 no_terms_available: "Nema dostupnih termina"
 categories_title: "Kategorije"

--- a/i18n/sv.yaml
+++ b/i18n/sv.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Tillgängliga språk"
 glossary_subtitle: "En omfattande lista över termer och definitioner"
 glossary_title: "Ordlista"
 home_title: "Hem"
+component_page_title: "%s-komponent"
+integration_page_title: "%s-integration"
 
 # Search translations
 search_placeholder: "Sök..."

--- a/i18n/sw.yaml
+++ b/i18n/sw.yaml
@@ -33,6 +33,8 @@ cookie_settings_analytics_description: "Kuki hizi hutusaidia kuelewa jinsi wagen
 cookie_settings_cancel: "Ghairi"
 cookie_settings_save: "Hifadhi Mapendekezo"
 home_title: "Nyumbani"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "Kamusi"
 no_terms_available: "Hakuna masharti yaliyopo"
 categories_title: "Jamii"

--- a/i18n/ta.yaml
+++ b/i18n/ta.yaml
@@ -32,6 +32,8 @@ cookie_settings_analytics_description: "வருகையாளர்கள் 
 cookie_settings_cancel: "ரத்து செய்"
 cookie_settings_save: "விருப்பங்களை சேமிக்கவும்"
 home_title: "முகப்பு"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "சொல்லகம்"
 no_terms_available: "பதங்கள் எதுவும் இல்லை"
 categories_title: "வகைகள்"

--- a/i18n/th.yaml
+++ b/i18n/th.yaml
@@ -5,6 +5,8 @@ language_selector_title: "ภาษาที่มี"
 glossary_subtitle: "รายการคำศัพท์และคำนิยามที่ครอบคลุม"
 glossary_title: "อภิธานศัพท์"
 home_title: "หน้าหลัก"
+component_page_title: "คอมโพเนนต์ %s"
+integration_page_title: "การผสานรวม %s"
 
 # Search translations
 search_placeholder: "ค้นหา..."

--- a/i18n/tr.yaml
+++ b/i18n/tr.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Mevcut Diller"
 glossary_subtitle: "Kapsamlı terimler ve tanımlar listesi"
 glossary_title: "Sözlük"
 home_title: "Ana Sayfa"
+component_page_title: "%s Bileşeni"
+integration_page_title: "%s Entegrasyonu"
 
 # Search translations
 search_placeholder: "Ara..."

--- a/i18n/uk.yaml
+++ b/i18n/uk.yaml
@@ -5,6 +5,8 @@ language_selector_title: "Доступні мови"
 glossary_subtitle: "Всебічний список термінів та визначень"
 glossary_title: "Глосарій"
 home_title: "Головна"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 
 # Search translations
 search_placeholder: "Пошук..."

--- a/i18n/ur.yaml
+++ b/i18n/ur.yaml
@@ -53,6 +53,8 @@ cookie_settings_cancel: "منسوخ کریں"
 cookie_settings_save: "ترجیحات محفوظ کریں"
 
 home_title: "ہوم"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "اصطلاحات"
 no_terms_available: "کوئی اصطلاحات دستیاب نہیں"
 categories_title: "زمرہ جات"

--- a/i18n/us.yaml
+++ b/i18n/us.yaml
@@ -53,6 +53,8 @@ cookie_settings_cancel: "Cancel"
 cookie_settings_save: "Save Preferences"
 
 home_title: "Home"
+component_page_title: "%s Component"
+integration_page_title: "%s Integration"
 glossary_eyebrow: "Glossary"
 no_terms_available: "No terms available"
 categories_title: "Categories"

--- a/i18n/vi.yaml
+++ b/i18n/vi.yaml
@@ -59,6 +59,8 @@ cookie_settings_cancel: "Hủy"
 cookie_settings_save: "Lưu Tùy Chọn"
 
 home_title: "Trang Chủ"
+component_page_title: "Thành phần %s"
+integration_page_title: "Tích hợp %s"
 glossary_eyebrow: "Thuật Ngữ"
 no_terms_available: "Không có thuật ngữ nào"
 categories_title: "Danh Mục"

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -5,6 +5,8 @@ language_selector_title: "可用语言"
 glossary_subtitle: "术语和定义的全面列表"
 glossary_title: "术语表"
 home_title: "首页"
+component_page_title: "%s组件"
+integration_page_title: "%s集成"
 
 # Search translations
 search_placeholder: "搜索..."

--- a/layouts/alias.html
+++ b/layouts/alias.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="{{ .Site.Language.Locale | default "en" }}">
+  <head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex, follow">
+    <link rel="canonical" href="{{ .Permalink }}">
+    <title>Redirecting | {{ .Site.Title }}</title>
+    <meta http-equiv="refresh" content="0; url={{ .Permalink }}">
+    <script>
+      window.location.replace({{ .Permalink | jsonify | safeJS }});
+    </script>
+  </head>
+  <body>
+    <p>Redirecting to <a href="{{ .Permalink }}">{{ .Permalink }}</a>.</p>
+  </body>
+</html>

--- a/layouts/glossary/single.html
+++ b/layouts/glossary/single.html
@@ -3,6 +3,8 @@
 {{/* Set page context for shortcodes to know about wrapper-narrower-content usage */}}
 {{ .Scratch.Set "hasWrapperNarrower" true }}
 
+{{ partial "schemaorg/article.html" (dict "page" . "articleType" "Article") }}
+
 {{ partial "breadcrumbs_default.html" . }}
 
 <!-- Hero Section with Term -->

--- a/layouts/partials/breadcrumbs_default.html
+++ b/layouts/partials/breadcrumbs_default.html
@@ -10,7 +10,8 @@
 
 {{/* Add current page - .Ancestors does not include the current page, so we add it separately */}}
 {{ if not .IsHome }}
-  {{ $breadcrumbItems = $breadcrumbItems | append (dict "title" .Title "url" .RelPermalink) }}
+  {{ $currentTitle := partial "helpers/page-display-title.html" (dict "page" .) }}
+  {{ $breadcrumbItems = $breadcrumbItems | append (dict "title" $currentTitle "url" .RelPermalink) }}
 {{ end }}
 
 {{ partial "components/breadcrumbs/basic" (dict "items" $breadcrumbItems) }}

--- a/layouts/partials/components/media/video.html
+++ b/layouts/partials/components/media/video.html
@@ -118,6 +118,8 @@
 "playBtnInnerClass" .playBtnInnerClass
 "svgClass" .svgClass
 "showPlayButton" $showPlayButton
+"page" .page
+"uploadDate" .uploadDate
 ) }}
 {{ else if eq $provider "custom" }}
 <!-- Load video helper partial for resource management -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,3 +1,11 @@
+{{ $pageTitle := partial "helpers/page-display-title.html" (dict "page" .) }}
+{{ $headTitle := "" }}
+{{ if .IsHome }}
+  {{ $headTitle = $pageTitle | default site.Title }}
+{{ else }}
+  {{ $headTitle = printf "%s | %s" $pageTitle site.Title }}
+{{ end }}
+
 <meta name="referrer" content="no-referrer">
 <meta charset="utf-8">
 <meta name="viewport" content="minimum-scale=1, width=device-width, initial-scale=1.0, shrink-to-fit=no">
@@ -8,7 +16,7 @@
 <meta name="robots" content="noindex, nofollow">
 {{ end }}
 
-<title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" (replace .Title "[year]" (now.Format "2006")) site.Title }}{{ end }}</title>
+<title>{{ $headTitle }}</title>
 {{ with .Permalink }}<link rel="canonical" href="{{ . }}">{{ end }}
 
 <!-- Generate hreflang alternate links -->
@@ -37,4 +45,3 @@
 {{ if templates.Exists "partials/tracking/tracking-scripts.html" }}
   {{ partial "tracking/tracking-scripts.html" . }}
 {{ end }}
-

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,4 @@
-{{ $pageTitle := partial "helpers/page-display-title.html" (dict "page" .) }}
+{{ $pageTitle := partial "helpers/page-seo-title.html" (dict "page" .) }}
 {{ $headTitle := "" }}
 {{ if .IsHome }}
   {{ $headTitle = $pageTitle | default site.Title }}

--- a/layouts/partials/helpers/component-display-name.html
+++ b/layouts/partials/helpers/component-display-name.html
@@ -32,4 +32,4 @@
   {{- $display = replaceRE "([A-Za-z])([0-9])" "$1 $2" $display -}}
   {{- $display = replaceRE "([0-9])([A-Za-z])" "$1 $2" $display -}}
 {{- end -}}
-{{- strings.TrimSpace $display -}}
+{{- return (strings.TrimSpace $display | htmlUnescape) -}}

--- a/layouts/partials/helpers/component-display-name.html
+++ b/layouts/partials/helpers/component-display-name.html
@@ -1,0 +1,35 @@
+{{- $raw := .name | default .page.Title -}}
+{{- $display := $raw -}}
+{{- $matched := false -}}
+{{- with site.Data.related_content.en.components -}}
+  {{- range $key, $_ := . -}}
+    {{- if eq (lower $key) (lower $raw) -}}
+      {{- $display = $key -}}
+      {{- $matched = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $matched -}}
+  {{- $phrase := lower $display -}}
+  {{- range slice
+    "microsoft" "wordpress" "instagram" "linkedin" "available" "worksheet" "worksheets"
+    "workbook" "workbooks" "calendar" "channels" "contacts" "messages" "received"
+    "outlook" "planner" "hubspot" "onedrive" "profile" "replies" "reaction"
+    "folders" "history" "formula" "display" "google" "sheets" "slides" "delete"
+    "remove" "update" "create" "assign" "search" "thread" "events" "labels"
+    "contact" "folder" "channel" "message" "plugin" "charts" "ranges" "media"
+    "slack" "excel" "gmail" "todo" "docs" "send" "list" "view" "find" "add"
+    "get" "new" "row" "rows" "task" "tasks" "plan" "plans" "user" "users"
+    "file" "files" "post" "posts" "range" "chart" "label" "apply" "times" "event"
+  -}}
+    {{- $phrase = replace $phrase . (printf " %s " .) -}}
+  {{- end -}}
+  {{- $phrase = replaceRE "\\b([a-z]+) s\\b" "${1}s" $phrase -}}
+  {{- $display = title (replaceRE "\\s+" " " (strings.TrimSpace $phrase)) -}}
+{{- else -}}
+  {{- $display = replaceRE "([A-Z]+)([A-Z][a-z])" "$1 $2" $display -}}
+  {{- $display = replaceRE "([a-z])([A-Z])" "$1 $2" $display -}}
+  {{- $display = replaceRE "([A-Za-z])([0-9])" "$1 $2" $display -}}
+  {{- $display = replaceRE "([0-9])([A-Za-z])" "$1 $2" $display -}}
+{{- end -}}
+{{- strings.TrimSpace $display -}}

--- a/layouts/partials/helpers/page-display-title.html
+++ b/layouts/partials/helpers/page-display-title.html
@@ -8,4 +8,4 @@
   {{- $pattern := i18n "integration_page_title" | default "%s Integration" -}}
   {{- $title = printf $pattern $title -}}
 {{- end -}}
-{{- $title -}}
+{{- return ($title | htmlUnescape) -}}

--- a/layouts/partials/helpers/page-display-title.html
+++ b/layouts/partials/helpers/page-display-title.html
@@ -1,0 +1,11 @@
+{{- $page := .page | default . -}}
+{{- $title := replace $page.Title "[year]" (now.Format "2006") -}}
+{{- if and (eq $page.Kind "term") (eq $page.Data.Singular "components") -}}
+  {{- $componentName := partial "helpers/component-display-name.html" (dict "page" $page) -}}
+  {{- $pattern := i18n "component_page_title" | default "%s Component" -}}
+  {{- $title = printf $pattern $componentName -}}
+{{- else if and (eq $page.Section "integrations") (not (in (lower $title) "integration")) -}}
+  {{- $pattern := i18n "integration_page_title" | default "%s Integration" -}}
+  {{- $title = printf $pattern $title -}}
+{{- end -}}
+{{- $title -}}

--- a/layouts/partials/helpers/page-meta-description.html
+++ b/layouts/partials/helpers/page-meta-description.html
@@ -1,32 +1,32 @@
-{{ $page := .page | default . }}
-{{ $description := "" }}
+{{- $page := .page | default . -}}
+{{- $description := "" -}}
 
-{{ if and (eq $page.Kind "term") (eq $page.Data.Singular "components") }}
-  {{ $componentName := partial "helpers/component-display-name.html" (dict "page" $page) }}
-  {{ $description = printf "Explore flow templates that use the %s component. See related automations, integration examples, and ways to use this component in workflows." $componentName }}
-{{ else }}
-  {{ with $page.Params.description }}
-    {{ $description = . }}
-  {{ else }}
-    {{ with $page.Description }}
-      {{ $description = . }}
-    {{ else }}
-      {{ with $page.Params.summary }}
-        {{ $description = . }}
-      {{ else }}
-        {{ if eq $page.Kind "term" }}
-          {{ $description = printf "Browse %s articles, tutorials, product updates, and automation guides from FlowHunt." $page.Title }}
-        {{ else if eq $page.Kind "taxonomy" }}
-          {{ $description = printf "Browse FlowHunt articles by topic, including AI agents, automation workflows, tutorials, product updates, and technical guides." }}
-        {{ else }}
-          {{ with site.Params.description }}
-            {{ $description = . }}
-          {{ end }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
+{{- if and (eq $page.Kind "term") (eq $page.Data.Singular "components") -}}
+  {{- $componentName := partial "helpers/component-display-name.html" (dict "page" $page) -}}
+  {{- $description = printf "Explore flow templates that use the %s component. See related automations, integration examples, and ways to use this component in workflows." $componentName -}}
+{{- else -}}
+  {{- with $page.Params.description -}}
+    {{- $description = . -}}
+  {{- else -}}
+    {{- with $page.Description -}}
+      {{- $description = . -}}
+    {{- else -}}
+      {{- with $page.Params.summary -}}
+        {{- $description = . -}}
+      {{- else -}}
+        {{- if eq $page.Kind "term" -}}
+          {{- $description = printf "Browse %s articles, tutorials, product updates, and automation guides from FlowHunt." $page.Title -}}
+        {{- else if eq $page.Kind "taxonomy" -}}
+          {{- $description = printf "Browse FlowHunt articles by topic, including AI agents, automation workflows, tutorials, product updates, and technical guides." -}}
+        {{- else -}}
+          {{- with site.Params.description -}}
+            {{- $description = . -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 
-{{ $description = replace $description "[year]" (now.Format "2006") }}
-{{ $description | plainify | htmlUnescape | chomp }}
+{{- $description = replace $description "[year]" (now.Format "2006") -}}
+{{- $description | plainify | htmlUnescape | chomp -}}

--- a/layouts/partials/helpers/page-meta-description.html
+++ b/layouts/partials/helpers/page-meta-description.html
@@ -13,13 +13,15 @@
     {{ else }}
       {{ with $page.Params.summary }}
         {{ $description = . }}
-      {{ else if eq $page.Kind "term" }}
-        {{ $description = printf "Browse %s articles, tutorials, product updates, and automation guides from FlowHunt." $page.Title }}
-      {{ else if eq $page.Kind "taxonomy" }}
-        {{ $description = printf "Browse FlowHunt articles by topic, including AI agents, automation workflows, tutorials, product updates, and technical guides." }}
       {{ else }}
-        {{ with site.Params.description }}
-          {{ $description = . }}
+        {{ if eq $page.Kind "term" }}
+          {{ $description = printf "Browse %s articles, tutorials, product updates, and automation guides from FlowHunt." $page.Title }}
+        {{ else if eq $page.Kind "taxonomy" }}
+          {{ $description = printf "Browse FlowHunt articles by topic, including AI agents, automation workflows, tutorials, product updates, and technical guides." }}
+        {{ else }}
+          {{ with site.Params.description }}
+            {{ $description = . }}
+          {{ end }}
         {{ end }}
       {{ end }}
     {{ end }}

--- a/layouts/partials/helpers/page-meta-description.html
+++ b/layouts/partials/helpers/page-meta-description.html
@@ -29,4 +29,4 @@
 {{- end -}}
 
 {{- $description = replace $description "[year]" (now.Format "2006") -}}
-{{- $description | plainify | htmlUnescape | chomp -}}
+{{- return ($description | plainify | htmlUnescape | chomp) -}}

--- a/layouts/partials/helpers/page-meta-description.html
+++ b/layouts/partials/helpers/page-meta-description.html
@@ -1,0 +1,30 @@
+{{ $page := .page | default . }}
+{{ $description := "" }}
+
+{{ if and (eq $page.Kind "term") (eq $page.Data.Singular "components") }}
+  {{ $componentName := partial "helpers/component-display-name.html" (dict "page" $page) }}
+  {{ $description = printf "Explore flow templates that use the %s component. See related automations, integration examples, and ways to use this component in workflows." $componentName }}
+{{ else }}
+  {{ with $page.Params.description }}
+    {{ $description = . }}
+  {{ else }}
+    {{ with $page.Description }}
+      {{ $description = . }}
+    {{ else }}
+      {{ with $page.Params.summary }}
+        {{ $description = . }}
+      {{ else if eq $page.Kind "term" }}
+        {{ $description = printf "Browse %s articles, tutorials, product updates, and automation guides from FlowHunt." $page.Title }}
+      {{ else if eq $page.Kind "taxonomy" }}
+        {{ $description = printf "Browse FlowHunt articles by topic, including AI agents, automation workflows, tutorials, product updates, and technical guides." }}
+      {{ else }}
+        {{ with site.Params.description }}
+          {{ $description = . }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ $description = replace $description "[year]" (now.Format "2006") }}
+{{ $description | plainify | htmlUnescape | chomp }}

--- a/layouts/partials/helpers/page-seo-title.html
+++ b/layouts/partials/helpers/page-seo-title.html
@@ -1,0 +1,16 @@
+{{- $page := .page | default . -}}
+{{- $title := "" -}}
+{{- with $page.Params.seo_title -}}
+  {{- $title = . -}}
+{{- else -}}
+  {{- with $page.Params.meta_title -}}
+    {{- $title = . -}}
+  {{- else -}}
+    {{- with $page.Params.browser_title -}}
+      {{- $title = . -}}
+    {{- else -}}
+      {{- $title = partial "helpers/page-display-title.html" (dict "page" $page) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- replace $title "[year]" (now.Format "2006") -}}

--- a/layouts/partials/helpers/page-seo-title.html
+++ b/layouts/partials/helpers/page-seo-title.html
@@ -13,4 +13,5 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
-{{- replace $title "[year]" (now.Format "2006") -}}
+{{- $title = replace $title "[year]" (now.Format "2006") -}}
+{{- return ($title | htmlUnescape) -}}

--- a/layouts/partials/schemaorg/article.html
+++ b/layouts/partials/schemaorg/article.html
@@ -26,26 +26,21 @@
 {{ end }}
 
 {{/* Get author information */}}
-{{/* Try data/authors.yaml first (legacy projects), then fall back to a */}}
-{{/* /author/<key>/ content page, then to "Anonymous" if neither exists. */}}
-{{ $authorName := "Anonymous" }}
-{{ $authorImage := "" }}
-{{ $authorURL := "" }}
+{{ $authorObj := dict "@type" "Organization" "name" $site.Title "url" $site.BaseURL }}
 {{ if $page.Params.author }}
   {{ $authorKey := $page.Params.author }}
   {{ $authors := hugo.Data.authors }}
   {{ if and $authors (index $authors $authorKey) }}
     {{ $author := index $authors $authorKey }}
-    {{ $authorName = $author.name }}
-    {{ $authorImage = $author.image }}
+    {{ $authorObj = dict "@type" "Person" "name" $author.name }}
+    {{ with $author.image }}{{ $authorObj = merge $authorObj (dict "image" .) }}{{ end }}
   {{ else }}
     {{ $authorPage := site.GetPage (printf "/author/%s" $authorKey) }}
     {{ if $authorPage }}
-      {{ $authorName = $authorPage.Title }}
+      {{ $authorObj = dict "@type" "Person" "name" $authorPage.Title "url" $authorPage.Permalink }}
       {{ with $authorPage.Params.image }}
-        {{ $authorImage = (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) }}
+        {{ $authorObj = merge $authorObj (dict "image" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .))) }}
       {{ end }}
-      {{ $authorURL = $authorPage.Permalink }}
     {{ end }}
   {{ end }}
 {{ end }}
@@ -60,10 +55,6 @@
   {{ $image = (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) }}
 {{ end }}
 
-{{- $authorObj := dict "@type" "Person" "name" $authorName -}}
-{{- with $authorImage }}{{ $authorObj = merge $authorObj (dict "image" .) }}{{ end -}}
-{{- with $authorURL }}{{ $authorObj = merge $authorObj (dict "url" .) }}{{ end -}}
-
 {{- $publisher := dict "@type" "Organization" "name" $site.Title "url" $site.BaseURL -}}
 {{- with $site.Params.organization.logo -}}
   {{- $logo := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
@@ -72,7 +63,13 @@
 
 {{- $mainEntity := dict "@type" "WebPage" "@id" $page.Permalink -}}
 
-{{- $schema := dict "@context" "https://schema.org" "@type" $articleType "headline" $page.Title "datePublished" ($page.Date.Format "2006-01-02T15:04:05Z07:00") "dateModified" ($page.Lastmod.Format "2006-01-02T15:04:05Z07:00") "author" $authorObj "publisher" $publisher "mainEntityOfPage" $mainEntity "url" $page.Permalink "articleBody" $page.Plain "inLanguage" $page.Language.LanguageCode -}}
+{{- $schema := dict "@context" "https://schema.org" "@type" $articleType "headline" $page.Title "author" $authorObj "publisher" $publisher "mainEntityOfPage" $mainEntity "url" $page.Permalink "articleBody" $page.Plain "inLanguage" $page.Language.LanguageCode -}}
+{{- if not $page.Date.IsZero -}}
+  {{- $schema = merge $schema (dict "datePublished" ($page.Date.Format "2006-01-02T15:04:05Z07:00")) -}}
+{{- end -}}
+{{- if not $page.Lastmod.IsZero -}}
+  {{- $schema = merge $schema (dict "dateModified" ($page.Lastmod.Format "2006-01-02T15:04:05Z07:00")) -}}
+{{- end -}}
 {{- with $page.Description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
 {{- with $image }}{{ $schema = merge $schema (dict "image" .) }}{{ end -}}
 {{- with $page.Params.tags }}{{ $schema = merge $schema (dict "keywords" (delimit . ", ")) }}{{ end -}}

--- a/layouts/partials/schemaorg/webpage.html
+++ b/layouts/partials/schemaorg/webpage.html
@@ -50,8 +50,21 @@
   {{- $publisher = merge $publisher (dict "logo" $logo) -}}
 {{- end -}}
 
-{{- $schema := dict "@context" "https://schema.org" "@type" $pageType "@id" $page.Permalink "url" $page.Permalink "name" $page.Title "inLanguage" $page.Language.LanguageCode "isPartOf" $isPartOf "datePublished" ($page.Date.Format "2006-01-02T15:04:05Z07:00") "dateModified" ($page.Lastmod.Format "2006-01-02T15:04:05Z07:00") "publisher" $publisher -}}
-{{- with $page.Description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
+{{- $pageName := partial "helpers/page-display-title.html" (dict "page" $page) -}}
+{{- $pageDescription := $page.Description -}}
+{{- if and (eq $page.Kind "term") (eq $page.Data.Singular "components") -}}
+  {{- $componentName := partial "helpers/component-display-name.html" (dict "page" $page) -}}
+  {{- $pageDescription = printf "Explore flow templates that use the %s component. See related automations, integration examples, and ways to use this component in workflows." $componentName -}}
+{{- end -}}
+
+{{- $schema := dict "@context" "https://schema.org" "@type" $pageType "@id" $page.Permalink "url" $page.Permalink "name" $pageName "inLanguage" $page.Language.LanguageCode "isPartOf" $isPartOf "publisher" $publisher -}}
+{{- if not $page.Date.IsZero -}}
+  {{- $schema = merge $schema (dict "datePublished" ($page.Date.Format "2006-01-02T15:04:05Z07:00")) -}}
+{{- end -}}
+{{- if not $page.Lastmod.IsZero -}}
+  {{- $schema = merge $schema (dict "dateModified" ($page.Lastmod.Format "2006-01-02T15:04:05Z07:00")) -}}
+{{- end -}}
+{{- with $pageDescription }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
 {{- with $page.Params.image -}}
   {{- $img := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
   {{- $schema = merge $schema (dict "image" $img) -}}

--- a/layouts/partials/schemaorg/webpage.html
+++ b/layouts/partials/schemaorg/webpage.html
@@ -51,11 +51,7 @@
 {{- end -}}
 
 {{- $pageName := partial "helpers/page-display-title.html" (dict "page" $page) -}}
-{{- $pageDescription := $page.Description -}}
-{{- if and (eq $page.Kind "term") (eq $page.Data.Singular "components") -}}
-  {{- $componentName := partial "helpers/component-display-name.html" (dict "page" $page) -}}
-  {{- $pageDescription = printf "Explore flow templates that use the %s component. See related automations, integration examples, and ways to use this component in workflows." $componentName -}}
-{{- end -}}
+{{- $pageDescription := partial "helpers/page-meta-description.html" (dict "page" $page) -}}
 
 {{- $schema := dict "@context" "https://schema.org" "@type" $pageType "@id" $page.Permalink "url" $page.Permalink "name" $pageName "inLanguage" $page.Language.LanguageCode "isPartOf" $isPartOf "publisher" $publisher -}}
 {{- if not $page.Date.IsZero -}}

--- a/layouts/partials/sections/banners/mini-banner-cta.html
+++ b/layouts/partials/sections/banners/mini-banner-cta.html
@@ -33,6 +33,7 @@
 {{ $primaryUrl := partial "helpers/get-translated-url.html" (dict "url" (.primaryUrl | default "/demo/")) }}
 {{ $secondaryText := .secondaryText | default (i18n "cta_banner.secondary_button") | default "Start 30-days free trial" }}
 {{ $secondaryUrl := partial "helpers/get-translated-url.html" (dict "url" (.secondaryUrl | default "/trial/")) }}
+{{ $logoAlt := .logoAlt | default (printf "%s logo" site.Title) }}
 
 <div class="mini-banner-cta min-h-[72px] rounded-xl border border-gray-200 overflow-hidden my-6">
   <div class="bg-gray-100 min-h-[72px] flex flex-col lg:flex-row lg:items-center gap-4 p-3 md:p-4 lg:py-3">
@@ -41,7 +42,7 @@
         {{ $logo := site.Params.logo_icon }}
         {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
           {{ $logoUrl := partial "functions/get-static-url.html" (dict "path" (printf "/images/%s" $logo)) }}
-          <img src="{{ $logoUrl }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
+          <img src="{{ $logoUrl }}" alt="{{ $logoAlt }}" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
         {{ else }}
           {{ partial "icons/rocket-launch-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}

--- a/layouts/partials/sections/banners/mini-banner-newsletter.html
+++ b/layouts/partials/sections/banners/mini-banner-newsletter.html
@@ -31,6 +31,7 @@
 {{ $placeholder := .placeholder | default (i18n "newsletter.placeholder") | default "Email address" }}
 {{ $buttonText := .buttonText | default (i18n "newsletter.button") | default "Subscribe" }}
 {{ $action := .action | default .Site.Params.footer.newsletter_action | default "#" }}
+{{ $logoAlt := .logoAlt | default (printf "%s logo" site.Title) }}
 
 <div class="newsletter-box min-h-[72px] rounded-xl border border-gray-200 overflow-hidden my-6">
   <div class="bg-gray-100 min-h-[72px] flex flex-col lg:flex-row lg:items-center gap-4 p-3 md:p-4 lg:py-3">
@@ -39,7 +40,7 @@
         {{ $logo := site.Params.logo_icon }}
         {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
           {{ $logoUrl := partial "functions/get-static-url.html" (dict "path" (printf "/images/%s" $logo)) }}
-          <img src="{{ $logoUrl }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
+          <img src="{{ $logoUrl }}" alt="{{ $logoAlt }}" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
         {{ else }}
           {{ partial "icons/envelope-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}

--- a/layouts/partials/social-meta.html
+++ b/layouts/partials/social-meta.html
@@ -13,29 +13,7 @@
 }}
 {{ $ogLocale := index $ogLocaleMap site.Language.LanguageCode | default (replace site.Language.LanguageCode "-" "_") }}
 
-{{ $metaDescription := "" }}
-{{ if and (eq .Kind "term") (eq .Data.Singular "components") }}
-  {{ $componentName := partial "helpers/component-display-name.html" (dict "page" .) }}
-  {{ $metaDescription = printf "Explore flow templates that use the %s component. See related automations, integration examples, and ways to use this component in workflows." $componentName }}
-{{ else }}
-  {{ with .Params.description }}
-    {{ $metaDescription = . }}
-  {{ else }}
-    {{ with .Description }}
-      {{ $metaDescription = . }}
-    {{ else }}
-      {{ with .Params.summary }}
-        {{ $metaDescription = . }}
-      {{ else }}
-        {{ with site.Params.description }}
-          {{ $metaDescription = . }}
-        {{ end }}
-      {{ end }}
-    {{ end }}
-  {{ end }}
-{{ end }}
-{{ $metaDescription = replace $metaDescription "[year]" (now.Format "2006") }}
-{{ $metaDescription = $metaDescription | plainify | htmlUnescape | chomp }}
+{{ $metaDescription := partial "helpers/page-meta-description.html" (dict "page" .) }}
 {{ if gt (len $metaDescription) 160 }}
   {{ $metaDescription = truncate 157 "..." $metaDescription }}
 {{ end }}

--- a/layouts/partials/social-meta.html
+++ b/layouts/partials/social-meta.html
@@ -18,7 +18,7 @@
   {{ $metaDescription = truncate 157 "..." $metaDescription }}
 {{ end }}
 
-{{ $pageTitle := partial "helpers/page-display-title.html" (dict "page" .) }}
+{{ $pageTitle := partial "helpers/page-seo-title.html" (dict "page" .) }}
 {{ $metaTitle := cond .IsHome ($pageTitle | default site.Title) (printf "%s | %s" $pageTitle site.Title) }}
 
 <!-- SEO Meta Tags -->

--- a/layouts/partials/social-meta.html
+++ b/layouts/partials/social-meta.html
@@ -13,8 +13,38 @@
 }}
 {{ $ogLocale := index $ogLocaleMap site.Language.LanguageCode | default (replace site.Language.LanguageCode "-" "_") }}
 
+{{ $metaDescription := "" }}
+{{ if and (eq .Kind "term") (eq .Data.Singular "components") }}
+  {{ $componentName := partial "helpers/component-display-name.html" (dict "page" .) }}
+  {{ $metaDescription = printf "Explore flow templates that use the %s component. See related automations, integration examples, and ways to use this component in workflows." $componentName }}
+{{ else }}
+  {{ with .Params.description }}
+    {{ $metaDescription = . }}
+  {{ else }}
+    {{ with .Description }}
+      {{ $metaDescription = . }}
+    {{ else }}
+      {{ with .Params.summary }}
+        {{ $metaDescription = . }}
+      {{ else }}
+        {{ with site.Params.description }}
+          {{ $metaDescription = . }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ $metaDescription = replace $metaDescription "[year]" (now.Format "2006") }}
+{{ $metaDescription = $metaDescription | plainify | htmlUnescape | chomp }}
+{{ if gt (len $metaDescription) 160 }}
+  {{ $metaDescription = truncate 157 "..." $metaDescription }}
+{{ end }}
+
+{{ $pageTitle := partial "helpers/page-display-title.html" (dict "page" .) }}
+{{ $metaTitle := cond .IsHome ($pageTitle | default site.Title) (printf "%s | %s" $pageTitle site.Title) }}
+
 <!-- SEO Meta Tags -->
-<meta name="description" content="{{ with .Params.description }}{{ replace . "[year]" (now.Format "2006") }}{{ else }}{{ with .Description }}{{ replace . "[year]" (now.Format "2006") }}{{ else }}{{ with .Params.summary }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}{{ end }}">
+<meta name="description" content="{{ $metaDescription }}">
 {{ with .Params.keywords }}<meta name="keywords" content="{{ delimit . ", " }}">{{ end }}
 
 <!-- Social Media Meta Tags -->
@@ -23,8 +53,8 @@
 <meta property="og:url" content="{{ .Permalink }}">
 <meta property="og:site_name" content="{{ site.Title }}">
 <meta property="og:locale" content="{{ $ogLocale }}">
-<meta property="og:title" content="{{ if .IsHome }}{{ site.Title }}{{ else }}{{ replace .Title "[year]" (now.Format "2006") }} | {{ site.Title }}{{ end }}">
-<meta property="og:description" content="{{ with .Params.description }}{{ replace . "[year]" (now.Format "2006") }}{{ else }}{{ with .Description }}{{ replace . "[year]" (now.Format "2006") }}{{ else }}{{ with .Params.summary }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}{{ end }}">
+<meta property="og:title" content="{{ $metaTitle }}">
+<meta property="og:description" content="{{ $metaDescription }}">
 
 <!-- Image selection logic -->
 {{ $ogImage := "" }}
@@ -47,6 +77,13 @@
     {{ end }}
   {{ end }}
 {{ end }}
+{{ if eq $ogImage "" }}
+  {{ with site.Params.organization.logo }}
+    {{ $ogImage = partial "functions/get-static-url.html" (dict "path" .) }}
+  {{ else }}
+    {{ $ogImage = absURL "/images/logo.svg" }}
+  {{ end }}
+{{ end }}
 
 <meta property="og:image" content="{{ $ogImage }}">
 <meta property="og:image:width" content="1200">
@@ -56,6 +93,6 @@
 <meta name="twitter:card" content="summary_large_image">
 {{ with site.Params.social.twitter }}<meta name="twitter:site" content="{{ . }}">{{ end }}
 <meta name="twitter:url" content="{{ .Permalink }}">
-<meta name="twitter:title" content="{{ if .IsHome }}{{ site.Title }}{{ else }}{{ replace .Title "[year]" (now.Format "2006") }} | {{ site.Title }}{{ end }}">
-<meta name="twitter:description" content="{{ with .Params.description }}{{ replace . "[year]" (now.Format "2006") }}{{ else }}{{ with .Description }}{{ replace . "[year]" (now.Format "2006") }}{{ else }}{{ with .Params.summary }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}{{ end }}">
+<meta name="twitter:title" content="{{ $metaTitle }}">
+<meta name="twitter:description" content="{{ $metaDescription }}">
 <meta name="twitter:image" content="{{ $ogImage }}">

--- a/layouts/shortcodes/youtubevideo.html
+++ b/layouts/shortcodes/youtubevideo.html
@@ -8,6 +8,7 @@
   - class: Additional CSS classes (optional)
   - width: Video width (optional, default: "100%")
   - height: Video height (optional, default: "auto")
+  - uploadDate: Stable upload date for VideoObject schema (optional, ISO date)
 @usage:
 {{< youtubevideo 
   videoID="dQw4w9WgXcQ" 
@@ -23,6 +24,7 @@
 {{ $class := default "" (.Get "class") }}
 {{ $width := default "100%" (.Get "width") }}
 {{ $height := default "auto" (.Get "height") }}
+{{ $uploadDate := .Get "uploadDate" }}
 
 {{ partial "components/media/video.html" (dict 
   "videoID" $videoID 
@@ -31,4 +33,6 @@
   "class" $class
   "width" $width
   "height" $height
+  "page" .Page
+  "uploadDate" $uploadDate
 ) }}


### PR DESCRIPTION
## Summary
- Adds reusable display-title helpers for component and integration pages
- Uses display titles in head, social metadata, WebPage schema, and breadcrumbs
- Avoids zero-date WebPage schema fields and provides an organization logo fallback for social images
- Adds translation patterns for component/integration display titles

## Testing
- Will be validated from FlowHunt via npm run deploy:test after updating the submodule pointer