### PR TITLE
feat(analytics): opt-in server-side GTM loader mode per language

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,6 +6,7 @@
   {{ partial "consent-head.html" . }}
 </head>
 <body class="antialiased bg-white dark:bg-gray-900 min-h-screen flex flex-col">
+{{ partial "gtm-noscript.html" . }}
 
 {{ $showPromoBanner := and 
     site.Params.promoBanner.enable 

--- a/layouts/partials/gtm-noscript.html
+++ b/layouts/partials/gtm-noscript.html
@@ -1,0 +1,10 @@
+{{- /* GTM noscript iframe — emit RIGHT AFTER the opening <body> tag. Renders only
+     for languages with the server-side GTM loader enabled (gtmNsUrl language
+     param — see utils/analytics/google-analytics-consent.html for the loader
+     counterpart). Sites overriding baseof or using standalone layouts include
+     this partial themselves. */ -}}
+{{- with .Site.Language.Params.gtmNsUrl }}
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="{{ . | safeURL }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+{{- end }}

--- a/layouts/partials/gtm-noscript.html
+++ b/layouts/partials/gtm-noscript.html
@@ -3,7 +3,7 @@
      param — see utils/analytics/google-analytics-consent.html for the loader
      counterpart). Sites overriding baseof or using standalone layouts include
      this partial themselves. */ -}}
-{{- with .Site.Language.Params.gtmNsUrl }}
+{{- with site.Params.gtmNsUrl }}
 <!-- Google Tag Manager (noscript) -->
 <noscript><iframe src="{{ . | safeURL }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->

--- a/layouts/partials/utils/analytics/google-analytics-consent.html
+++ b/layouts/partials/utils/analytics/google-analytics-consent.html
@@ -160,7 +160,10 @@
        after <body> by the site's baseof/standalone layouts.
 
        gtag mode (default): the original direct gtag.js load + config below. */ -}}
-  {{- $gtmLoaderUrl := .Site.Language.Params.gtmLoaderUrl | default "" -}}
+  {{- /* site.Params is language-merged: single-domain multilingual sites set the
+       params once in [params]; per-domain-per-language sites (LA) set them under
+       [languages.XX.params]. */ -}}
+{{- $gtmLoaderUrl := site.Params.gtmLoaderUrl | default "" -}}
   {{- if $gtmLoaderUrl }}
   <!-- Google Tag Manager (server-side loader) -->
   <script>(function(w,d,s,l){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.async=true;j.src="{{ $gtmLoaderUrl | safeURL }}";f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer');</script>

--- a/layouts/partials/utils/analytics/google-analytics-consent.html
+++ b/layouts/partials/utils/analytics/google-analytics-consent.html
@@ -146,6 +146,26 @@
     };
   </script>
 
+  {{- /* STEP 2/3 — TWO MODES, selected per language:
+
+       GTM mode (opt-in): set language params in the site config, e.g.
+           [languages.de.params]
+               gtmLoaderUrl = "https://r2lcn.example.de/loader.js?<encoded-config>"
+               gtmNsUrl     = "https://r2lcn.example.de/ns.html?id=GTM-XXXXXXX"
+       The server-side GTM loader replaces gtag.js AND the GA4/Ads configs —
+       measurement IDs, cross-domain linker and enhanced conversions live in the
+       GTM container. STEP 1 above (consent defaults + stored-choice update +
+       the gtag() dataLayer stub) stays — GTM consumes the same dataLayer
+       consent commands. The noscript iframe (gtmNsUrl) must be emitted right
+       after <body> by the site's baseof/standalone layouts.
+
+       gtag mode (default): the original direct gtag.js load + config below. */ -}}
+  {{- $gtmLoaderUrl := .Site.Language.Params.gtmLoaderUrl | default "" -}}
+  {{- if $gtmLoaderUrl }}
+  <!-- Google Tag Manager (server-side loader) -->
+  <script>(function(w,d,s,l){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s);j.async=true;j.src="{{ $gtmLoaderUrl | safeURL }}";f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer');</script>
+  <!-- End Google Tag Manager -->
+  {{- else }}
   {{/* STEP 2: Load gtag.js AFTER consent defaults are set */}}
   <script async src="https://www.googletagmanager.com/gtag/js?id={{ $analyticsID }}"></script>
 
@@ -184,4 +204,5 @@
     });
     {{- end }}
   </script>
+  {{- end }}
 {{ end }}


### PR DESCRIPTION
## Summary

Per-language **GTM mode** for the GA consent partial — opt-in via language params:

```toml
[languages.de.params]
    gtmLoaderUrl = "https://r2lcn.example.de/loader.js?<encoded-config>"
    gtmNsUrl     = "https://r2lcn.example.de/ns.html?id=GTM-XXXXXXX"
```

- **STEP 1 stays for both modes**: Consent Mode region defaults + stored-choice update + the `gtag()` dataLayer stub — GTM consumes the same dataLayer consent commands, so the whole consent stack (banner, consent-core, default→update pattern from #378) works unchanged.
- **With the param**: the server-side GTM loader (Stape-style first-party domain) replaces `gtag.js` + the GA4/Ads `config` calls — measurement IDs, cross-domain linker and enhanced conversions live in the container.
- **Without the param**: the original gtag block renders **verbatim** (it was only wrapped in the `else` branch). A blind submodule bump changes nothing for any site — same opt-in principle as `[cookieConsent]`/`[geoConsent]`.
- New **`gtm-noscript.html`** partial (noscript iframe right after `<body>`; empty without `gtmNsUrl`), included in the theme baseof; sites with overridden baseofs/standalone layouts include it themselves.

## Verification

LiveAgent EN+DE production build: DE renders the loader after the consent defaults + noscript 129 chars after `<body>`, no `gtag.js`; EN output unchanged (gtag + linker exactly as before). Template if/end balance checked. First consumer: LiveAgent DE GTM test (PR follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)