### PR TITLE
fix(cls): eliminate mobile font-swap layout shift (font-display: optional)

### DIFF
--- a/assets/css/fonts.css
+++ b/assets/css/fonts.css
@@ -4,6 +4,13 @@
   font-style: normal;
   font-weight: 100 900; /* supports all weights from 100-900 */
   src: url('/fonts/inter/Inter-VariableFont_opsz,wght.woff2') format('woff2-variations');
-  font-display: swap;
+  /* `optional` (not `swap`) to eliminate mobile CLS: on a cold load, if Inter
+     isn't ready by first paint the browser keeps the fallback for the whole
+     page instead of swapping mid-session. Inter's wider metrics reflow text on
+     narrow viewports (~29px hero shift on mobile vs ~1px on desktop), which was
+     the dominant cause of the mobile Core Web Vitals CLS regression. The font is
+     preloaded in head.html, so it makes the ~100ms `optional` window on most
+     visits; later visits use the cached font with zero shift. */
+  font-display: optional;
 }
 

--- a/layouts/partials/components/logos/simple.html
+++ b/layouts/partials/components/logos/simple.html
@@ -78,7 +78,11 @@
 
         <div class="mx-auto flex flex-wrap {{ $justifyClass }} items-center gap-8 sm:gap-12 md:gap-16">
           {{ range $index, $logo := $logos }}
-            <div class="flex items-center justify-center">
+            {{/* min-h-12 reserves the logo row height so the flex strip doesn't
+                 collapse→expand as the lazy SVG logos load (these are SVGs, which
+                 Hugo's imageConfig can't measure, so lazyimg emits no width/height).
+                 Prevents a mobile CLS shift in the partner/customer logo strip. */}}
+            <div class="flex items-center justify-center min-h-12">
               {{ $class := "block max-h-12 h-10 lg:h-12 w-full object-contain" }}
               {{ if $logo.url }}<a href="{{ partial "helpers/get-translated-url.html" (dict "url" $logo.url) }}" target="_blank" rel="noopener noreferrer" title="{{ $logo.name }}">{{ end }}
                   {{ partial "components/media/lazyimg.html" (dict


### PR DESCRIPTION
## Problem

Mobile-only Cumulative Layout Shift (CLS) regression — desktop CLS stayed **Good**, mobile went **Poor** (>0.25) across the long-tail templated pages (mcp-servers, integrations, glossary, etc.).

Root cause, confirmed by deterministic measurement on production (fallback font vs Inter, same page):

| Viewport | Hero shift when Inter swaps in |
|---|---|
| **Mobile (412px)** | **+29px** down |
| **Desktop (1280px)** | **+1px** |

The Inter `@font-face` uses `font-display: swap`, so on a cold load the browser paints in the system fallback, then swaps to Inter. Inter's wider metrics make hero/body text **wrap to extra lines on narrow viewports**, shoving content down ~29px on mobile vs ~1px on desktop — a ~29× asymmetry that exactly matches the "mobile Poor / desktop Good" signature. It's a *chronic* ~0.08 baseline (the font config has been `swap` since mid-2025) that compounds when the swap lands mid-scroll on slow connections (measured 0.08 load → 0.21 scroll session).

## Changes

- **`assets/css/fonts.css`** — `font-display: swap` → **`optional`**. If Inter isn't ready by first paint, the browser keeps the fallback for the whole page instead of swapping mid-session → no swap-induced reflow on any platform. The font is preloaded in `head.html`, so it makes the ~100ms `optional` window on most visits; repeat views use the cached font with zero shift.
  - Chosen over a metric-matched fallback (`size-adjust` / `local('Arial')`) because Arial is absent on **Android** — the affected cohort — making that approach unreliable there.
- **`layouts/partials/components/logos/simple.html`** — add `min-h-12` to the partner-logo cells so the flex strip doesn't collapse→expand as the lazy **SVG** logos load (SVGs get no width/height from Hugo's `imageConfig`, and this is the only logos partial using `flex-wrap` instead of a fixed grid). Secondary, smaller contributor (~0.015).

## Trade-off

With `optional`, a small share of **first-time** visitors on slow connections may briefly see the system font for that first pageview (Inter applies from cache on the next view). This is the standard Google-recommended way to eliminate font-swap CLS.

## Verification notes

`font-display` was **never** `optional` before — this is an improvement over the historical baseline, not a revert. Re-measure CLS on a **cold** mobile load (warm reloads cache the font and read 0.00, which is why this was easy to miss). Field (CrUX/Search Console) data lags ~28 days, so the "Poor" count won't drop immediately on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)