### PR TITLE
fix(video-handler): stop forging global cookie consent on video play

### DIFF
--- a/assets/js/components/video-handler.js
+++ b/assets/js/components/video-handler.js
@@ -288,23 +288,13 @@
         if (granted) {
             localStorage.setItem('video-consent', 'granted');
             document.cookie = 'video-consent=granted; path=/; max-age=31536000'; // 1 year
-            
-            // Try to sync with global cookie consent if possible
-            // But only do this if we don't already have a global cookie consent
-            var globalConsent = document.cookie.indexOf('cookie_consent_status=') > -1;
-            if (!globalConsent && typeof CookieManager !== 'undefined' && CookieManager.set) {
-                CookieManager.set('cookie_consent_status', 'all', 365);
-                
-                // If we have gtag, update consent there too
-                if (typeof window.gtag === 'function') {
-                    window.gtag('consent', 'update', {
-                        'analytics_storage': 'granted',
-                        'ad_storage': 'granted',
-                        'ad_user_data': 'granted',
-                        'ad_personalization': 'granted'
-                    });
-                }
-            }
+
+            // Deliberately NOT synced to the global cookie_consent_status: playing a
+            // video is consent for THIS embed only, not an "accept all" banner choice.
+            // The old sync here forged a full-consent cookie (suppressed the banner
+            // permanently and enabled every tracker for EU visitors) and fired a
+            // partial 4-param gtag update. The banner JS / consentCore own the global
+            // consent; this handler only READS it (checkGdprConsent above).
         } else {
             localStorage.removeItem('video-consent');
             document.cookie = 'video-consent=; path=/; max-age=0'; // Remove cookie


### PR DESCRIPTION
## Summary

`setGdprConsent()` in `assets/js/components/video-handler.js` wrote the **global** `cookie_consent_status=all` cookie (+ a partial 4-param `gtag consent update`) whenever a visitor granted consent for a **single video embed** and no global cookie existed yet.

Consequences (all sites using the theme):
- An EU visitor who plays one video gets a forged "accept all": the consent banner is suppressed **permanently** and every tracker turns on — without any banner interaction. GDPR violation.
- Only the legacy cookie was written (no `cookie_consent_v2`), indistinguishable from a genuine banner choice.
- The gtag update was the partial 4-param variant (no functionality/personalization/security, no `ads_data_redaction`).

## Fix

Video consent stays **scoped to embeds** (localStorage + `video-consent` cookie). The global consent is owned by the banner JS / `consentCore`; this handler already only **reads** it in `checkGdprConsent()` — that read-gate is unchanged, so "accept all" in the banner still auto-enables embeds.

The reverse direction (banner → video): both the theme `cookie-consent.js` and LA's consent-core already call `flowhuntMedia.video.setGdprConsent(true)` on real consent — unchanged.

## Context

Found during the PAP geo-gating rollout audit — blocker for introducing geo-gated consent on PAP/FH (`LiveAgent-hugo/docs/cookie-consent-pap-rollout-plan-2026-07.md`, PR 0). No behavior change for visitors who already made a real banner choice.

`node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)