### PR TITLE
feat(consent): optional cookieDomain to share consent across subdomains

### DIFF
--- a/assets/js/components/consent-core.js
+++ b/assets/js/components/consent-core.js
@@ -43,10 +43,18 @@
     var m = document.cookie.match('(?:^|; )' + name + '=([^;]*)');
     return m ? decodeURIComponent(m[1]) : null;
   }
+  // Optional cookie Domain (set by cookies-bar.html from [params.cookieConsent]
+  // cookieDomain, e.g. ".flowhunt.io"). Lets the consent cookie be shared across
+  // subdomains of one registrable domain (www → app → api) so the app can read
+  // the visitor's choice natively. Unset (default) → host-only, unchanged.
+  function cookieDomainAttr() {
+    var d = window.__consentCookieDomain;
+    return (typeof d === 'string' && d) ? '; Domain=' + d : '';
+  }
   function setCookie(name, value, days) {
     var exp = new Date(Date.now() + days * 864e5).toUTCString();
     document.cookie = name + '=' + encodeURIComponent(value) +
-      '; expires=' + exp + '; path=/; SameSite=Lax';
+      '; expires=' + exp + '; path=/; SameSite=Lax' + cookieDomainAttr();
   }
 
   function region() {

--- a/assets/js/cookie-consent.js
+++ b/assets/js/cookie-consent.js
@@ -22,7 +22,12 @@ const CookieManager = {
   set(name, value, days) {
     const date = new Date();
     date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-    document.cookie = `${name}=${value};expires=${date.toUTCString()};path=/`;
+    // Optional Domain (window.__consentCookieDomain, set by cookies-bar.html from
+    // [params.cookieConsent] cookieDomain) so the consent cookie is shared across
+    // subdomains of one registrable domain. Unset (default) → host-only, unchanged.
+    const dom = (typeof window.__consentCookieDomain === 'string' && window.__consentCookieDomain)
+      ? `;Domain=${window.__consentCookieDomain}` : '';
+    document.cookie = `${name}=${value};expires=${date.toUTCString()};path=/${dom}`;
   },
 
   get(name) {

--- a/layouts/partials/cookies-bar.html
+++ b/layouts/partials/cookies-bar.html
@@ -17,6 +17,14 @@
 */}}
 {{- $blocking := false -}}
 {{- with site.Params.cookieConsent -}}{{- $blocking = .blocking | default false -}}{{- end -}}
+{{- /* Optional cookie Domain so the consent cookie is shared across subdomains of
+       one registrable domain (e.g. ".flowhunt.io" → www / app / api read the same
+       choice). Set via [params.cookieConsent] cookieDomain. Consumed by
+       consent-core.js + cookie-consent.js. Parse-time inline so it runs before the
+       deferred consent scripts. No param → host-only cookie, unchanged. */ -}}
+{{- with site.Params.cookieConsent }}{{ with .cookieDomain }}
+<script>window.__consentCookieDomain={{ . | jsonify }};</script>
+{{ end }}{{ end -}}
 {{- if $blocking -}}
 {{/* Theme setup */}}
 {{ $theme := .theme | default "light" }}


### PR DESCRIPTION
## What

Adds an opt-in `[params.cookieConsent] cookieDomain` (e.g. `".flowhunt.io"`). When set, `cookies-bar.html` emits `window.__consentCookieDomain` and both consent-cookie writers add `; Domain=<value>`:
- `consent-core.js` `setCookie` (writes `cookie_consent_v2`)
- `cookie-consent.js` `CookieManager.set` (writes `cookie_consent_status` + `cookie_consent_v2` in the v2 variant)

So the consent cookies become readable across **subdomains of one registrable domain** (www → app → api). This lets an app on a sibling subdomain (e.g. `app.flowhunt.io`) read the visitor's consent choice **natively**, instead of re-prompting a second banner.

## Why

FlowHunt's app (`app.flowhunt.io`) needs to honor the consent given on the marketing site (`www.flowhunt.io`) — same registrable domain, so a domain-scoped cookie is the correct mechanism. Today the consent cookie is host-only, so `app.flowhunt.io` can't read it.

## Safety

- **Opt-in only.** No `cookieDomain` param → no `window.__consentCookieDomain` → host-only cookie, **behavior unchanged** for every site that doesn't set it (LiveAgent, PAP, etc.).
- Both writers use the same global, so no duplicate host-only + domain cookie.
- Different **registrable** domains (e.g. amicited.com ↔ flowhunt.io) still can't share a cookie — that's a browser limit; those keep using URL passthrough.

## Testing

- `node --check` passes on both JS files.
- Consumers rebuild their JS (gulp) after bumping the submodule; first consumer is FlowHunt (`cookieDomain = ".flowhunt.io"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)