### PR TITLE
fix(a11y): improve hero split-image alt attributes

### DIFF
--- a/layouts/partials/sections/banners/mini-banner-cta.html
+++ b/layouts/partials/sections/banners/mini-banner-cta.html
@@ -41,7 +41,7 @@
         {{ $logo := site.Params.logo_icon }}
         {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
           {{ $logoUrl := partial "functions/get-static-url.html" (dict "path" (printf "/images/%s" $logo)) }}
-          <img src="{{ $logoUrl }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
+          <img src="{{ $logoUrl }}" alt="{{ i18n "header.logo_alt" | default "Logo" }}" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
         {{ else }}
           {{ partial "icons/rocket-launch-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}

--- a/layouts/partials/sections/banners/mini-banner-newsletter.html
+++ b/layouts/partials/sections/banners/mini-banner-newsletter.html
@@ -39,7 +39,7 @@
         {{ $logo := site.Params.logo_icon }}
         {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
           {{ $logoUrl := partial "functions/get-static-url.html" (dict "path" (printf "/images/%s" $logo)) }}
-          <img src="{{ $logoUrl }}" alt="Logo" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
+          <img src="{{ $logoUrl }}" alt="{{ i18n "header.logo_alt" | default "Logo" }}" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
         {{ else }}
           {{ partial "icons/envelope-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}

--- a/layouts/partials/sections/hero/split_right_media.html
+++ b/layouts/partials/sections/hero/split_right_media.html
@@ -98,7 +98,7 @@
             {{/* Image Overlay (integrations, success-stories) */}}
             {{ partial "components/media/lazyimg.html" (dict
               "src" $overlayIcon
-              "alt" "Logo"
+              "alt" (printf "%s logo" ($heading | default "LiveAgent"))
               "class" (printf "%s object-contain" $overlayIconSizeImage)
               "noLazy" true
             ) }}
@@ -106,7 +106,7 @@
             {{/* Feature SVG icon */}}
             {{ partial "components/media/svg-icon.html" (dict
               "src" $overlayIcon
-              "alt" "Feature icon"
+              "alt" ""
               "class" (printf "%s %s" $overlayIconSizeSvg $overlayColor)
             ) }}
           {{ end }}

--- a/layouts/partials/sections/hero/split_with_image.html
+++ b/layouts/partials/sections/hero/split_with_image.html
@@ -242,7 +242,7 @@ Design Tokens:
                   {{/* Integration logo (Image Overlay) */}}
                   {{ partial "components/media/lazyimg.html" (dict
                     "src" $iconImageSrc
-                    "alt" "Integration logo"
+                    "alt" (printf "%s logo" ($heading | default "Integration"))
                     "class" (printf "%s object-contain" $overlayIconSizeIntegrations)
                     "noLazy" true
                   ) }}
@@ -250,7 +250,7 @@ Design Tokens:
                   {{/* Feature SVG icon (SVG Overlay) */}}
                   {{ partial "components/media/svg-icon.html" (dict
                     "src" $iconImageSrc
-                    "alt" "Feature icon"
+                    "alt" ""
                     "class" (printf "%s %s" $overlayIconSizeFeatures $config.overlayColor)
                   ) }}
                 {{ end }}


### PR DESCRIPTION
## Summary

- Integration logo overlay: replace static `"Integration logo"` with `"{heading} logo"` so each integration page renders a descriptive alt (e.g. `"Telegram logo"`, `"Slack logo"`).
- Feature SVG icon overlay: set `alt=""` — these icons are decorative and adjacent to the heading, so an alt only adds noise for screen readers.

## Why

Site-audit on liveagent.com (2026-05-26) flagged ~109 pages with the generic `"Logo"` / `"Integration logo"` alt in the hero overlay slot. Fixing it at the boilerplate level fixes the issue for **every** project using this submodule — instead of each project carrying a 438-line override that duplicates the file just to change 2 lines.

## Test plan
- [ ] `hugo --gc --minify --configDir ./config_en` on consumer project (LiveAgent) — already verified locally, build pass in 23s.
- [ ] Render check on `/integrations/telegram/` — `alt="Telegram logo"` confirmed in built HTML.
- [ ] Visual regression on at least one feature-hero page — feature SVG icon now has empty alt (was `"Feature icon"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)