### PR TITLE
fix: restore video provider auto-detection for custom videos

### DIFF
--- a/layouts/partials/components/media/video.html
+++ b/layouts/partials/components/media/video.html
@@ -66,7 +66,7 @@
 {{ $controls := (and (not $useLightbox) (.controls | default true)) }}
 {{ $poster := .poster }}
 {{ $posterHeight := .posterHeight | default "" }}
-{{ $provider := .provider | default "youtube" }}
+{{ $provider := .provider | default "" }}
 {{ $pureVideo := .pureVideo | default false }}
 
 {{ $noLazy := .noLazy | default false }}


### PR DESCRIPTION
## Problem

`components/media/video.html` defaults `\$provider` to `"youtube"`. This makes the auto-detection block (`{{ if not \$provider }}`, ~line 78) **dead code** — `not "youtube"` is always false, so a non-YouTube `src` is never reclassified as `custom`.

Consequence: any caller that does **not** pass `provider` explicitly — notably the `{{< lazyvideo >}}` shortcode — renders custom `.mp4`/`.webm` files as **broken YouTube embeds**, because the file path gets passed through as a YouTube video ID.

## Root cause

Regression in `25e231e` (PR #193, 2025-10-21):

```diff
-{{ \$provider := .provider | default "" }}
+{{ \$provider := .provider | default "youtube" }}
```

Before the change, the empty-string default (falsy) let the auto-detection run.

## Fix

One-line revert to `default ""`. Auto-detection now resolves:
- YouTube URL / `videoID` → `youtube`
- everything else → `custom`

## Impact

- Shared theme submodule → affects **LiveAgent, PostAffiliatePro, FlowHunt** (all currently broken for custom `.mp4` via `lazyvideo`).
- Explicit-provider callers (hero sections, `youtubevideo`, `lazyimg_external`'s `cond \$isYouTube`) are **unaffected** — they pass `provider` directly.

## Verification

Built a LiveAgent test page with `{{< lazyvideo src="/images/.../video.mp4" autoplay loop muted >}}` — `hugo --gc --minify` passes and the page now renders a proper custom `<video><source ...></video>` instead of a broken YouTube iframe.

**Risk tier:** Tier 3 (theme submodule — propagates to all sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)