### PR TITLE
fix(consent): don't fire banner consent update when consent-core owns it

### DIFF
--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -106,7 +106,11 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   function updateAnalyticsConsent(allowed) {
-    if (typeof window.gtag === 'function') {
+    // Consent Mode update: skip when consent-core.js is present (LiveAgent) — it owns
+    // the full 7-parameter update and fires it on the same banner click. Firing this
+    // partial 4-parameter update too would duplicate it in the dataLayer. Sites without
+    // consent-core (e.g. PAP / FlowHunt) still fire it here as before.
+    if (typeof window.gtag === 'function' && !window.consentCore) {
       window.gtag('consent', 'update', {
         'analytics_storage': allowed ? 'granted' : 'denied',
         'ad_storage': allowed ? 'granted' : 'denied',


### PR DESCRIPTION
`updateAnalyticsConsent()` in `assets/js/cookie-consent.js` fired a partial **4-parameter** `gtag('consent','update')` on every banner accept/reject (and on load for returning `all` users).

On sites that also run **consent-core.js** (LiveAgent), consent-core already fires the full **7-parameter** update on the same click — so this produced a **second, redundant consent update** in the dataLayer (reported by the tracking owner).

## Fix
Guard the gtag update with `!window.consentCore`:
- **With consent-core** (LiveAgent) → skipped; consent-core is the single Consent Mode updater.
- **Without consent-core** (PAP / FlowHunt) → fires exactly as before.

Capterra / Meta Pixel consent calls are unchanged. `window.consentCore` is set before this handler runs, so the guard is reliable.

## Impact
- LiveAgent: removes the duplicate 4-param consent update.
- PAP / FlowHunt: no change.

## Consumers
Consumed by LiveAgent-hugo via the submodule pointer bump (LiveAgent-hugo PR #599).

🤖 Generated with [Claude Code](https://claude.com/claude-code)