### PR TITLE
fix(helpers): route /images/ asset links through CDN domain

### DIFF
--- a/layouts/partials/helpers/get-translated-url.html
+++ b/layouts/partials/helpers/get-translated-url.html
@@ -16,6 +16,19 @@
 {{- /* Handle external URLs and anchors - return as-is */ -}}
 {{- if or (hasPrefix $url "http://") (hasPrefix $url "https://") (hasPrefix $url "#") -}}
   {{- $url -}}
+{{- else if hasPrefix $url "/images/" -}}
+  {{- /* Static assets live in cdn-assets and are served from /images/. When the static-assets
+         CDN is enabled, non-image asset links (PDF/ZIP/video downloads) must point at the CDN
+         domain - on the web host the /images/* -> CDN rewrite only covers image extensions, so
+         these otherwise stay on the site domain and 404. See web-issues #4181.
+         If the CDN is NOT enabled (or the project doesn't use it), fall back to the original
+         relLangURL behaviour unchanged, so language-subdir setups are not affected. */ -}}
+  {{- $staticURL := partial "functions/get-static-url.html" (dict "path" $url) -}}
+  {{- if ne $staticURL $url -}}
+    {{- $staticURL -}}
+  {{- else -}}
+    {{- $url | relLangURL -}}
+  {{- end -}}
 {{- else -}}
   {{- /* Try to find the page and get its actual URL from frontmatter */ -}}
   {{- $contentPath := strings.TrimPrefix "/" (strings.TrimSuffix "/" $url) -}}


### PR DESCRIPTION
## Problem

Non-image static asset download links (PDF / ZIP / video) under `/images/` 404 in production. Reported in web-issues #4181 — the "Download manual" / "Download logos" buttons on `/about/branding/` return 404 on prod (work locally).

**Root cause:** image `src` attributes are routed through `get-static-url` (so they pick up the static-assets CDN domain), but links go through `get-translated-url`, which never applies the CDN domain. For a `/images/...` path that matches no page, it falls back to `$url | relLangURL` and stays on the site domain. On the web host the `/images/* -> CDN` rewrite only covers image extensions, so `.pdf` / `.zip` / `.mp4` fall through to the 404 handler. The files themselves are already on the CDN.

## Fix

In `get-translated-url`, detect `/images/` paths and resolve them via `get-static-url`:

- **CDN enabled** (production) → absolute CDN URL where the file actually lives (e.g. `https://images.liveagent.com/images/about/LiveAgent-logo-manual.pdf`, verified `200`).
- **CDN disabled** (local/dev, or projects not using it) → falls back to the original `relLangURL` behaviour **unchanged**, so language-subdir setups are unaffected.

The change only diverges from current behaviour when `staticAssets.enabled = true`, and even then only prepends the correct CDN domain — never a language prefix.

## Cross-project verification

- **LA**: `defaultContentLanguageInSubdir = false`; build with CDN off → links stay relative `/images/...`; with CDN on → `https://images.liveagent.com/images/about/...` (200). No CDN-domain leakage into page / CSS / other links; no content page has `url = "/images/..."`.
- **FlowHunt**: `defaultContentLanguageInSubdir = false`, `staticAssets.domain = https://static.flowhunt.io`, enabled only in production. Live site already serves images from `static.flowhunt.io/images/...`, confirming the `get-static-url` chain (top-level `[staticAssets]` resolves via `site.Language.Params`). FH has no `/images/` download links today → zero practical impact; future ones resolve correctly.
- **Projects without `staticAssets`** → `get-static-url` is a no-op → zero behaviour change.

## Risk

Tier 3 (shared theme submodule — propagates to all consuming sites). Behaviour change is gated behind `staticAssets.enabled`; disabled path is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)