### PR TITLE
fix(scripts): make front matter parsers BOM-safe

### DIFF
--- a/scripts/extract_keywords.py
+++ b/scripts/extract_keywords.py
@@ -220,6 +220,8 @@ def update_frontmatter(content: str, keywords: list[str]) -> str:
     corrupts complex TOML structures (nested tables, inline tables, booleans).
     The line-based approach safely adds/updates only the keywords line.
     """
+    # Strip a leading BOM (not whitespace) so the +++ checks below match.
+    content = content.lstrip('﻿')
     if not content.startswith('+++'):
         return content
 
@@ -257,7 +259,8 @@ def update_frontmatter(content: str, keywords: list[str]) -> str:
 def drop_keywords_from_file(file_path: Path) -> bool:
     """Remove keywords from a single file's frontmatter."""
     try:
-        content = file_path.read_text(encoding='utf-8')
+        # utf-8-sig strips a leading BOM so the +++ check below matches.
+        content = file_path.read_text(encoding='utf-8-sig')
         if not content.startswith('+++'):
             return False
 

--- a/scripts/offload_replicate_images.py
+++ b/scripts/offload_replicate_images.py
@@ -383,6 +383,8 @@ def process_md_file(md_path):
         print(f"!!! ERROR: Failed to read file {md_path}: {e}")
         return
     # Split TOML frontmatter and body
+    # Strip a leading BOM (not whitespace) so the +++ check below matches.
+    content = content.lstrip('﻿')
     if content.startswith('+++'):
         end_idx = content.find('+++', 3)
         if end_idx != -1:

--- a/scripts/sync_content_attributes.py
+++ b/scripts/sync_content_attributes.py
@@ -51,7 +51,11 @@ en_content_dir = content_dir / 'en'
 
 def extract_front_matter(file_path):
     """Extract TOML front matter from markdown file"""
-    with open(file_path, 'r', encoding='utf-8') as f:
+    # utf-8-sig strips a leading BOM if present. Without this, a BOM defeats the
+    # `^\s*\+\+\+` match below (the BOM is not whitespace), the front matter parses
+    # as empty, and callers wrongly prepend a fresh `+++ date +++` block — producing
+    # a broken double front matter.
+    with open(file_path, 'r', encoding='utf-8-sig') as f:
         content = f.read()
     
     # Look for front matter between +++ delimiters

--- a/scripts/sync_translation_urls.py
+++ b/scripts/sync_translation_urls.py
@@ -90,9 +90,13 @@ def extract_front_matter(file_path: Path) -> Tuple[str, Dict, str, str]:
     """Extract TOML front matter from markdown file
     Returns: (original_front_matter_text, parsed_dict, remaining_content, full_content)
     """
-    with open(file_path, 'r', encoding='utf-8') as f:
+    # utf-8-sig strips a leading BOM. Without this, a BOM defeats the `^\+\+\+`
+    # match below (the BOM is not whitespace), the front matter parses as empty,
+    # and update_front_matter_url_only prepends a fresh `+++ url +++` block —
+    # producing a broken double front matter.
+    with open(file_path, 'r', encoding='utf-8-sig') as f:
         content = f.read()
-    
+
     # Look for front matter between +++ delimiters
     match = re.match(r'^\+\+\+\s*\n*(.*?)\n*\+\+\+\s*\n*', content, re.DOTALL)
     if match:

--- a/scripts/toml_frontmatter.py
+++ b/scripts/toml_frontmatter.py
@@ -42,6 +42,8 @@ def parse_toml_frontmatter(content: str) -> Tuple[dict, str]:
     Returns:
         Tuple of (metadata dict, body content)
     """
+    # Strip a leading BOM (not whitespace) so the +++ regex matches.
+    content = content.lstrip('﻿')
     # Match TOML frontmatter (between +++ markers)
     match = re.match(r'^\+\+\+\s*\n(.*?)\n\+\+\+\s*\n?(.*)', content, re.DOTALL)
 
@@ -190,7 +192,7 @@ class TOMLHandler:
     FM_BOUNDARY = re.compile(r'^\+\+\+\s*$', re.MULTILINE)
 
     def detect(self, text: str) -> bool:
-        return text.startswith('+++')
+        return text.lstrip('﻿').startswith('+++')
 
     def load(self, fm: str) -> dict:
         try:
@@ -228,6 +230,8 @@ def update_frontmatter_attribute(content: str, key: str, value: Any) -> str:
     Returns:
         Updated content with the attribute modified
     """
+    # Strip a leading BOM (not whitespace) so the +++ checks below match.
+    content = content.lstrip('﻿')
     if not content.startswith('+++'):
         return content
 

--- a/scripts/update-content-dates.py
+++ b/scripts/update-content-dates.py
@@ -43,7 +43,8 @@ def get_staged_files() -> list[str]:
 
 def read_blob(ref: str) -> str | None:
     code, out = git('show', ref)
-    return out if code == 0 else None
+    # Strip a leading BOM so the `^\+\+\+` front matter regexes below match.
+    return out.lstrip('﻿') if code == 0 else None
 
 
 def update_date(content: str, new_date: str) -> str:
@@ -92,7 +93,8 @@ def main() -> None:
 
         file_path = Path(repo_root) / rel_path
         try:
-            disk_content = file_path.read_text(encoding='utf-8')
+            # utf-8-sig strips a leading BOM so update_date's regex matches.
+            disk_content = file_path.read_text(encoding='utf-8-sig')
         except OSError:
             continue
 


### PR DESCRIPTION
## Problem

Content `.md` files can carry a leading **UTF-8 BOM** before the `+++` front matter delimiter. A BOM is **not whitespace**, so the front matter regexes (`^\+\+\+`, `^\s*\+\+\+`) and `content.startswith('+++')` checks fail to match. The parser then returns an **empty** front matter, and writer scripts fall into their "add missing field" branch and **prepend a brand-new `+++ ... +++` block** on top of the real front matter.

The result is a **broken double front matter** — Hugo parses only the first (injected) block and the real `title`/`description`/`image`/`keywords` fall into the page body.

### This actually happened
`sync_content_attributes.py` injected a duplicate `+++ date +++` block into **28 `content/en/blog/*.md`** files (tell-tale: dates clustered in a 6-second window from per-file `datetime.now()`). Content repair is handled in a separate FlowHunt-hugo PR.

## Fix

Make every front matter parser tolerate a leading BOM (`encoding='utf-8-sig'` on read, or `content.lstrip('﻿')` before the `+++` check):

| Script | Role | Fix |
|---|---|---|
| `sync_content_attributes.py` | **the injector** | read with `utf-8-sig` |
| `sync_translation_urls.py` | same latent bug via `url` block (pipeline) | read with `utf-8-sig` |
| `update-content-dates.py` | pre-commit date hook | `utf-8-sig` disk read + strip BOM from `git show` blobs |
| `toml_frontmatter.py` | shared parser (imported by 9 scripts) | `lstrip` BOM in `parse` / `update_frontmatter_attribute` / `detect` |
| `extract_keywords.py` | keyword writer (pipeline) | `lstrip` BOM / `utf-8-sig` before `+++` checks |
| `offload_replicate_images.py` | image offloader (pipeline) | `lstrip` BOM before the `+++` split |

The 9 scripts that import `toml_frontmatter` (linkbuilding, related-content, clustering, site-audit, amplify-redirects, …) inherit the fix automatically.

## Verification

- `py_compile` passes on all 6 changed scripts.
- Reproduction: a BOM-prefixed sample now parses correctly (`date`/`title` present → the prepend branch no longer fires); `update_frontmatter_attribute` keeps exactly 2 `+++` delimiters (no doubling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)