### PR TITLE
fix(linkbuilding): only linkify prose — skip title/head, chrome, forms, quotes

### DIFF
--- a/scripts/linkbuilding_frontmatter.py
+++ b/scripts/linkbuilding_frontmatter.py
@@ -35,9 +35,10 @@ LANG_CODES = {
 SKIP_TEXT_PARENTS = {
     "a", "button", "script", "style", "textarea", "select", "option",
     "code", "pre", "kbd", "samp", "svg", "math", "noscript",
+    "title", "head",
     "h1", "h2", "h3", "h4", "h5", "h6",
 }
-SKIP_TEXT_ANCESTORS = {"a", "h1", "h2", "h3", "h4", "h5", "h6"}
+SKIP_TEXT_ANCESTORS = {"a", "head", "h1", "h2", "h3", "h4", "h5", "h6"}
 
 _hugo_config_cache: dict[str, Any] = {}
 

--- a/scripts/linkbuilding_frontmatter.py
+++ b/scripts/linkbuilding_frontmatter.py
@@ -36,9 +36,18 @@ SKIP_TEXT_PARENTS = {
     "a", "button", "script", "style", "textarea", "select", "option",
     "code", "pre", "kbd", "samp", "svg", "math", "noscript",
     "title", "head",
+    "label", "summary", "legend", "figcaption", "caption", "th",
+    "cite", "time",
     "h1", "h2", "h3", "h4", "h5", "h6",
 }
-SKIP_TEXT_ANCESTORS = {"a", "head", "h1", "h2", "h3", "h4", "h5", "h6"}
+# Container elements whose text should never be linkified, regardless of how
+# deeply nested it is (site chrome, forms, figures, quotes, contact blocks).
+SKIP_TEXT_ANCESTORS = {
+    "a", "head",
+    "nav", "header", "footer", "aside", "form", "figure", "blockquote",
+    "address",
+    "h1", "h2", "h3", "h4", "h5", "h6",
+}
 
 _hugo_config_cache: dict[str, Any] = {}
 


### PR DESCRIPTION
## Problem

`scripts/linkbuilding_frontmatter.py` injected internal `<a>` links into non-prose regions of the page. The most visible symptom was the **`<title>`** — invalid HTML, visible markup in the browser tab:

```html
<title>FlowHunt — <a class="prose-links" href="/components/AIAgent/">AI Agents</a> for Marketing, SEO, and Growth</title>
```

A full English build (3,194 pages) revealed the same root cause leaking links into other regions:

| Region | Pages affected | Note |
|---|---|---|
| `nav` / `header` | **~31%** (123/400 sampled) | mega-menu descriptions, e.g. "generative" → /glossary/ |
| `footer` | many | footer text |
| `blockquote` | several | customer testimonials/quotes |
| `aside` | a few | sidebars / promo widgets |
| `address` | about-us | contact block |
| `title` | `/`, `/ai-chatbot/`, … | any title matching a keyword |

### Root cause

The text-node walker only skipped a small fixed set of tags. `title`/`head` were missing, and no site-chrome/structural containers were excluded. The legacy `linkbuilding.py` had a broader `SKIP_TAGS` guard; it was not carried over when linkbuilding moved to the frontmatter-based rewrite.

## Fix

Extend the two skip sets so linkbuilding targets **prose content only**:

- `SKIP_TEXT_ANCESTORS` (containers, text nests deep): `nav, header, footer, aside, form, figure, blockquote, address, head`
- `SKIP_TEXT_PARENTS` (leaf/inline): `title, label, summary, legend, figcaption, caption, th, cite, time`

## Verification

Full English build + `linkbuilding_frontmatter.py --lang en`, scanned across all built pages:

- **0** `prose-links` in `title`, `nav`, `header`, `footer`, `aside`, `form`, `blockquote`, `address`, and the caption/label/etc. tags
- Body links preserved — ~20k links added as before
- Confirmed live on a running dev server (home + about-us clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)