### PR TITLE
fix(cookie-banner): prevent scroll-to-top + URL hash on consent button clicks

### DIFF
--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -45,24 +45,29 @@ document.addEventListener('DOMContentLoaded', function() {
 
   document.addEventListener('click', function(event) {
     if (event.target.closest('[data-cookie-consent="accept-all"]')) {
+      event.preventDefault();
       setConsent('all');
       hideBanner();
     }
 
     if (event.target.closest('[data-cookie-consent="accept-necessary"]')) {
+      event.preventDefault();
       setConsent('necessary');
       hideBanner();
     }
 
     if (event.target.closest('[data-cookie-consent="settings"]')) {
+      event.preventDefault();
       modal?.classList.remove('hidden');
     }
 
     if (event.target.closest('[data-cookie-settings-close]')) {
+      event.preventDefault();
       modal?.classList.add('hidden');
     }
 
     if (event.target.closest('[data-cookie-settings-save]')) {
+      event.preventDefault();
       const allowAnalytics = analyticsCheckbox?.checked || false;
       setConsent(allowAnalytics ? 'all' : 'necessary');
       modal?.classList.add('hidden');


### PR DESCRIPTION
## Problem

Cookie banner buttons in `cookies-bar.html` render as `<a href=\"#\">` (via the buttons partial defaulting to `element=\"link\"`). The click handlers in `cookie-consent.js` previously did not call `event.preventDefault()`, so clicking any consent button caused:

- Page scrolled to the top
- URL changed to `.../#`
- Looked like a refresh to users (without actually being one)

Confirmed via Chrome DevTools Network tab — no document reload, but visual jump + URL hash change.

## Fix

Add `event.preventDefault()` to all 5 consent click handlers:

- `data-cookie-consent=\"accept-all\"`
- `data-cookie-consent=\"accept-necessary\"`
- `data-cookie-consent=\"settings\"`
- `data-cookie-settings-close`
- `data-cookie-settings-save`

No behavioural change to consent storage or analytics update logic — only the unwanted native anchor navigation is suppressed.

## Test plan

- [ ] Open the site in incognito
- [ ] Scroll down on the page
- [ ] Click \"Accept All\" → banner disappears, **page stays in the same scroll position**, URL stays clean (no `#`)
- [ ] Repeat with \"Necessary\", \"Settings\", \"Save\" — same expected behavior
- [ ] Cookie `cookie_consent_status` is set correctly, `updateGoogleAnalyticsConsent` fires
- [ ] No regressions in tracking partial consent flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)