### PR TITLE
fix(pre-commit): make update-content-dates.py run on Python 3.9

### DIFF
--- a/scripts/update-content-dates.py
+++ b/scripts/update-content-dates.py
@@ -12,6 +12,8 @@ Usage (called automatically by .husky/pre-commit):
   python3 themes/boilerplate/scripts/update-content-dates.py
 """
 
+from __future__ import annotations
+
 import re
 import subprocess
 import datetime


### PR DESCRIPTION
## Problem
The pre-commit hook runs \`python3 themes/boilerplate/scripts/update-content-dates.py\`. On macOS the default \`python3\` is **3.9.6**, but the script uses PEP 604 union syntax (\`str | None\`) plus \`list[...]\`/\`tuple[...]\` annotations that only evaluate on **Python 3.10+**. Result: every commit fails with \`TypeError: unsupported operand type(s) for |\` and devs are forced to use \`git commit --no-verify\`.

## Fix
Add \`from __future__ import annotations\` at the top of the script. All annotations are then evaluated lazily as strings, so the 3.10+ syntax no longer runs on 3.9. There is **no runtime union usage** in the script, so this fully restores compatibility with zero behavior change.

## Verification
Ran the script under \`/usr/bin/python3\` (3.9.6) → exits 0 (previously \`TypeError\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)