### PR TITLE
Switch embedding model to google/embeddinggemma-300m

### DIFF
--- a/scripts/generate_clustering.py
+++ b/scripts/generate_clustering.py
@@ -30,7 +30,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from embedding_cache import EmbeddingCache, shared_sqlite_cache_path
 
 # Constants
-MODEL_NAME = "Alibaba-NLP/gte-multilingual-base"
+MODEL_NAME = "google/embeddinggemma-300m"
 MIN_CLUSTER_SIZE = 5  # Minimum pages per cluster
 MIN_SAMPLES = 3  # Minimum samples for core point
 MAX_CLUSTER_SIZE = 5  # Maximum pages before creating subclusters (recursive subdivision)

--- a/scripts/generate_paragraph_linkbuilding.py
+++ b/scripts/generate_paragraph_linkbuilding.py
@@ -52,7 +52,7 @@ import toml_frontmatter as frontmatter
 from sync_translation_urls import ensure_url_slashes, get_directory_url_path, get_hugo_config
 
 
-MODEL_NAME = "Alibaba-NLP/gte-multilingual-base"
+MODEL_NAME = "google/embeddinggemma-300m"
 
 _TOKEN_RE = re.compile(r"[^\W\d_][\w'’.-]*", re.UNICODE)
 _SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")

--- a/scripts/generate_related_content.py
+++ b/scripts/generate_related_content.py
@@ -41,7 +41,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from embedding_cache import EmbeddingCache, shared_sqlite_cache_path
 
 # Constants
-MODEL_NAME = "Alibaba-NLP/gte-multilingual-base"  # Smaller model that works well with sentence-transformers
+MODEL_NAME = "google/embeddinggemma-300m"
 MAX_TEXT_LENGTH = 2000  # Align with generate_site_audit so embedding cache is shared
 TOP_K = 3  # Number of related content items to find
 

--- a/scripts/generate_site_audit.py
+++ b/scripts/generate_site_audit.py
@@ -49,7 +49,7 @@ from bs4 import BeautifulSoup
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from embedding_cache import EmbeddingCache, shared_sqlite_cache_path
 
-DEFAULT_MODEL = "Alibaba-NLP/gte-multilingual-base"
+DEFAULT_MODEL = "google/embeddinggemma-300m"
 DEFAULT_MAX_CHARS = 2000
 DEFAULT_DUP_THRESHOLD = 0.92
 DEFAULT_DUP_KNN = 10


### PR DESCRIPTION
## Summary

- Replaces `Alibaba-NLP/gte-multilingual-base` with `google/embeddinggemma-300m` in all 4 embedding scripts
- Affects: `generate_clustering.py`, `generate_related_content.py`, `generate_paragraph_linkbuilding.py`, `generate_site_audit.py`

## Why

EmbeddingGemma-300M is the #1 ranked open multilingual embedding model under 500M parameters on MTEB, with a notable clustering improvement (+7.8) — directly relevant to our clustering and similarity use cases. Same ~300M parameter count, same sentence-transformers loading interface.

## Compatibility

- All scripts truncate input to 2000 characters (~400–600 tokens), safely within EmbeddingGemma's 2048-token context window
- `trust_remote_code=True` in `embedding_cache.py` is harmless for this model
- Existing `.audit_cache/embedding-cache.sqlite3` caches will be invalidated on first run (cache keys include model name) and regenerated automatically

## Test plan

- [ ] Run `generate_clustering.py` on a site and verify clusters are produced
- [ ] Run `generate_related_content.py` and verify related content output
- [ ] Run `generate_paragraph_linkbuilding.py` and compare link suggestions quality
- [ ] Run `generate_site_audit.py` and verify embeddings + similarity scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)