### PR TITLE
fix(consent): make the blocking banner + 4-category consent OPT-IN per site

### DIFF
--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -1,16 +1,21 @@
 /**
- * Cookie Consent Script
+ * Cookie Consent Script — two variants, selected by the rendered banner markup.
  *
- * Owns the blocking banner + 4-category settings modal (cookies-bar.html).
- * Consent is persisted in two cookies:
- *  - cookie_consent_status — legacy 2-state ('all' | 'necessary'), kept as the
- *    "a choice was made" marker (banner show/hide, backward compat). It is 'all'
- *    ONLY when every category is granted — it used to become 'all' whenever the
- *    Analytics switch was on, silently granting marketing.
- *  - cookie_consent_v2 — granular per-category choice ("a1m0f1" = analytics /
- *    marketing / functional). Wins over the legacy cookie when both exist.
- * Sites with a richer consent layer (window.consentCore, e.g. LiveAgent) keep
- * owning Google Consent Mode — the gtag update below is skipped for them.
+ * LEGACY (default cookies-bar variant): the original non-blocking bottom bar +
+ * 2-category settings modal. Behavior is intentionally byte-identical to the
+ * pre-rework script: single cookie_consent_status cookie ('all' | 'necessary'),
+ * Save maps "analytics on" -> 'all', vendor hooks keyed off analytics. Every
+ * site that has not opted into the consent rework stays on this path.
+ *
+ * V2 (blocking variant, opt-in via [params.cookieConsent] blocking = true —
+ * LiveAgent / PostAffiliatePro / FlowHunt / amicited): blocking modal +
+ * 4-category settings. Adds the granular cookie_consent_v2 ("a1m0f1") next to
+ * the legacy cookie (which is 'all' ONLY when every category is granted),
+ * per-category Google Consent Mode updates, marketing-driven vendor hooks.
+ * Skipped when window.consentCore owns Consent Mode (LiveAgent).
+ *
+ * The branch is detected from the data-consent-v2 attribute that only the
+ * blocking cookies-bar variant renders on #cookie-consent-banner.
  */
 
 const CookieManager = {
@@ -34,6 +39,124 @@ const CookieManager = {
 };
 
 document.addEventListener('DOMContentLoaded', function() {
+  const bannerEl = document.getElementById('cookie-consent-banner');
+  if (bannerEl && bannerEl.hasAttribute('data-consent-v2')) {
+    initConsentV2();
+  } else {
+    initConsentLegacy();
+  }
+});
+
+function initConsentLegacy() {
+  const banner = document.getElementById('cookie-consent-banner');
+  const modal = document.getElementById('cookie-settings-modal');
+  const analyticsCheckbox = document.getElementById('analytics-cookies');
+  const consentStatus = CookieManager.get('cookie_consent_status');
+
+  if (banner) {
+    banner.removeAttribute('style');
+  }
+
+  if (consentStatus) {
+    hideBanner();
+  } else {
+    showBanner();
+  }
+
+  if (consentStatus === 'all' && analyticsCheckbox) {
+    analyticsCheckbox.checked = true;
+    updateAnalyticsConsent(true);
+  }
+
+  document.addEventListener('click', function(event) {
+    if (event.target.closest('[data-cookie-consent="accept-all"]')) {
+      event.preventDefault();
+      setConsent('all');
+      hideBanner();
+    }
+
+    if (event.target.closest('[data-cookie-consent="accept-necessary"]')) {
+      event.preventDefault();
+      setConsent('necessary');
+      hideBanner();
+    }
+
+    if (event.target.closest('[data-cookie-consent="settings"]')) {
+      event.preventDefault();
+      modal?.classList.remove('hidden');
+    }
+
+    if (event.target.closest('[data-cookie-settings-close]')) {
+      event.preventDefault();
+      modal?.classList.add('hidden');
+    }
+
+    if (event.target.closest('[data-cookie-settings-save]')) {
+      event.preventDefault();
+      const allowAnalytics = analyticsCheckbox?.checked || false;
+      setConsent(allowAnalytics ? 'all' : 'necessary');
+      modal?.classList.add('hidden');
+      hideBanner();
+    }
+  });
+
+  function hideBanner() {
+    if (banner) {
+      banner.removeAttribute('style');
+      banner.classList.add('cookie-hidden');
+      banner.style.display = 'none';
+      banner.style.visibility = 'hidden';
+      banner.style.opacity = '0';
+    }
+  }
+
+  function showBanner() {
+    if (banner) {
+      banner.classList.remove('cookie-hidden');
+      banner.style.display = 'block';
+      banner.style.visibility = 'visible';
+      banner.style.opacity = '1';
+    }
+  }
+
+  function setConsent(level) {
+    CookieManager.set('cookie_consent_status', level, 365);
+    updateAnalyticsConsent(level === 'all');
+    console.log('Cookie consent set to:', level); // Pre debugovanie
+    
+    // If user accepts all cookies, set YouTube GDPR consent too
+    if (level === 'all' && window.flowhuntMedia && window.flowhuntMedia.video && typeof window.flowhuntMedia.video.setGdprConsent === 'function') {
+      window.flowhuntMedia.video.setGdprConsent(true);
+    }
+  }
+
+  function updateAnalyticsConsent(allowed) {
+    // Consent Mode update: skip when consent-core.js is present (LiveAgent) — it owns
+    // the full 7-parameter update and fires it on the same banner click. Firing this
+    // partial 4-parameter update too would duplicate it in the dataLayer. Sites without
+    // consent-core (e.g. PAP / FlowHunt) still fire it here as before.
+    if (typeof window.gtag === 'function' && !window.consentCore) {
+      window.gtag('consent', 'update', {
+        'analytics_storage': allowed ? 'granted' : 'denied',
+        'ad_storage': allowed ? 'granted' : 'denied',
+        'ad_user_data': allowed ? 'granted' : 'denied',
+        'ad_personalization': allowed ? 'granted' : 'denied'
+      });
+    }
+    
+    // Update Capterra consent
+    if (typeof window.updateCapterraConsent === 'function') {
+      window.updateCapterraConsent(allowed);
+    }
+
+    // Update Meta Pixel consent
+    if (typeof window.updateMetaPixelConsent === 'function') {
+      window.updateMetaPixelConsent(allowed);
+    }
+  }
+}
+
+function initConsentV2() {
   const banner = document.getElementById('cookie-consent-banner');
   const modal = document.getElementById('cookie-settings-modal');
   const DAYS = 365;
@@ -193,4 +316,4 @@ document.addEventListener('DOMContentLoaded', function() {
       window.updateMetaPixelConsent(c.marketing);
     }
   }
-});
+}

--- a/layouts/partials/cookies-bar.html
+++ b/layouts/partials/cookies-bar.html
@@ -1,22 +1,23 @@
 {{/*
-@section: Cookie Consent Blocking Modal
-@description: GDPR-compliant blocking cookie consent — centered modal with a 30% dim
-  overlay that blocks the page until the visitor makes a choice, three equal-weight
-  buttons (Reject all / Manage preferences / Accept all — Accept last), and a
-  4-category settings modal (Necessary / Analytics / Marketing / Functional) with
-  Cookiebot-style switches. Docked to the bottom on mobile (buttons in the thumb
-  zone, clear of a bottom-right chat widget). Handled by assets/js/cookie-consent.js
-  (persists the granular choice in cookie_consent_v2 = "a1m0f1" alongside the legacy
-  cookie_consent_status). Ported from the LiveAgent project override
-  (LiveAgent-hugo #633 / #634 / #636, web-issues #4193 / #4195).
-@params:
-- title: Banner title (optional, default: uses i18n "cookie_consent_title")
-- message: Main message text about cookie usage (optional, default: uses i18n "cookie_consent_message")
-- policyText: Text for the privacy/cookie policy link (optional, default: "privacy policy")
-- policyUrl: URL to the privacy/cookie policy (optional, default: "/privacy-policy/")
-- theme: Visual appearance - "light" (default) or "dark"
-*/}}
+@section: Cookie Consent Banner (two variants)
+@description: Variant is selected per site via config — DEFAULT is the original
+  non-blocking bottom bar with the 2-category settings modal (unchanged legacy
+  behavior for every existing site). Sites that opted into the consent rework
+  (LiveAgent, PostAffiliatePro, FlowHunt, later amicited) enable the BLOCKING
+  centered modal with GDPR button parity + 4-category settings (Necessary /
+  Analytics / Marketing / Functional, granular cookie_consent_v2) via:
 
+      [params.cookieConsent]
+          blocking = true
+
+  assets/js/cookie-consent.js branches on the data-consent-v2 marker attribute
+  emitted by the blocking variant, so legacy sites keep the exact pre-rework JS
+  behavior (legacy cookie only, analytics-driven vendor hooks).
+@params: title, message, policyText, policyUrl, theme (light|dark) — same for both variants.
+*/}}
+{{- $blocking := false -}}
+{{- with site.Params.cookieConsent -}}{{- $blocking = .blocking | default false -}}{{- end -}}
+{{- if $blocking -}}
 {{/* Theme setup */}}
 {{ $theme := .theme | default "light" }}
 {{ $isDark := eq $theme "dark" }}
@@ -38,7 +39,7 @@
      the inner flex layer, which the JS never touches. Overlay is bg-black/30
      (= rgba(0,0,0,0.3)) with NO close handler, so the page is blocked until the user
      makes a choice. Three EQUAL-weight buttons for GDPR parity, Accept last. */}}
-<div id="{{ $bannerId }}" data-cookie-consent-banner class="fixed inset-0 z-[99999] {{ $darkClass }}">
+<div id="{{ $bannerId }}" data-cookie-consent-banner data-consent-v2 class="fixed inset-0 z-[99999] {{ $darkClass }}">
     <div class="absolute inset-0 bg-black/30"></div>
     {{/* Mobile: dock the card to the bottom so the (stacked) buttons sit in the
          thumb zone, Accept last = lowest. Desktop (sm+): vertically centered. */}}
@@ -190,3 +191,107 @@
     </div>
     </div>
 </div>
+{{- else -}}
+{{/* Theme setup */}}
+{{ $theme := .theme | default "light" }}
+{{ $isDark := eq $theme "dark" }}
+{{ $darkClass := cond $isDark "dark" "" }}
+
+{{- $title := .title | default (i18n "cookie_consent_title") -}}
+{{- $message := .message | default (i18n "cookie_consent_message") -}}
+{{- $policyText := .policyText | default "privacy policy" -}}
+{{- $policyUrl := .policyUrl | default "/privacy-policy/" -}}
+{{- $acceptAllText := i18n "cookie_consent_accept_all" -}}
+{{- $acceptNecessaryText := i18n "cookie_consent_accept_necessary" -}}
+{{- $settingsText := i18n "cookie_consent_settings" -}}
+{{- $bannerId := "cookie-consent-banner" -}}
+
+<div id="{{ $bannerId }}" data-cookie-consent-banner class="pointer-events-none fixed inset-x-0 bottom-0 px-6 pb-20 md:pb-6 z-[99999] {{ $darkClass }}">
+    <div class="pointer-events-auto max-w-xl rounded-xl section-bg-light dark:section-bg-dark p-6 ring-1 shadow-lg ring-gray-900/10">
+        <p class="text-secondary text-sm/6"><strong class="text-heading text-md mb-4 font-semibold">{{ $title }}</strong><br> {{ $message }} See our <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $policyUrl) }}" class="font-semibold text-primary hover:text-primary-500">{{ $policyText }}</a>.</p>
+        <div class="mt-4 flex items-center gap-x-3 gap-y-2 md:gap-y-0 flex-wrap">
+            {{ partial "components/buttons/buttons.html" (dict
+            "text" $acceptAllText
+            "url" "#"
+            "dataAttributes" "data-cookie-consent=accept-all"
+            "variant" "primary"
+            "classes" "text-sm"
+            ) }}
+
+            {{ partial "components/buttons/buttons.html" (dict
+            "text" $acceptNecessaryText
+            "dataAttributes" "data-cookie-consent=accept-necessary"
+            "url" "#"
+            "variant" "secondary"
+            "classes" "text-sm"
+            ) }}
+
+            {{ partial "components/buttons/buttons.html" (dict
+            "text" $settingsText
+            "url" "#"
+            "dataAttributes" "data-cookie-consent=settings"
+            "variant" "text"
+            "classes" "text-sm"
+            ) }}
+        </div>
+    </div>
+</div>
+
+<!-- Cookie Settings Modal (hidden by default) -->
+<div id="cookie-settings-modal" class="fixed inset-0 z-50 hidden {{ $darkClass }}">
+    <div class="absolute inset-0 bg-black bg-opacity-50" data-cookie-settings-close></div>
+    <div class="relative mx-auto max-w-xl p-4 sm:p-6 section-bg-light dark:section-bg-dark rounded-xl shadow-xl mt-20">
+        <div class="flex justify-between items-center mb-4">
+            <h2 class="text-heading text-xl font-bold">{{ i18n "cookie_settings_title" }}</h2>
+            <button type="button" class="text-gray-400 hover:text-gray-500 dark:text-gray-300 dark:hover:text-white" data-cookie-settings-close>
+                <span class="sr-only">{{ i18n "cookie_settings_close" }}</span>
+                <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
+
+        <div class="space-y-4">
+            <div class="border-gray-200 dark:border-gray-700 border-b pb-4">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h3 class="text-heading text-lg font-medium">{{ i18n "cookie_settings_necessary_title" }}</h3>
+                        <p class="text-tertiary text-sm">{{ i18n "cookie_settings_necessary_description" }}</p>
+                    </div>
+                    <div class="ml-3 flex h-5 items-center">
+                        <input id="necessary-cookies" name="necessary-cookies" type="checkbox" checked disabled class="h-4 w-4 rounded-xl border-gray-300 text-primary focus:ring-primary dark:border-gray-600 dark:bg-gray-700">
+                    </div>
+                </div>
+            </div>
+
+            <div class="border-gray-200 dark:border-gray-700 border-b pb-4">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h3 class="text-heading text-lg font-medium">{{ i18n "cookie_settings_analytics_title" }}</h3>
+                        <p class="text-tertiary text-sm">{{ i18n "cookie_settings_analytics_description" }}</p>
+                    </div>
+                    <div class="ml-3 flex h-5 items-center">
+                        <input id="analytics-cookies" name="analytics-cookies" type="checkbox" class="h-4 w-4 rounded-xl border-gray-300 text-primary focus:ring-primary dark:border-gray-600 dark:bg-gray-700">
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-6 flex justify-end gap-x-3">
+            {{ partial "components/buttons/buttons.html" (dict
+            "text" (i18n "cookie_settings_cancel")
+            "url" "#"
+            "dataAttributes" "data-cookie-settings-close"
+            "variant" "secondary"
+            ) }}
+
+            {{ partial "components/buttons/buttons.html" (dict
+            "text" (i18n "cookie_settings_save")
+            "url" "#"
+            "dataAttributes" "data-cookie-settings-save"
+            "variant" "primary"
+            ) }}
+        </div>
+    </div>
+</div>
+{{- end -}}


### PR DESCRIPTION
## Summary

Management decision: the consent rework (blocking modal + 4-category settings + granular `cookie_consent_v2`, #372) is intended **only for LiveAgent, PostAffiliatePro, FlowHunt and later amicited**. Every other site using the theme banner must keep the original behavior even after a submodule bump. #372 made the new banner the default for everyone — this PR makes it opt-in:

- **`cookies-bar.html`** — renders the **original non-blocking bottom bar + 2-category settings** by default (markup restored 1:1 from pre-#372). The blocking variant renders only with:
  ```toml
  [params.cookieConsent]
      blocking = true
  ```
  The blocking variant marks the banner with `data-consent-v2`.
- **`cookie-consent.js`** — branches on that marker:
  - `initConsentLegacy()`: byte-identical pre-rework behavior (legacy cookie only, Save maps "analytics on" → `all`, analytics-driven vendor hooks). Zero change for non-opted-in sites.
  - `initConsentV2()`: the #372 behavior (granular cookie, corrected Save mapping, per-category Consent Mode, marketing-driven vendor hooks).

## Verification

Built LiveAgent (its project override deleted) against this branch:
- without the param → legacy bottom bar renders (no `data-consent-v2`, no marketing/functional switches)
- with `blocking = true` → blocking modal + 4-category settings render

`node --check` passes.

## Follow-ups

- LA #648 and PAP #631 bump PRs must re-bump to this commit and set the param (LA's is already prepared on its branch).
- FlowHunt sets the param with its own bump PR.
- ⚠️ Merge this **before** any other site bumps past `bc2b23c`, otherwise they'd briefly inherit the blocking banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)