### PR TITLE
feat(linkbuilding): add no-linkbuilding class opt-out (subtree-inherited)

### DIFF
--- a/scripts/linkbuilding_frontmatter.py
+++ b/scripts/linkbuilding_frontmatter.py
@@ -63,6 +63,24 @@ SKIP_TEXT_ANCESTORS = {
     "aside", "form", "figure", "blockquote", "address",
 }
 
+# Opt-out marker: any element carrying this class excludes its ENTIRE subtree
+# from linkbuilding. Checked via find_parent (ancestor walk), so the opt-out is
+# inherited by every descendant text node at any depth — put it once on a
+# banner/section wrapper and nothing inside gets auto-linked.
+NO_LINKBUILDING_CLASS = "no-linkbuilding"
+
+
+def _is_linkbuilding_excluded(tag: Any) -> bool:
+    """True if this element opts out of linkbuilding via the marker class.
+
+    Used as a find_parent predicate so the opt-out is inherited by the whole
+    subtree: a text node is excluded if it OR any ancestor carries the class.
+    """
+    get = getattr(tag, "get", None)
+    if get is None:  # NavigableString / non-Tag — no attributes
+        return False
+    return NO_LINKBUILDING_CLASS in (get("class") or [])
+
 _hugo_config_cache: dict[str, Any] = {}
 
 
@@ -144,6 +162,7 @@ class LinkBuilder:
             and node.parent
             and node.parent.name not in SKIP_TEXT_PARENTS
             and not node.find_parent(SKIP_TEXT_ANCESTORS)
+            and not node.find_parent(_is_linkbuilding_excluded)
         ]
 
         for keyword in keywords:


### PR DESCRIPTION
## What

Adds a `no-linkbuilding` opt-out marker class to the linkbuilding apply step (`scripts/linkbuilding_frontmatter.py`).

Any element carrying the `no-linkbuilding` class excludes its **entire subtree** from auto-linkbuilding. Implemented as a `find_parent` predicate, so the opt-out is **inherited by every descendant text node at any depth** — add it once on a wrapper (e.g. a banner or a section) and nothing inside gets auto-linked.

## Why

Until now linkbuilding could only be excluded by HTML tag (`header`, `footer`, `nav`, `aside`, `form`, `figure`, `blockquote`, headings, …). Banners and other section wrappers are built with `<section>`/`<div>`, so their prose text was getting auto-linked. This gives authors a per-block, class-based opt-out without touching the tag skip-lists.

## How to use

```html
<div class="... no-linkbuilding">
  <!-- any prose here is never auto-linked, at any nesting depth -->
</div>
```

## Notes

- **No behavior change** unless the class is present — purely additive.
- Marker class only; no CSS attached (Tailwind ignores it).
- Shared boilerplate → available to all consuming sites (LA / PAP / FH).

## Testing

Verified with a unit-style check:
- prose outside a marked wrapper → still linked
- prose nested deep inside `class="no-linkbuilding"` → not linked (inheritance confirmed)
- syntax/compile check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)