### PR TITLE
feat(consent): standalone banner JS component for layouts that bypass baseof

### DIFF
--- a/assets/js/components/cookie-consent-standalone.js
+++ b/assets/js/components/cookie-consent-standalone.js
@@ -1,0 +1,5 @@
+// Standalone build of the theme cookie-consent banner JS for layouts that bypass
+// the theme baseof and do not load the main.js bundle (e.g. design-system landing
+// pages). Built by the sites' gulp component task to static/js/. Safe to include
+// alongside main.js — cookie-consent.js carries an idempotency guard.
+import '../cookie-consent.js';

--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -38,14 +38,20 @@ const CookieManager = {
   }
 };
 
-document.addEventListener('DOMContentLoaded', function() {
-  const bannerEl = document.getElementById('cookie-consent-banner');
-  if (bannerEl && bannerEl.hasAttribute('data-consent-v2')) {
-    initConsentV2();
-  } else {
-    initConsentLegacy();
-  }
-});
+// Idempotency guard — this module ships in the theme main.js bundle AND as the
+// cookie-consent-standalone component (for layouts that bypass baseof and don't
+// load main.js). If both end up on one page, initialize only once.
+if (!window.__ccBannerJsLoaded) {
+  window.__ccBannerJsLoaded = true;
+  document.addEventListener('DOMContentLoaded', function() {
+    const bannerEl = document.getElementById('cookie-consent-banner');
+    if (bannerEl && bannerEl.hasAttribute('data-consent-v2')) {
+      initConsentV2();
+    } else {
+      initConsentLegacy();
+    }
+  });
+}
 
 function initConsentLegacy() {
   const banner = document.getElementById('cookie-consent-banner');

--- a/layouts/partials/cookies-bar.html
+++ b/layouts/partials/cookies-bar.html
@@ -84,10 +84,10 @@
   #cookie-settings-modal .cc-sw input{position:absolute;opacity:0;width:0;height:0;margin:0}
   #cookie-settings-modal .cc-sw-slider{position:absolute;inset:0;background:#52525b;border-radius:9999px;transition:background .2s;cursor:pointer}
   #cookie-settings-modal .cc-sw-slider::before{content:"";position:absolute;height:18px;width:18px;left:3px;top:3px;background:#fff;border-radius:50%;transition:transform .2s}
-  #cookie-settings-modal .cc-sw input:checked + .cc-sw-slider{background:rgb(var(--color-primary-400))}
+  #cookie-settings-modal .cc-sw input:checked + .cc-sw-slider{background:rgb(var(--color-primary-400, 96 165 250))}
   #cookie-settings-modal .cc-sw input:checked + .cc-sw-slider::before{transform:translateX(20px)}
   #cookie-settings-modal .cc-sw input:disabled + .cc-sw-slider{opacity:.5;cursor:not-allowed}
-  #cookie-settings-modal .cc-sw input:focus-visible + .cc-sw-slider{outline:2px solid rgb(var(--color-primary-400));outline-offset:2px}
+  #cookie-settings-modal .cc-sw input:focus-visible + .cc-sw-slider{outline:2px solid rgb(var(--color-primary-400, 96 165 250));outline-offset:2px}
 </style>
 
 <!-- Cookie Settings Modal (hidden by default) — Necessary + Analytics as switches.


### PR DESCRIPTION
## Why

Some sites have layouts that define their own `<head>` and never load the theme `main.js` bundle (amicited design-port landing pages, see amicited-hugo#91/#92) — the cookie banner markup rendered there without any behavior (buttons dead, modal never opens).

## Changes

- **`assets/js/components/cookie-consent-standalone.js`** — wrapper importing `../cookie-consent.js`; the sites' gulp component task builds it to `static/js/`, layouts include it with a `fileExists` guard. Same single source of truth, second packaging.
- **`assets/js/cookie-consent.js`** — idempotency guard (`window.__ccBannerJsLoaded`): a page that ends up with both `main.js` and the component initializes exactly once.
- **`cookies-bar.html`** — switch ON-color falls back to the theme blue when a site doesn't define the brand triplet: `rgb(var(--color-primary-400, 96 165 250))`.

## Impact on existing sites

None: new build artifact (nothing references it unless a layout opts in), guard is a no-op, fallback applies only where the variable is undefined. `node --check` passes; verified end-to-end on amicited design pages (banner buttons + settings modal working via the component).

Consumer: amicited-hugo#92 consent upgrade (depends on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)