### PR TITLE
chore(tailwind): migrate theme from Tailwind CSS v3 to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,39 @@
 A clean and minimal Hugo theme designed for QualityUnit websites with a focus on performance, SEO, and responsive design. 
 This theme includes Tailwind CSS integration, comprehensive SEO features, responsive image processing, and multilingual support out of the box.
 
+---
+
+> ## ⚠️ This theme requires Tailwind CSS v4
+>
+> **Bumping the submodule pointer without upgrading your project to Tailwind v4 will
+> break your build.** The theme's stylesheets use `@import "tailwindcss"`, `@config`,
+> `@utility` and `@reference`, none of which exist in v3.
+>
+> Your project needs, at minimum:
+>
+> ```jsonc
+> // package.json
+> "tailwindcss": "^4.3.3",
+> "@tailwindcss/postcss": "^4.3.3",
+> // and REMOVE: autoprefixer, postcss-import, @tailwindcss/aspect-ratio
+> ```
+>
+> ```js
+> // gulpfile.js — the PostCSS chain
+> const tailwindcss = require('@tailwindcss/postcss');
+> postcss([ tailwindcss(), cssnano() ])
+> ```
+>
+> **Before you migrate, read [Migrating a project to Tailwind v4](#migrating-a-project-to-tailwind-v4)
+> further down.** There are four failure modes that are not obvious and cost real
+> debugging time — standalone stylesheets using `@apply`, the `@config` path, the
+> `aspect-ratio` plugin, and `hover:` behaviour.
+>
+> Pin to the last v3 commit if you are not ready:
+> `git checkout 2517448 -- themes/boilerplate` (or keep your existing pointer).
+
+---
+
 
 ## Projects running this theme
 - [AiMingle](https://www.aimingle.cz/) - https://github.com/QualityUnit/aimingle-hugo
@@ -172,31 +205,36 @@ You need to create a `package.json` file in your project root (not in the theme 
     "build": "gulp css && gulp js"
   },
   "devDependencies": {
-    "@tailwindcss/aspect-ratio": "^0.4.2",
-    "@tailwindcss/forms": "^0.5.7",
-    "@tailwindcss/typography": "^0.5.10",
-    "autoprefixer": "^10.4.21",
+    "@tailwindcss/forms": "^0.5.11",
+    "@tailwindcss/postcss": "^4.3.3",
+    "@tailwindcss/typography": "^0.5.20",
     "cssnano": "^7.0.7",
     "esbuild": "^0.25.5",
     "gulp": "^5.0.1",
     "gulp-postcss": "^10.0.0",
     "postcss": "^8.4.31",
     "postcss-cli": "^10.1.0",
-    "postcss-import": "^16.1.0",
-    "tailwindcss": "^3.4.17",
+    "tailwindcss": "^4.3.3",
     "yargs": "^18.0.0"
   }
 }
 ```
 
+Three packages that a v3 setup had are deliberately absent:
+
+| Removed | Why |
+|---|---|
+| `autoprefixer` | `@tailwindcss/postcss` applies vendor prefixes itself, via Lightning CSS |
+| `postcss-import` | v4 inlines `@import` itself |
+| `@tailwindcss/aspect-ratio` | declares no v4 support; v4 has `aspect-*` natively |
+
 ### Build System Overview
 
 The theme uses a Gulp-based build system that:
 
-1. **CSS Processing**: 
-   - Processes CSS `@import` statements with postcss-import
-   - Compiles Tailwind CSS with PostCSS
-   - Adds vendor prefixes with autoprefixer
+1. **CSS Processing**:
+   - Compiles Tailwind CSS with `@tailwindcss/postcss`, which also inlines
+     `@import` and applies vendor prefixes
    - Minifies output with cssnano
 2. **JavaScript Bundling**: Uses ESBuild for fast bundling and minification
 3. **Watch Mode**: Provides live reloading during development
@@ -209,9 +247,7 @@ The build system requires a `gulpfile.js` in your project root:
 ```javascript
 const gulp = require('gulp');
 const postcss = require('gulp-postcss');
-const postcssImport = require('postcss-import');
-const tailwindcss = require('tailwindcss');
-const autoprefixer = require('autoprefixer');
+const tailwindcss = require('@tailwindcss/postcss');
 const esbuild = require('esbuild');
 const { spawn } = require('child_process');
 const cssnano = require('cssnano');
@@ -224,13 +260,10 @@ const cssDest = 'static/css';
 const jsEntryPoints = ['themes/boilerplate/assets/js/main.js'];
 const jsDest = 'static/js';
 
-// CSS build with @import processing
 function buildCSS() {
     return gulp.src(cssSrc)
         .pipe(postcss([
-            postcssImport,    // Process @import statements first
-            tailwindcss,
-            autoprefixer,
+            tailwindcss(),   // also inlines @import and adds vendor prefixes
             cssnano()
         ]))
         .pipe(gulp.dest(cssDest));
@@ -239,37 +272,43 @@ function buildCSS() {
 // Build tasks and configuration...
 ```
 
+If you also compile `assets/css/components/*.css` individually, **exclude any
+component stylesheet that `main.css` already `@import`s** — currently
+`components/floating-cta.css`. See
+[Migrating a project to Tailwind v4](#migrating-a-project-to-tailwind-v4) for why.
+
 ## PostCSS Configuration
 
 ### Required Setup
 
-This theme uses Tailwind CSS which is processed through Gulp and PostCSS. You **must** create a `postcss.config.js` file in your project root (not in the theme directory) with the following content:
+Create a `postcss.config.js` in your project root (not in the theme directory):
 
 ```javascript
 // postcss.config.js in your project root
 module.exports = {
   plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
+    '@tailwindcss/postcss': {},
   },
 };
 ```
 
+Note that if your `gulpfile.js` builds its own PostCSS plugin array — as the
+example above does — this file is never read. It applies only to direct
+`postcss-cli` invocations.
+
 ### Tailwind Configuration
 
-The theme includes a pre-configured `tailwind.config.js` that:
-
-1. Scans the correct template directories for class usage
-2. Includes necessary Tailwind plugins
-3. Provides custom color schemes and utilities
+The theme keeps using a JavaScript `tailwind.config.js`, loaded from CSS with
+`@config`. Your project supplies its own; the copy inside the theme directory is
+only a template for projects that have none.
 
 ```javascript
-// tailwind.config.js example
+// tailwind.config.js in YOUR project root
 module.exports = {
     darkMode: 'class',
     content: [
         './layouts/**/*.html',
-        './themes/boilerplate/layouts/**/*.html', 
+        './themes/boilerplate/layouts/**/*.html',
         './themes/boilerplate/assets/js/**/*.js',
     ],
     theme: {
@@ -280,38 +319,136 @@ module.exports = {
     plugins: [
         require('@tailwindcss/typography'),
         require('@tailwindcss/forms'),
-        require('@tailwindcss/aspect-ratio'),
     ],
 };
 ```
+
+`content` still works under `@config`. Two keys do **not**: `safelist` and
+`corePlugins`. Replace a safelist with `@source inline("...")` in your CSS.
 
 ### Build Process Integration
 
 The Gulp build system automatically:
 
-1. **Processes @import statements**: Uses postcss-import to inline imported CSS files
-2. **Compiles Tailwind CSS**: Runs Tailwind CSS compilation with PostCSS
-3. **Applies Autoprefixer**: Adds vendor prefixes for browser compatibility  
-4. **Minifies Output**: Uses cssnano for production-ready CSS
-5. **Watches Changes**: Rebuilds CSS when source files change
+1. **Compiles Tailwind CSS**: `@tailwindcss/postcss` resolves `@import`, `@config`
+   and `@apply`, and applies vendor prefixes
+2. **Minifies Output**: Uses cssnano for production-ready CSS
+3. **Watches Changes**: Rebuilds CSS when source files change
 
 ### CSS Import System
 
-The theme supports CSS imports in the main CSS file:
-
 ```css
 /* themes/boilerplate/assets/css/main.css */
-@import "./fonts.css";
-@import "./typewriter.css";
-@import "./lazy-images.css";
-@import "./lazy-videos.css";
+@custom-variant hover (&:hover);
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import './variables.css' layer(base);
+@import './fonts.css' layer(base);
+@import './typewriter.css' layer(base);
+
+@import 'tailwindcss';
+@config '../../../../tailwind.config.js';
 ```
 
-The `postcss-import` plugin automatically inlines these imports during the build process, creating a single minified CSS file in `static/css/main.css`.
+`@config` points **four levels up**, at your project's root config — not the
+theme's own. Hugo always mounts the theme at `themes/boilerplate/`, so this path is
+correct for every project. Do not "fix" it to `../../`.
+
+Tailwind inlines these imports during the build, producing a single minified
+`static/css/main.css`.
+
+## Migrating a project to Tailwind v4
+
+Reference implementation: **LiveAgent** — see qualityunit/hugo-boilerplate#384 and
+the matching LiveAgent-hugo PR.
+
+Run the official codemod first; it handles the bulk of the class renames well,
+including Hugo's `{{- … -}}` delimiters:
+
+```bash
+npx @tailwindcss/upgrade      # requires a clean git tree
+```
+
+Then deal with the parts it cannot know about.
+
+### 1. Standalone stylesheets that use `@apply`
+
+A stylesheet compiled by Tailwind on its own, with no `@import "tailwindcss"`, was
+perfectly legal in v3. In v4 it is a **hard build failure**:
+
+```
+Cannot apply unknown utility class `sm:px-6`.
+```
+
+It needs `@reference` to get theme context without emitting anything:
+
+```css
+@reference "../../themes/boilerplate/assets/css/tailwind-context.css";
+```
+
+Point it at `tailwind-context.css`, **never at `main.css`** — `main.css` imports
+component stylesheets, so referencing it back is circular
+("Exceeded maximum recursion depth").
+
+And a file that `main.css` already `@import`s must have **no** `@reference` at all
+— the referenced context declares `@config`, which becomes a nested `@config`
+once `main.css` inlines the file, and v4 rejects that. Exclude such files from any
+"compile every `components/*.css` individually" task instead.
+
+### 2. The `@config` path
+
+The codemod writes `@config '../../tailwind.config.js'`, which resolves to the
+**theme's** config. Under v3 the config came from the working directory, i.e. your
+project's root config; the theme's copy was never read. Left uncorrected this
+silently swaps your entire palette. The theme's `main.css` already uses the right
+path — check yours if you add your own entrypoint.
+
+### 3. Dropping `@tailwindcss/aspect-ratio`
+
+Not just a class rename. The plugin also styled the *direct child*:
+
+```css
+.aspect-w-4 > * { position: absolute; inset: 0; width: 100%; height: 100% }
+```
+
+Native `aspect-ratio` does not. Where the child is a wrapper — `lazyimg` renders a
+`<figure>`, so the `class` parameter lands on the inner `<img>` — the wrapper has no
+height and images collapse. Pass `"figureClass" "size-full"` alongside `"class"`.
+
+### 4. `hover:` on touch devices
+
+v4 gates `hover:` behind `@media (hover: hover)`. The theme currently overrides that
+back to v3 behaviour with `@custom-variant hover (&:hover)`, declared in **both**
+`main.css` and `tailwind-context.css` — a stylesheet reaching Tailwind through
+`@reference` does not see variants declared in `main.css`, and the two bundles would
+otherwise disagree on touch devices.
+
+The override does **not** reach `@apply hover:*` inside files that `main.css`
+imports; those are resolved before the variant takes effect. Write them as explicit
+`&:hover { @apply … }` blocks.
+
+### Compatibility layer
+
+`main.css` carries a `TODO(v4-compat)` block restoring five v3 defaults —
+`border-color`, `placeholder`, button `cursor`, ring colour, and `hover:`. Entries
+are independent and meant to be removed one at a time, easiest first:
+
+```
+hover → placeholder → cursor → ring → border-color
+```
+
+`border-color` is last because it affects roughly 555 call sites.
+
+### Browser support
+
+v4 targets Chrome 111+ / Safari 16.4+ / Firefox 128+. In practice v4.1+ emits
+fallbacks and older browsers still render usably. What genuinely breaks below those
+versions is Tailwind's **default** palette, which is defined in `oklch()` with no
+fallback — badges and coloured callouts lose their background. Colours declared as
+`rgb(var(--x) / <alpha-value>)` in your config, which is how the theme's brand
+palette works, are unaffected.
+
+Measure before worrying: check your GA4 share of Windows 7 (Chrome caps at 109) and
+macOS Catalina (Safari caps at 15.6).
 
 ## JavaScript Bundling with ESBuild
 
@@ -362,7 +499,18 @@ If you encounter build errors:
 
 **Common Issues:**
 
-- **MIME type errors**: Usually resolved by properly configuring postcss-import plugin
+- **`Cannot apply unknown utility class ...`** — a stylesheet compiled on its own is
+  using `@apply` with no Tailwind context. Add `@reference` to
+  `tailwind-context.css`. See
+  [Migrating a project to Tailwind v4](#migrating-a-project-to-tailwind-v4).
+- **`@config cannot be nested`** — a file that `main.css` `@import`s carries a
+  `@reference` (or its own `@config`). Remove it and exclude that file from any
+  standalone-compile task.
+- **`Exceeded maximum recursion depth`** — a `@reference` points at `main.css`.
+  Point it at `tailwind-context.css` instead.
+- **Colours all wrong after upgrading** — `@config` is resolving the theme's own
+  config instead of your project's. It must be four levels up from
+  `themes/boilerplate/assets/css/`.
 - **Missing CSS files**: Ensure all @import paths are correct and files exist
 - **Build failures**: Check that all dependencies are installed and paths are correct
 

--- a/assets/css/components/floating-cta.css
+++ b/assets/css/components/floating-cta.css
@@ -65,7 +65,17 @@
 
 /* Dark theme button override - white on dark */
 .floating-cta--dark .floating-cta__action .btn-primary {
-  @apply bg-white text-gray-900 hover:bg-gray-100;
+  @apply bg-white text-gray-900;
+
+  /* Written as an explicit &:hover rather than `@apply hover:bg-gray-100`.
+     This file is @imported by main.css and Tailwind resolves its @apply before
+     main.css's `@custom-variant hover` is in effect, so the shorthand would still
+     emit v4's @media (hover: hover) gate and behave differently from v3 on touch.
+     Drop the nesting and go back to the shorthand once that compat entry is
+     removed. */
+  &:hover {
+    @apply bg-gray-100;
+  }
 }
 
 /* ================================================================ */
@@ -259,8 +269,13 @@
 }
 
 .floating-cta__secondary a {
-  @apply text-xs hover:underline transition-colors;
+  @apply text-xs transition-colors;
   color: #94a3b8;
+
+  /* Explicit &:hover — see the note on .floating-cta--dark .btn-primary above. */
+  &:hover {
+    @apply underline;
+  }
 }
 
 .floating-cta__secondary a:hover {

--- a/assets/css/components/floating-cta.css
+++ b/assets/css/components/floating-cta.css
@@ -1,3 +1,13 @@
+/*
+  NOT compiled standalone — this file is @imported by ../main.css and gets its
+  Tailwind context from there. It must therefore NOT carry its own @reference:
+  the referenced context declares @config, and once this file is inlined into
+  main.css that becomes a nested @config, which v4 rejects.
+
+  Consequently it must be EXCLUDED from any "compile every components/*.css on its
+  own" task (see the glob in the consumer's gulpfile). Nothing loads
+  /css/floating-cta.css directly, so the standalone artifact was unused anyway.
+*/
 /* ================================================================ */
 /* FLOATING CTA COMPONENT */
 /* A sticky CTA that floats next to blog content on the right side */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,521 +1,726 @@
 /* 🎨 CSS IMPORTS - ALL IMPORTS MUST BE FIRST */
-@import "./variables.css";
-@import "./fonts.css";
-@import "./typewriter.css";
-@import "./lazy-images.css";
-@import "./lazy-videos.css";
-@import "./components/floating-cta.css";
+@import './variables.css' layer(base);
+@import './fonts.css' layer(base);
+@import './typewriter.css' layer(base);
+@import './lazy-images.css' layer(base);
+@import './lazy-videos.css' layer(base);
+@import './components/floating-cta.css' layer(base);
 
 /* 🎯 TAILWIND LAYERS */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss';
+
+/*
+  Resolve the CONSUMER's root tailwind.config.js, not the theme's own.
+
+  Under v3 the config was auto-detected from cwd, which is the consuming repo's
+  root — `themes/boilerplate/tailwind.config.js` was never read by a consumer that
+  has its own config. v4 has no cwd auto-detection, so the path must be explicit.
+
+  Hugo always mounts this theme at `themes/boilerplate/`, so four levels up is the
+  consumer's root for every site. Do not "fix" this to `../../`; that points at the
+  theme's own config (a template) and silently swaps the whole palette.
+
+  Kept inline rather than pulled from tailwind-context.css because `@config`
+  cannot be nested inside an @import. tailwind-context.css duplicates these two
+  lines for @reference consumers — keep the two in sync.
+*/
+@config '../../../../tailwind.config.js';
+
+/*
+  The default border color has changed to `currentcolor` in Tailwind CSS v4,
+  so we've added these compatibility styles to make sure everything still
+  looks the same as it did with Tailwind CSS v3.
+
+  If we ever want to remove these styles, we need to add an explicit border
+  color utility to any element that depends on these defaults.
+*/
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentcolor);
+  }
+}
 
 /* 🎨 CORE STYLES */
-@layer components {
-  /* Cookie consent styles - simplified */
-  .cookie-hidden {
-    @apply hidden !important;
-    display: none !important;
-    visibility: hidden !important;
-    opacity: 0 !important;
-    pointer-events: none !important;
-  }
 
+@utility cookie-hidden {
+  /* Cookie consent styles - simplified */
+  @apply hidden!;
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
+
+@utility section-bg-light {
   /* ================================================================ */
   /* 🎨 SECTION BACKGROUNDS */
   /* ================================================================ */
-  
-  .section-bg-light {
-    @apply bg-white;
-    /* Light background, typically for white or neutral sections */
-  }
+  @apply bg-white;
+  /* Light background, typically for white or neutral sections */
+}
 
-  .section-bg-alternate {
-    @apply bg-gray-50;
-    /* Alternate background, light gray in light mode, dark gray in dark mode */
-  }
+@utility section-bg-alternate {
+  @apply bg-gray-50;
+  /* Alternate background, light gray in light mode, dark gray in dark mode */
+}
 
-  .section-bg-dark {
-    @apply bg-gray-900;
-    /* Dark background, used for contrast or "dark mode" sections */
-  }
+@utility section-bg-dark {
+  @apply bg-gray-900;
+  /* Dark background, used for contrast or "dark mode" sections */
 
-  .section-bg-dark a[data-lb], .bg-gray-900 a[data-lb] {
+  & a[data-lb] {
     @apply text-primary-500 hover:text-primary-700;
   }
+}
 
+/*
+  Must stay a plain descendant rule. The v4 upgrade tool turned the original
+  `.section-bg-dark a[data-lb], .bg-gray-900 a[data-lb]` selector into two
+  `@utility` blocks — but `@utility bg-gray-900` shadows Tailwind's own
+  `bg-gray-900` utility and would stop it setting a background at all.
+*/
+@layer components {
+  .bg-gray-900 a[data-lb] {
+    @apply text-primary-500 hover:text-primary-700;
+  }
+}
+
+@utility wrapper {
   /* ================================================================ */
   /* 📦 WRAPPER CLASSES */
   /* ================================================================ */
-  
-  .wrapper {
-    @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
-  }
-  .wrapper-narrow {
-    @apply max-w-4xl mx-auto px-4 sm:px-6 lg:px-8;
-  }
-  .wrapper-content {
-    @apply max-w-4xl px-4 sm:px-6 lg:px-8;
-  }
+  @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
 
-  .wrapper .wrapper-content {
+  & .wrapper-content {
     @apply px-0;
   }
-  .wrapper-content .wrapper {
+  .wrapper-content & {
     @apply px-0;
   }
+}
 
+@utility wrapper-narrow {
+  @apply max-w-4xl mx-auto px-4 sm:px-6 lg:px-8;
+}
+
+@utility wrapper-content {
+  @apply max-w-4xl px-4 sm:px-6 lg:px-8;
+
+  .wrapper & {
+    @apply px-0;
+  }
+  & .wrapper {
+    @apply px-0;
+  }
+}
+
+@utility surface-primary {
   /* ================================================================ */
   /* 🏠 SURFACE STYLES */
   /* ================================================================ */
-  
-  .surface-primary {
-    @apply bg-white dark:bg-gray-900;
-    /* Primary surface background – white in light mode, dark gray in dark mode */
-  }
+  @apply bg-white dark:bg-gray-900;
+  /* Primary surface background – white in light mode, dark gray in dark mode */
+}
 
-  .surface-secondary {
-    @apply bg-gray-50 dark:bg-gray-400/10;
-    /* Secondary surface background – light gray in light mode, very light gray in dark mode */
-  }
+@utility surface-secondary {
+  @apply bg-gray-50 dark:bg-gray-400/10;
+  /* Secondary surface background – light gray in light mode, very light gray in dark mode */
+}
 
-  .surface-brand, .product-bg-primary {
-    @apply bg-brand-surface dark:bg-brand-dark-surface;
-    /* Brand surface background – brand primary in light mode, brand secondary in dark mode */
-  }
+@utility surface-brand {
+  @apply bg-brand-surface dark:bg-brand-dark-surface;
+  /* Brand surface background – brand primary in light mode, brand secondary in dark mode */
+}
 
-  .surface-brand-secondary, .product-surface {
-    @apply bg-brand-surface-secondary/20 dark:bg-brand-dark-surface-secondary/20;
-    /* Brand surface background – brand primary in light mode, brand secondary in dark mode */
-  }
+@utility product-bg-primary {
+  @apply bg-brand-surface dark:bg-brand-dark-surface;
+  /* Brand surface background – brand primary in light mode, brand secondary in dark mode */
+}
 
-  .surface-underlight, .product-underlight {
-    @apply bg-brand-underlight dark:bg-brand-dark-underlight;
-    /* Brand underlight background – brand primary in light mode, brand secondary in dark mode */
-  }
+@utility surface-brand-secondary {
+  @apply bg-brand-surface-secondary/20 dark:bg-brand-dark-surface-secondary/20;
+  /* Brand surface background – brand primary in light mode, brand secondary in dark mode */
+}
 
+@utility product-surface {
+  @apply bg-brand-surface-secondary/20 dark:bg-brand-dark-surface-secondary/20;
+  /* Brand surface background – brand primary in light mode, brand secondary in dark mode */
+}
+
+@utility surface-underlight {
+  @apply bg-brand-underlight dark:bg-brand-dark-underlight;
+  /* Brand underlight background – brand primary in light mode, brand secondary in dark mode */
+}
+
+@utility product-underlight {
+  @apply bg-brand-underlight dark:bg-brand-dark-underlight;
+  /* Brand underlight background – brand primary in light mode, brand secondary in dark mode */
+}
+
+@utility border-gray-primary {
   /* ================================================================ */
   /* BORDER STYLES */
   /* ================================================================ */
 
   /* Border gray primary - "border primary" in design*/
-  .border-gray-primary, .surface-border {
-    @apply border-gray-300 dark:border-gray-600;
-    /* Primary border – light gray in light mode, darker gray in dark mode */
-  }
+  @apply border-gray-300 dark:border-gray-600;
+  /* Primary border – light gray in light mode, darker gray in dark mode */
   /* Form elements with surface border */
-  input.border-gray-primary,
-  select.border-gray-primary,
-  textarea.border-gray-primary {
-    @apply border-gray-300 dark:border-gray-600 !important;
+  &input {
+    @apply border-gray-300! dark:border-gray-600!;
   }
+  & select {
+    @apply border-gray-300! dark:border-gray-600!;
+  }
+  & textarea {
+    @apply border-gray-300! dark:border-gray-600!;
+  }
+}
 
-  .border-secondary, .surface-divider {
-    @apply border-gray-200 dark:border-gray-700;
-    /* Secondary border – light gray in light mode, darker gray in dark mode */
-  }
+@utility surface-border {
+  @apply border-gray-300 dark:border-gray-600;
+  /* Primary border – light gray in light mode, darker gray in dark mode */
+}
+
+@utility border-secondary {
+  @apply border-gray-200 dark:border-gray-700;
+  /* Secondary border – light gray in light mode, darker gray in dark mode */
+}
+
+@utility surface-divider {
+  @apply border-gray-200 dark:border-gray-700;
+  /* Secondary border – light gray in light mode, darker gray in dark mode */
 
   /* For compatibility with older naming */
-  .surface-divider {
-    @apply border-t;
-  }
+  @apply border-t;
+}
 
-  .border-brand, .product-border {
-    @apply border-brand-border dark:border-brand-dark-border;
-    /* Brand border – brand color in light mode, lighter brand-600 in dark mode */
-  }
+@utility border-brand {
+  @apply border-brand-border dark:border-brand-dark-border;
+  /* Brand border – brand color in light mode, lighter brand-600 in dark mode */
+}
 
-   /* 📝 TEXT STYLES */
-   /* Heading - "text primary" in design*/
-  .text-heading  {
-    @apply text-gray-900 dark:text-white;
-    /* Main heading text – black in light mode, white in dark mode */
-  }
+@utility product-border {
+  @apply border-brand-border dark:border-brand-dark-border;
+  /* Brand border – brand color in light mode, lighter brand-600 in dark mode */
+}
 
-  .text-secondary, .text-body {
-    @apply text-gray-600 dark:text-gray-300;
-    /* Body text – medium gray in light mode, light gray in dark mode */
-  }
+@utility text-heading {
+  /* 📝 TEXT STYLES */
+  /* Heading - "text primary" in design*/
+  @apply text-gray-900 dark:text-white;
+  /* Main heading text – black in light mode, white in dark mode */
+}
 
-  .text-tertiary, .text-muted {
-    @apply text-gray-500 dark:text-gray-400;
-    /* Subtle/secondary text – slightly muted for less emphasis */
-  }
+@utility text-secondary {
+  @apply text-gray-600 dark:text-gray-300;
+  /* Body text – medium gray in light mode, light gray in dark mode */
+}
 
-  .text-placeholder {
-    @apply text-gray-400 dark:text-gray-500;
-    /* Placeholder text – light gray in light mode, slightly darker in dark mode */
-  }
+@utility text-body {
+  @apply text-gray-600 dark:text-gray-300;
+  /* Body text – medium gray in light mode, light gray in dark mode */
+}
 
-  .text-brand, .product-primary, .product-text {
-    @apply text-brand-text dark:text-brand-dark-text;
-    /* Brand text – brand color in light mode, lighter brand-400 in dark mode */
-  }
+@utility text-tertiary {
+  @apply text-gray-500 dark:text-gray-400;
+  /* Subtle/secondary text – slightly muted for less emphasis */
+}
 
+@utility text-muted {
+  @apply text-gray-500 dark:text-gray-400;
+  /* Subtle/secondary text – slightly muted for less emphasis */
+}
+
+@utility text-placeholder {
+  @apply text-gray-400 dark:text-gray-500;
+  /* Placeholder text – light gray in light mode, slightly darker in dark mode */
+}
+
+@utility text-brand {
+  @apply text-brand-text dark:text-brand-dark-text;
+  /* Brand text – brand color in light mode, lighter brand-400 in dark mode */
+}
+
+@utility product-primary {
+  @apply text-brand-text dark:text-brand-dark-text;
+  /* Brand text – brand color in light mode, lighter brand-400 in dark mode */
+}
+
+@utility product-text {
+  @apply text-brand-text dark:text-brand-dark-text;
+  /* Brand text – brand color in light mode, lighter brand-400 in dark mode */
+}
+
+@utility icon-gray {
   /* 🎨 ICON STYLES */
-  .icon-gray {
-    @apply text-gray-400 dark:text-gray-500;
-    /* Gray icon color – light gray in light mode, slightly darker in dark mode */
-  }
+  @apply text-gray-400 dark:text-gray-500;
+  /* Gray icon color – light gray in light mode, slightly darker in dark mode */
+}
 
-  .icon-brand, .product-icon {
-    @apply text-brand-icon dark:text-brand-dark-icon;
-    /* Brand icon color – brand color in light mode, lighter brand-400 in dark mode */
-  }
+@utility icon-brand {
+  @apply text-brand-icon dark:text-brand-dark-icon;
+  /* Brand icon color – brand color in light mode, lighter brand-400 in dark mode */
+}
 
-  .icon-on-gray, .icon-secondary {
-    @apply text-gray-600 dark:text-gray-300;
-    /* On gray icon color – light gray in light mode, slightly darker in dark mode */
-  }
+@utility product-icon {
+  @apply text-brand-icon dark:text-brand-dark-icon;
+  /* Brand icon color – brand color in light mode, lighter brand-400 in dark mode */
+}
 
-  .icon-on-brand, .icon-primary {
-    @apply text-white dark:text-white;
-    /* On brand icon color – brand color in light mode, lighter brand-400 in dark mode */
-  }
+@utility icon-on-gray {
+  @apply text-gray-600 dark:text-gray-300;
+  /* On gray icon color – light gray in light mode, slightly darker in dark mode */
+}
 
+@utility icon-secondary {
+  @apply text-gray-600 dark:text-gray-300;
+  /* On gray icon color – light gray in light mode, slightly darker in dark mode */
+}
+
+@utility icon-on-brand {
+  @apply text-white dark:text-white;
+  /* On brand icon color – brand color in light mode, lighter brand-400 in dark mode */
+}
+
+@utility icon-primary {
+  @apply text-white dark:text-white;
+  /* On brand icon color – brand color in light mode, lighter brand-400 in dark mode */
+}
+
+@utility error-border {
   /* INPUT ERRORS STYLES */
-  .error-border {
-    @apply border-red-500 dark:border-red-400;
-    /* Input errors – red border in light mode, darker red in dark mode */
-  }
+  @apply border-red-500 dark:border-red-400;
+  /* Input errors – red border in light mode, darker red in dark mode */
+}
 
-  .error-text {
-      @apply text-red-500 dark:text-red-400;
-      /* Input errors – red text in light mode, darker red in dark mode */
-  }
+@utility error-text {
+  @apply text-red-500 dark:text-red-400;
+  /* Input errors – red text in light mode, darker red in dark mode */
+}
 
-  .error-placeholder {
-    @apply placeholder:text-red-400 dark:placeholder:text-red-300;
-    /* Input errors placeholder – red text in light mode, darker red in dark mode */
-  }
+@utility error-placeholder {
+  @apply placeholder:text-red-400 dark:placeholder:text-red-300;
+  /* Input errors placeholder – red text in light mode, darker red in dark mode */
+}
 
+@utility success-border {
   /* INPUT SUCCESS STYLES */
-  .success-border {
-    @apply border-green-500 dark:border-green-400;
-    /* Input success – green border in light mode, darker green in dark mode */
-  }
+  @apply border-green-500 dark:border-green-400;
+  /* Input success – green border in light mode, darker green in dark mode */
+}
 
-  .success-text {
-    @apply text-green-500 dark:text-green-400;
-    /* Input success – green text in light mode, darker green in dark mode */
-  }
+@utility success-text {
+  @apply text-green-500 dark:text-green-400;
+  /* Input success – green text in light mode, darker green in dark mode */
+}
 
-  .success-placeholder{
-    @apply placeholder:text-green-400 dark:placeholder:text-green-300;
-    /* Input success placeholder – green text in light mode, darker green in dark mode */
-  }  
+@utility success-placeholder {
+  @apply placeholder:text-green-400 dark:placeholder:text-green-300;
+  /* Input success placeholder – green text in light mode, darker green in dark mode */
+}
 
+@utility link-building-link {
   /* 🔗 LINK STYLES */
-  .link-building-link {
-    @apply underline hover:text-primary;
-  }
+  @apply underline hover:text-primary;
+}
 
-
+@utility btn-transition {
   /* ================================================================ */
   /* 🔘 BUTTON SYSTEM (from main-old.css) */
   /* ================================================================ */
 
   /* Common button transition */
-  .btn-transition {
-    @apply transition-all duration-300 ease-in-out;
-  }
+  @apply transition-all duration-300 ease-in-out;
+}
 
+@utility btn-primary {
   /* Primary button on light backgrounds – white text, customizable background */
-  .btn-primary {
-    @apply inline-flex items-center justify-center text-sm font-semibold rounded-md shadow-sm text-white bg-button-primary hover:bg-button-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-button-primary-outline btn-transition;
-  }
+  @apply inline-flex items-center justify-center text-sm font-semibold rounded-md shadow-xs text-white bg-button-primary hover:bg-button-primary-hover focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-button-primary-outline btn-transition;
+}
 
+@utility btn-primary-alternate {
   /* Primary button on light alternate backgrounds – white text, customizable background */
-  .btn-primary-alternate {
-    @apply inline-flex items-center justify-center text-sm font-semibold rounded-md shadow-sm text-white bg-button-primary hover:bg-button-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-button-primary-outline btn-transition;
-  }
+  @apply inline-flex items-center justify-center text-sm font-semibold rounded-md shadow-xs text-white bg-button-primary hover:bg-button-primary-hover focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-button-primary-outline btn-transition;
+}
 
+@utility btn-primary-dark {
   /* Primary button on dark backgrounds – customizable background for contrast */
-  .btn-primary-dark {
-    @apply inline-flex items-center justify-center text-sm font-semibold rounded-md shadow-sm text-white bg-button-primary-dark hover:bg-button-primary-dark-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-button-primary-dark btn-transition;
-  }
+  @apply inline-flex items-center justify-center text-sm font-semibold rounded-md shadow-xs text-white bg-button-primary-dark hover:bg-button-primary-dark-hover focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-button-primary-dark btn-transition;
+}
 
+@utility btn-primary-alternate-dark {
   /* Primary button on dark alternate backgrounds – white background with dark text */
-  .btn-primary-alternate-dark {
-    @apply inline-flex items-center justify-center text-sm font-semibold rounded-md shadow-sm text-gray-900 bg-white hover:bg-gray-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-100 btn-transition;
-  }
-  
+  @apply inline-flex items-center justify-center text-sm font-semibold rounded-md shadow-xs text-gray-900 bg-white hover:bg-gray-100 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-100 btn-transition;
+}
+
+@utility btn-secondary {
   /* Secondary button – customizable colors for all states */
-  .btn-secondary {
-    @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md shadow-sm bg-button-secondary border-button-secondary-border text-button-secondary-text hover:border-button-secondary-border-hover btn-transition;
-  }
+  @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md shadow-xs bg-button-secondary border-button-secondary-border text-button-secondary-text hover:border-button-secondary-border-hover btn-transition;
+}
 
+@utility btn-secondary-alternate {
   /* Secondary button for alternate light backgrounds – customizable colors */
-  .btn-secondary-alternate {
-    @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md bg-button-secondary border-button-secondary-border text-button-secondary-text hover:border-button-secondary-border-hover btn-transition;
-  }
+  @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md bg-button-secondary border-button-secondary-border text-button-secondary-text hover:border-button-secondary-border-hover btn-transition;
+}
 
+@utility btn-secondary-dark {
   /* Secondary button for dark backgrounds – customizable dark colors */
-  .btn-secondary-dark {
-    @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md shadow-sm bg-button-secondary-dark/10 text-button-secondary-dark-text border-button-secondary-dark-border hover:border-button-secondary-dark-border-hover btn-transition;
-  }
+  @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md shadow-xs bg-button-secondary-dark/10 text-button-secondary-dark-text border-button-secondary-dark-border hover:border-button-secondary-dark-border-hover btn-transition;
+}
 
+@utility btn-secondary-alternate-dark {
   /* Secondary button for dark alternate backgrounds – customizable dark colors */
-  .btn-secondary-alternate-dark {
-    @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md shadow-sm text-button-secondary-dark-text border-button-secondary-dark-border hover:border-button-secondary-dark-border-hover btn-transition;
-  }
+  @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md shadow-xs text-button-secondary-dark-text border-button-secondary-dark-border hover:border-button-secondary-dark-border-hover btn-transition;
+}
 
+@utility btn-text {
   /* Minimal text button – customizable text colors */
-  .btn-text {
-    @apply text-sm font-semibold text-button-text hover:text-button-text-hover btn-transition;
-  }
-  
+  @apply text-sm font-semibold text-button-text hover:text-button-text-hover btn-transition;
+}
+
+@utility btn-text-dark {
   /* Minimal text button for dark backgrounds – customizable dark text colors */
-  .btn-text-dark {
-    @apply text-sm font-semibold text-button-text-dark hover:text-button-text-dark-hover btn-transition;
-  }
+  @apply text-sm font-semibold text-button-text-dark hover:text-button-text-dark-hover btn-transition;
+}
 
+@utility btn-arrow {
   /* Button arrow animation */
-  .btn-arrow {
-    @apply font-semibold inline-block transition-transform duration-300;
-  }
+  @apply font-semibold inline-block transition-transform duration-300;
+}
 
+@utility badge-base {
   /* ================================================================ */
   /* 🏷️ BADGE SYSTEM (from badges.css) */
   /* ================================================================ */
 
   /* Base styles for all badges */
-  .badge-base {
-    @apply inline-flex items-center justify-center px-2 py-1 text-xs font-semibold rounded-md leading-4 tracking-[0.216px];
-  }
+  @apply inline-flex items-center justify-center px-2 py-1 text-xs font-semibold rounded-md leading-4 tracking-[0.216px];
+}
 
+@utility badge-gray {
   /* Color schemes for badges */
-  .badge-gray {
-    @apply bg-gray-100 dark:bg-gray-400/20 text-gray-500 dark:text-gray-400;
-  }
-  .badge-red {
-    @apply bg-red-100 dark:bg-red-300/20 text-red-700 dark:text-red-300;
-  }
-  .badge-yellow {
-    @apply bg-yellow-100 dark:bg-yellow-500/20 text-yellow-800 dark:text-yellow-500;
-  }
-  .badge-green {
-    @apply bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400;
-  }
-  .badge-blue {
-    @apply bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400;
-  }
-  .badge-purple {
-    @apply bg-purple-100 dark:bg-purple-500/20 text-purple-700 dark:text-purple-400;
-  }
-  .badge-indigo {
-    @apply bg-indigo-100 dark:bg-indigo-500/20 text-indigo-700 dark:text-indigo-400;
-  }
-  .badge-pink {
-    @apply bg-pink-100 dark:bg-pink-500/20 text-pink-700 dark:text-pink-400;
-  }
-  .badge-orange {
-    @apply bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400;
-  }
-  .badge-teal {
-    @apply bg-teal-100 dark:bg-teal-500/20 text-teal-700 dark:text-teal-400;
-  }
-  .badge-cyan {
-    @apply bg-cyan-100 dark:bg-cyan-500/20 text-cyan-700 dark:text-cyan-400;
-  }
-  .badge-lime {
-    @apply bg-lime-100 dark:bg-lime-500/20 text-lime-700 dark:text-lime-400;
-  }
-  .badge-emerald {
-    @apply bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-400;
-  }
-  .badge-sky {
-    @apply bg-sky-100 dark:bg-sky-500/20 text-sky-700 dark:text-sky-400;
-  }
-  .badge-violet {
-    @apply bg-violet-100 dark:bg-violet-500/20 text-violet-700 dark:text-violet-400;
-  }
-  .badge-fuchsia {
-    @apply bg-fuchsia-100 dark:bg-fuchsia-500/20 text-fuchsia-700 dark:text-fuchsia-400;
-  }
-  .badge-rose {
-    @apply bg-rose-100 dark:bg-rose-500/20 text-rose-700 dark:text-rose-400;
-  }
-  .badge-amber {
-    @apply bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400;
-  }
-  .badge-slate {
-    @apply bg-slate-100 dark:bg-slate-400/20 text-slate-700 dark:text-slate-400;
-  }
-
-  /* Class for adding border */
-  .badge-with-border {
-    @apply border; /* Just add border, the color will be from the badge color */
-  }
+  @apply bg-gray-100 dark:bg-gray-400/20 text-gray-500 dark:text-gray-400;
 
   /* Border colors for badges with border */
-  .badge-gray.badge-with-border {
-      @apply border-gray-500/20 dark:border-gray-400/20;
-  }
-  .badge-red.badge-with-border {
-      @apply border-red-500/20 dark:border-red-300/20;
-  }
-  .badge-yellow.badge-with-border {
-      @apply border-yellow-500/20 dark:border-yellow-500/20;
-  }
-  .badge-green.badge-with-border {
-      @apply border-green-500/20 dark:border-green-500/20;
-  }
-  .badge-blue.badge-with-border {
-      @apply border-blue-500/20 dark:border-blue-500/20;
-  }
-  .badge-purple.badge-with-border {
-      @apply border-purple-500/20 dark:border-purple-500/20;
-  }
-  .badge-indigo.badge-with-border {
-      @apply border-indigo-500/20 dark:border-indigo-500/20;
-  }
-  .badge-pink.badge-with-border {
-      @apply border-pink-500/20 dark:border-pink-500/20;
-  }
-  .badge-orange.badge-with-border {
-      @apply border-orange-500/20 dark:border-orange-500/20;
-  }
-  .badge-teal.badge-with-border {
-      @apply border-teal-500/20 dark:border-teal-500/20;
-  }
-  .badge-cyan.badge-with-border {
-      @apply border-cyan-500/20 dark:border-cyan-500/20;
-  }
-  .badge-lime.badge-with-border {
-      @apply border-lime-500/20 dark:border-lime-500/20;
-  }
-  .badge-emerald.badge-with-border {
-      @apply border-emerald-500/20 dark:border-emerald-500/20;
-  }
-  .badge-sky.badge-with-border {
-      @apply border-sky-500/20 dark:border-sky-500/20;
-  }
-  .badge-violet.badge-with-border {
-      @apply border-violet-500/20 dark:border-violet-500/20;
-  }
-  .badge-fuchsia.badge-with-border {
-      @apply border-fuchsia-500/20 dark:border-fuchsia-500/20;
-  }
-  .badge-rose.badge-with-border {
-      @apply border-rose-500/20 dark:border-rose-500/20;
-  }
-  .badge-amber.badge-with-border {
-      @apply border-amber-500/20 dark:border-amber-500/20;
-  }
-  .badge-slate.badge-with-border {
-      @apply border-slate-500/20 dark:border-slate-400/20;
+  &.badge-with-border {
+    @apply border-gray-500/20 dark:border-gray-400/20;
   }
 }
 
-/* 🛠️ UTILITIES */
-@layer utilities {
-  /* Custom utility classes */
-  .text-shadow {
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    /* Light text shadow for subtle depth */
+@utility badge-red {
+  @apply bg-red-100 dark:bg-red-300/20 text-red-700 dark:text-red-300;
+  &.badge-with-border {
+    @apply border-red-500/20 dark:border-red-300/20;
   }
+}
 
-  .hide-search-clear::-webkit-search-cancel-button {
+@utility badge-yellow {
+  @apply bg-yellow-100 dark:bg-yellow-500/20 text-yellow-800 dark:text-yellow-500;
+  &.badge-with-border {
+    @apply border-yellow-500/20 dark:border-yellow-500/20;
+  }
+}
+
+@utility badge-green {
+  @apply bg-green-100 dark:bg-green-500/20 text-green-700 dark:text-green-400;
+  &.badge-with-border {
+    @apply border-green-500/20 dark:border-green-500/20;
+  }
+}
+
+@utility badge-blue {
+  @apply bg-blue-100 dark:bg-blue-500/20 text-blue-700 dark:text-blue-400;
+  &.badge-with-border {
+    @apply border-blue-500/20 dark:border-blue-500/20;
+  }
+}
+
+@utility badge-purple {
+  @apply bg-purple-100 dark:bg-purple-500/20 text-purple-700 dark:text-purple-400;
+  &.badge-with-border {
+    @apply border-purple-500/20 dark:border-purple-500/20;
+  }
+}
+
+@utility badge-indigo {
+  @apply bg-indigo-100 dark:bg-indigo-500/20 text-indigo-700 dark:text-indigo-400;
+  &.badge-with-border {
+    @apply border-indigo-500/20 dark:border-indigo-500/20;
+  }
+}
+
+@utility badge-pink {
+  @apply bg-pink-100 dark:bg-pink-500/20 text-pink-700 dark:text-pink-400;
+  &.badge-with-border {
+    @apply border-pink-500/20 dark:border-pink-500/20;
+  }
+}
+
+@utility badge-orange {
+  @apply bg-orange-100 dark:bg-orange-500/20 text-orange-700 dark:text-orange-400;
+  &.badge-with-border {
+    @apply border-orange-500/20 dark:border-orange-500/20;
+  }
+}
+
+@utility badge-teal {
+  @apply bg-teal-100 dark:bg-teal-500/20 text-teal-700 dark:text-teal-400;
+  &.badge-with-border {
+    @apply border-teal-500/20 dark:border-teal-500/20;
+  }
+}
+
+@utility badge-cyan {
+  @apply bg-cyan-100 dark:bg-cyan-500/20 text-cyan-700 dark:text-cyan-400;
+  &.badge-with-border {
+    @apply border-cyan-500/20 dark:border-cyan-500/20;
+  }
+}
+
+@utility badge-lime {
+  @apply bg-lime-100 dark:bg-lime-500/20 text-lime-700 dark:text-lime-400;
+  &.badge-with-border {
+    @apply border-lime-500/20 dark:border-lime-500/20;
+  }
+}
+
+@utility badge-emerald {
+  @apply bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-400;
+  &.badge-with-border {
+    @apply border-emerald-500/20 dark:border-emerald-500/20;
+  }
+}
+
+@utility badge-sky {
+  @apply bg-sky-100 dark:bg-sky-500/20 text-sky-700 dark:text-sky-400;
+  &.badge-with-border {
+    @apply border-sky-500/20 dark:border-sky-500/20;
+  }
+}
+
+@utility badge-violet {
+  @apply bg-violet-100 dark:bg-violet-500/20 text-violet-700 dark:text-violet-400;
+  &.badge-with-border {
+    @apply border-violet-500/20 dark:border-violet-500/20;
+  }
+}
+
+@utility badge-fuchsia {
+  @apply bg-fuchsia-100 dark:bg-fuchsia-500/20 text-fuchsia-700 dark:text-fuchsia-400;
+  &.badge-with-border {
+    @apply border-fuchsia-500/20 dark:border-fuchsia-500/20;
+  }
+}
+
+@utility badge-rose {
+  @apply bg-rose-100 dark:bg-rose-500/20 text-rose-700 dark:text-rose-400;
+  &.badge-with-border {
+    @apply border-rose-500/20 dark:border-rose-500/20;
+  }
+}
+
+@utility badge-amber {
+  @apply bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400;
+  &.badge-with-border {
+    @apply border-amber-500/20 dark:border-amber-500/20;
+  }
+}
+
+@utility badge-slate {
+  @apply bg-slate-100 dark:bg-slate-400/20 text-slate-700 dark:text-slate-400;
+  &.badge-with-border {
+    @apply border-slate-500/20 dark:border-slate-400/20;
+  }
+}
+
+@utility badge-with-border {
+  /* Class for adding border */
+  @apply border; /* Just add border, the color will be from the badge color */
+
+  /* Border colors for badges with border */
+  &.badge-gray {
+    @apply border-gray-500/20 dark:border-gray-400/20;
+  }
+  &.badge-red {
+    @apply border-red-500/20 dark:border-red-300/20;
+  }
+  &.badge-yellow {
+    @apply border-yellow-500/20 dark:border-yellow-500/20;
+  }
+  &.badge-green {
+    @apply border-green-500/20 dark:border-green-500/20;
+  }
+  &.badge-blue {
+    @apply border-blue-500/20 dark:border-blue-500/20;
+  }
+  &.badge-purple {
+    @apply border-purple-500/20 dark:border-purple-500/20;
+  }
+  &.badge-indigo {
+    @apply border-indigo-500/20 dark:border-indigo-500/20;
+  }
+  &.badge-pink {
+    @apply border-pink-500/20 dark:border-pink-500/20;
+  }
+  &.badge-orange {
+    @apply border-orange-500/20 dark:border-orange-500/20;
+  }
+  &.badge-teal {
+    @apply border-teal-500/20 dark:border-teal-500/20;
+  }
+  &.badge-cyan {
+    @apply border-cyan-500/20 dark:border-cyan-500/20;
+  }
+  &.badge-lime {
+    @apply border-lime-500/20 dark:border-lime-500/20;
+  }
+  &.badge-emerald {
+    @apply border-emerald-500/20 dark:border-emerald-500/20;
+  }
+  &.badge-sky {
+    @apply border-sky-500/20 dark:border-sky-500/20;
+  }
+  &.badge-violet {
+    @apply border-violet-500/20 dark:border-violet-500/20;
+  }
+  &.badge-fuchsia {
+    @apply border-fuchsia-500/20 dark:border-fuchsia-500/20;
+  }
+  &.badge-rose {
+    @apply border-rose-500/20 dark:border-rose-500/20;
+  }
+  &.badge-amber {
+    @apply border-amber-500/20 dark:border-amber-500/20;
+  }
+  &.badge-slate {
+    @apply border-slate-500/20 dark:border-slate-400/20;
+  }
+}
+
+@utility text-shadow {
+  /* Custom utility classes */
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  /* Light text shadow for subtle depth */
+}
+
+@utility hide-search-clear {
+  &::-webkit-search-cancel-button {
     appearance: none;
     @apply hidden;
   }
+}
 
+@utility toc-select {
   /* TOC select appearance reset */
-  .toc-select {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-  }
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 
-  .toc-select::-ms-expand {
+  &::-ms-expand {
     display: none;
   }
+}
 
+@utility hero-overlay-shadow {
   /* Hero overlay shadow */
-  .hero-overlay-shadow {
-    box-shadow: 0.25rem 0.54rem 0.34rem -0.29rem rgba(0, 0, 0, 0.06), 0.245rem 0.538rem 0.343rem -0.294rem rgba(0, 0, 0, 0.06);
-  }
+  box-shadow:
+    0.25rem 0.54rem 0.34rem -0.29rem rgba(0, 0, 0, 0.06),
+    0.245rem 0.538rem 0.343rem -0.294rem rgba(0, 0, 0, 0.06);
+}
 
-  /* Eliminate focus outline for iframes */
-  iframe {
-    outline: none !important;
-  }
-
+@utility prose-links {
   /* ================================================================ */
   /* 📝 PROSE STYLES */
   /* ================================================================ */
-  
-  .prose-links {
-    @apply prose-a:text-secondary prose-a:font-normal prose-a:underline;
-    /* Standard prose with custom link styling */
-  }
+  @apply prose-a:text-secondary prose-a:font-normal prose-a:underline;
+  /* Standard prose with custom link styling */
 
-  .prose-links a:not([class^="btn-"]),
-  a.prose-links:not([class^="btn-"]) {
+  & a:not([class^='btn-']) {
     text-decoration-line: underline !important;
     text-underline-offset: 0.16em;
     text-decoration-thickness: from-font;
   }
-  
-  .prose-links a:hover:not([class^="btn-"]),
-  a.prose-links:hover:not([class^="btn-"]) {
+
+  & a:not([class^='btn-']) {
+    text-decoration-line: underline !important;
+    text-underline-offset: 0.16em;
+    text-decoration-thickness: from-font;
+  }
+
+  & a:hover:not([class^='btn-']) {
     @apply text-brand-text;
   }
-  
+
+  & a:hover:not([class^='btn-']) {
+    @apply text-brand-text;
+  }
+}
+
+@utility scrollbar-custom {
   /* ================================================================ */
   /* CUSTOM SCROLLBAR */
   /* ================================================================ */
-
-  .scrollbar-custom {
-    overflow: auto;
-  }
-  .scrollbar-custom::-webkit-scrollbar {
+  overflow: auto;
+  &::-webkit-scrollbar {
     width: 4px;
   }
 
-  .scrollbar-custom::-webkit-scrollbar-thumb {
+  &::-webkit-scrollbar-thumb {
     @apply bg-gray-400 rounded-md;
   }
 
-  .scrollbar-custom::-webkit-scrollbar-track {
+  &::-webkit-scrollbar-track {
     @apply bg-transparent;
   }
+}
 
+@utility text-glow-primary {
   /*
   * Text shadow primary styles
   */
-  .text-glow-primary {
-    -webkit-filter: drop-shadow(-1px -1px 0 rgba(140, 200, 253, 0.8))
-      drop-shadow(1px -1px 0 rgba(140, 200, 253, 0.8))
-      drop-shadow(-1px 1px 0 rgba(140, 200, 253, 0.8))
-      drop-shadow(1px 1px 0 rgba(140, 200, 253, 0.8))
-      drop-shadow(0 0 9px rgba(87, 171, 250, 0.5));
-    filter: drop-shadow(-1px -1px 0 rgba(140, 200, 253, 0.8))
-      drop-shadow(1px -1px 0 rgba(140, 200, 253, 0.8))
-      drop-shadow(-1px 1px 0 rgba(140, 200, 253, 0.8))
-      drop-shadow(1px 1px 0 rgba(140, 200, 253, 0.8))
-      drop-shadow(0 0 9px rgba(87, 171, 250, 0.5));
-  }
-  
+  -webkit-filter: drop-shadow(-1px -1px 0 rgba(140, 200, 253, 0.8))
+    drop-shadow(1px -1px 0 rgba(140, 200, 253, 0.8))
+    drop-shadow(-1px 1px 0 rgba(140, 200, 253, 0.8))
+    drop-shadow(1px 1px 0 rgba(140, 200, 253, 0.8))
+    drop-shadow(0 0 9px rgba(87, 171, 250, 0.5));
+  filter: drop-shadow(-1px -1px 0 rgba(140, 200, 253, 0.8))
+    drop-shadow(1px -1px 0 rgba(140, 200, 253, 0.8))
+    drop-shadow(-1px 1px 0 rgba(140, 200, 253, 0.8))
+    drop-shadow(1px 1px 0 rgba(140, 200, 253, 0.8))
+    drop-shadow(0 0 9px rgba(87, 171, 250, 0.5));
+}
+
+@utility single-content {
   /*
   * Prose figure styles for single pages
   */
-  .single-content figure {
+  & figure {
     text-align: center;
   }
-  
-  .single-content figure picture {
+
+  & figure picture {
     display: inline-block;
     max-width: 100%;
     margin-left: auto;
     margin-right: auto;
   }
 
-  .single-content figure img {
+  & figure img {
     max-width: 100%;
     height: auto;
     display: inline-block;
+  }
+}
+
+/* 🛠️ UTILITIES */
+@layer utilities {
+  /* Eliminate focus outline for iframes */
+  iframe {
+    outline: none !important;
   }
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -253,7 +253,7 @@
 
   /* Secondary button for dark backgrounds – customizable dark colors */
   .btn-secondary-dark {
-    @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md shadow-sm bg-button-secondary-dark bg-opacity-10 text-button-secondary-dark-text border-button-secondary-dark-border hover:border-button-secondary-dark-border-hover btn-transition;
+    @apply inline-flex items-center justify-center text-sm font-semibold border rounded-md shadow-sm bg-button-secondary-dark/10 text-button-secondary-dark-text border-button-secondary-dark-border hover:border-button-secondary-dark-border-hover btn-transition;
   }
 
   /* Secondary button for dark alternate backgrounds – customizable dark colors */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,15 @@
+/* ================================================================== */
+/*  REQUIRES TAILWIND CSS v4 (>= 4.3.3)                               */
+/*                                                                    */
+/*  This file uses @import "tailwindcss", @config, @utility and       */
+/*  @custom-variant — none of which exist in v3. If your project is   */
+/*  still on Tailwind v3, bumping the theme submodule pointer WILL    */
+/*  break your build.                                                 */
+/*                                                                    */
+/*  Migration guide: README.md -> "Migrating a project to Tailwind v4"*/
+/*  Last v3-compatible theme commit: 2517448                          */
+/* ================================================================== */
+
 /*
   TODO(v4-compat): hover
   v4 gates `hover:` behind @media (hover: hover) so it no longer fires on touch

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,3 +1,16 @@
+/*
+  TODO(v4-compat): hover
+  v4 gates `hover:` behind @media (hover: hover) so it no longer fires on touch
+  devices. That is the better behaviour and this override should be the FIRST
+  compat entry removed — it is kept only so the upgrade ships pixel-identical.
+  747 `hover:` usages are affected.
+
+  Declared HERE, above the @imports, on purpose: a custom variant only applies to
+  @apply that Tailwind processes AFTER the declaration, and components/floating-cta.css
+  is inlined by the import below. Declared further down it would miss those.
+*/
+@custom-variant hover (&:hover);
+
 /* 🎨 CSS IMPORTS - ALL IMPORTS MUST BE FIRST */
 @import './variables.css' layer(base);
 @import './fonts.css' layer(base);
@@ -26,13 +39,20 @@
 */
 @config '../../../../tailwind.config.js';
 
-/*
-  The default border color has changed to `currentcolor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
+/* ================================================================ */
+/* TODO(v4-compat): Tailwind v3 defaults restored                   */
+/* ---------------------------------------------------------------- */
+/* Everything in this block exists only to keep the v4 upgrade       */
+/* visually identical to v3. Each entry is independent and can be    */
+/* removed on its own once the markup no longer relies on it.        */
+/* Removal order, easiest first: hover -> placeholder -> cursor ->   */
+/* ring -> border-color (that last one touches ~555 call sites).     */
+/* ================================================================ */
 
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
+/*
+  border-color: v3 defaulted to gray-200, v4 defaults to currentcolor.
+  ~555 usages of a bare `border` rely on this.
+  To remove: give every such element an explicit border-<color> utility.
 */
 @layer base {
   *,
@@ -43,6 +63,43 @@
     border-color: var(--color-gray-200, currentcolor);
   }
 }
+
+/*
+  placeholder: v3 defaulted to gray-400 (via @tailwindcss/forms), v4 uses
+  currentColor at 50% opacity — which reads much darker on our inputs.
+  To remove: audit input contrast, then delete.
+*/
+@layer base {
+  input::placeholder,
+  textarea::placeholder {
+    color: var(--color-gray-400);
+  }
+}
+
+/*
+  cursor: v3 preflight set `cursor: pointer` on buttons, v4 sets `default`.
+  To remove: add `cursor-pointer` to button components.
+*/
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}
+
+/*
+  ring: v3 defaulted to 3px / blue-500. v4 defaults to 1px / currentColor.
+  The upgrade tool already rewrote bare `ring` to `ring-3` at the call sites,
+  so this only restores the default COLOUR for rings with no explicit colour.
+  To remove: add an explicit ring-<color> wherever a ring utility appears alone.
+*/
+@theme {
+  /* Literal rather than var(--color-blue-500): v3's computed default was
+     rgba(59,130,246,.5) — blue-500 at 50% alpha, not full opacity. Spelling it
+     out in rgb() also keeps it working on browsers without oklch support. */
+  --default-ring-color: rgb(59 130 246 / 0.5);
+}
+
 
 /* 🎨 CORE STYLES */
 

--- a/assets/css/tailwind-context.css
+++ b/assets/css/tailwind-context.css
@@ -24,3 +24,15 @@
 */
 @import 'tailwindcss';
 @config '../../../../tailwind.config.js';
+
+/*
+  TODO(v4-compat): hover — must be repeated here, not only in main.css.
+
+  A stylesheet that @references this file does NOT see variants declared in
+  main.css, so without this line an `@apply hover:*` in e.g. a project's
+  custom.css would still emit v4's @media (hover: hover) gate while the same
+  @apply in main.css would not — the two bundles would disagree on touch devices.
+
+  Remove together with the matching entry in main.css.
+*/
+@custom-variant hover (&:hover);

--- a/assets/css/tailwind-context.css
+++ b/assets/css/tailwind-context.css
@@ -1,0 +1,26 @@
+/*
+  @reference target for stylesheets compiled STANDALONE.
+
+  FOR @reference ONLY — never @import this file. `main.css` carries its own copy of
+  these two lines, because `@config` cannot be nested inside an @import.
+
+  Who needs it: any stylesheet that goes through Tailwind on its own and uses
+  @apply — `components/floating-cta.css` here, `assets/css/custom.css` and
+  `assets/css/components/*.css` in a consuming project. Such a file has no theme
+  context of its own; in v3 that was fine, in v4 it is a hard build failure
+  ("Cannot apply unknown utility class"). @reference supplies the context without
+  emitting anything into that file's output.
+
+  Why this file rather than referencing `main.css` directly: `main.css` @imports
+  several of those same component stylesheets, so pointing their @reference back at
+  `main.css` is circular — it fails with "Exceeded maximum recursion depth". This
+  file imports nothing local, so it is safe to reference from anywhere.
+
+  KEEP IN SYNC with the @import/@config pair at the top of main.css.
+
+  The @config path resolves the CONSUMER's root config, not the theme's own — see
+  the longer comment in main.css. Hugo always mounts this theme at
+  `themes/boilerplate/`, so four levels up is the consumer root for every site.
+*/
+@import 'tailwindcss';
+@config '../../../../tailwind.config.js';

--- a/assets/css/typewriter.css
+++ b/assets/css/typewriter.css
@@ -8,7 +8,7 @@
   position: relative;
   /* color: theme('colors.indigo.600'); */ /* Replaced by gradient */
   font-weight: inherit;
-  background-image: linear-gradient(to right, theme('colors.indigo.600'), theme('colors.purple.600'), theme('colors.pink.500')); /* Example gradient */
+  background-image: linear-gradient(to right, var(--color-indigo-600), var(--color-purple-600), var(--color-pink-500)); /* Example gradient */
   -webkit-background-clip: text; /* For Safari/Chrome */
   background-clip: text;
   color: transparent;

--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -101,3 +101,216 @@
   --color-brand-text: #0ea5e9;
   --color-brand-icon: #0ea5e9;
 }
+
+/* PROJECT VARIABLES - Custom colors for this project */
+
+@layer base {
+  :root {
+  /* LiveAgent Brand Orange Colors */
+  --color-primary-50: 255 247 237;
+  --color-primary-100: 255 237 213;
+  --color-primary-200: 254 215 170;
+  --color-primary-300: 253 186 116;
+  --color-primary-400: 251 146 60;
+  --color-primary-500: 249 115 22;
+  --color-primary-600: 234 88 12;
+  --color-primary-700: 194 65 12;
+  --color-primary-800: 154 52 18;
+  --color-primary-900: 124 45 18;
+  --color-primary-950: 67 20 7;
+  --color-primary: 251 146 60;
+
+  /* Gray colors (neutral palette) */
+  --color-gray-50: 250 250 250;
+  --color-gray-100: 245 245 245;
+  --color-gray-200: 229 229 229;
+  --color-gray-300: 212 212 212;
+  --color-gray-400: 163 163 163;
+  --color-gray-500: 115 115 115;
+  --color-gray-600: 82 82 82;
+  --color-gray-700: 64 64 64;
+  --color-gray-800: 38 38 38;
+  --color-gray-900: 23 23 23;
+  --color-gray-950: 10 10 10;
+
+  /* Button colors - neutral dark */
+  --color-button-primary: var(--color-gray-900);
+  --color-button-primary-hover: var(--color-gray-800);
+  --color-button-primary-dark: var(--color-primary-400);
+  --color-button-primary-dark-hover: var(--color-primary-300);
+  --color-button-primary-outline: var(--color-gray-900);
+
+  /* Brand colors */
+  --color-brand-surface: var(--color-primary);
+  --color-brand-dark-surface: var(--color-primary);
+  --color-brand-surface-secondary: var(--color-primary-500); /* -20% opacity */
+  --color-brand-dark-surface-secondary: var(--color-primary-500); /* -20% opacity */
+  --color-brand-border: var(--color-primary-300);
+  --color-brand-dark-border: var(--color-primary-300);
+  --color-brand-text: var(--color-primary);
+  --color-brand-dark-text: var(--color-primary);
+  --color-brand-icon: var(--color-primary);
+  --color-brand-dark-icon: var(--color-primary);
+  --color-brand-underlight: var(--color-primary-300);
+  --color-brand-dark-underlight: var(--color-primary-900);
+  }
+}
+/* PROJECT VARIABLES - Custom colors for this project */
+
+@layer base {
+  :root {
+  /* LiveAgent Brand Orange Colors */
+  --color-primary-50: 255 247 237;
+  --color-primary-100: 255 237 213;
+  --color-primary-200: 254 215 170;
+  --color-primary-300: 253 186 116;
+  --color-primary-400: 251 146 60;
+  --color-primary-500: 249 115 22;
+  --color-primary-600: 234 88 12;
+  --color-primary-700: 194 65 12;
+  --color-primary-800: 154 52 18;
+  --color-primary-900: 124 45 18;
+  --color-primary-950: 67 20 7;
+  --color-primary: 251 146 60;
+
+  /* Gray colors (neutral palette) */
+  --color-gray-50: 250 250 250;
+  --color-gray-100: 245 245 245;
+  --color-gray-200: 229 229 229;
+  --color-gray-300: 212 212 212;
+  --color-gray-400: 163 163 163;
+  --color-gray-500: 115 115 115;
+  --color-gray-600: 82 82 82;
+  --color-gray-700: 64 64 64;
+  --color-gray-800: 38 38 38;
+  --color-gray-900: 23 23 23;
+  --color-gray-950: 10 10 10;
+
+  /* Button colors - neutral dark */
+  --color-button-primary: var(--color-gray-900);
+  --color-button-primary-hover: var(--color-gray-800);
+  --color-button-primary-dark: var(--color-primary-400);
+  --color-button-primary-dark-hover: var(--color-primary-300);
+  --color-button-primary-outline: var(--color-gray-900);
+
+  /* Brand colors */
+  --color-brand-surface: var(--color-primary);
+  --color-brand-dark-surface: var(--color-primary);
+  --color-brand-surface-secondary: var(--color-primary-500); /* -20% opacity */
+  --color-brand-dark-surface-secondary: var(--color-primary-500); /* -20% opacity */
+  --color-brand-border: var(--color-primary-300);
+  --color-brand-dark-border: var(--color-primary-300);
+  --color-brand-text: var(--color-primary);
+  --color-brand-dark-text: var(--color-primary);
+  --color-brand-icon: var(--color-primary);
+  --color-brand-dark-icon: var(--color-primary);
+  --color-brand-underlight: var(--color-primary-300);
+  --color-brand-dark-underlight: var(--color-primary-900);
+  }
+}
+/* PROJECT VARIABLES - Custom colors for this project */
+
+@layer base {
+  :root {
+  /* LiveAgent Brand Orange Colors */
+  --color-primary-50: 255 247 237;
+  --color-primary-100: 255 237 213;
+  --color-primary-200: 254 215 170;
+  --color-primary-300: 253 186 116;
+  --color-primary-400: 251 146 60;
+  --color-primary-500: 249 115 22;
+  --color-primary-600: 234 88 12;
+  --color-primary-700: 194 65 12;
+  --color-primary-800: 154 52 18;
+  --color-primary-900: 124 45 18;
+  --color-primary-950: 67 20 7;
+  --color-primary: 251 146 60;
+
+  /* Gray colors (neutral palette) */
+  --color-gray-50: 250 250 250;
+  --color-gray-100: 245 245 245;
+  --color-gray-200: 229 229 229;
+  --color-gray-300: 212 212 212;
+  --color-gray-400: 163 163 163;
+  --color-gray-500: 115 115 115;
+  --color-gray-600: 82 82 82;
+  --color-gray-700: 64 64 64;
+  --color-gray-800: 38 38 38;
+  --color-gray-900: 23 23 23;
+  --color-gray-950: 10 10 10;
+
+  /* Button colors - neutral dark */
+  --color-button-primary: var(--color-gray-900);
+  --color-button-primary-hover: var(--color-gray-800);
+  --color-button-primary-dark: var(--color-primary-400);
+  --color-button-primary-dark-hover: var(--color-primary-300);
+  --color-button-primary-outline: var(--color-gray-900);
+
+  /* Brand colors */
+  --color-brand-surface: var(--color-primary);
+  --color-brand-dark-surface: var(--color-primary);
+  --color-brand-surface-secondary: var(--color-primary-500); /* -20% opacity */
+  --color-brand-dark-surface-secondary: var(--color-primary-500); /* -20% opacity */
+  --color-brand-border: var(--color-primary-300);
+  --color-brand-dark-border: var(--color-primary-300);
+  --color-brand-text: var(--color-primary);
+  --color-brand-dark-text: var(--color-primary);
+  --color-brand-icon: var(--color-primary);
+  --color-brand-dark-icon: var(--color-primary);
+  --color-brand-underlight: var(--color-primary-300);
+  --color-brand-dark-underlight: var(--color-primary-900);
+  }
+}
+/* PROJECT VARIABLES - Custom colors for this project */
+
+@layer base {
+  :root {
+  /* LiveAgent Brand Orange Colors */
+  --color-primary-50: 255 247 237;
+  --color-primary-100: 255 237 213;
+  --color-primary-200: 254 215 170;
+  --color-primary-300: 253 186 116;
+  --color-primary-400: 251 146 60;
+  --color-primary-500: 249 115 22;
+  --color-primary-600: 234 88 12;
+  --color-primary-700: 194 65 12;
+  --color-primary-800: 154 52 18;
+  --color-primary-900: 124 45 18;
+  --color-primary-950: 67 20 7;
+  --color-primary: 251 146 60;
+
+  /* Gray colors (neutral palette) */
+  --color-gray-50: 250 250 250;
+  --color-gray-100: 245 245 245;
+  --color-gray-200: 229 229 229;
+  --color-gray-300: 212 212 212;
+  --color-gray-400: 163 163 163;
+  --color-gray-500: 115 115 115;
+  --color-gray-600: 82 82 82;
+  --color-gray-700: 64 64 64;
+  --color-gray-800: 38 38 38;
+  --color-gray-900: 23 23 23;
+  --color-gray-950: 10 10 10;
+
+  /* Button colors - neutral dark */
+  --color-button-primary: var(--color-gray-900);
+  --color-button-primary-hover: var(--color-gray-800);
+  --color-button-primary-dark: var(--color-primary-400);
+  --color-button-primary-dark-hover: var(--color-primary-300);
+  --color-button-primary-outline: var(--color-gray-900);
+
+  /* Brand colors */
+  --color-brand-surface: var(--color-primary);
+  --color-brand-dark-surface: var(--color-primary);
+  --color-brand-surface-secondary: var(--color-primary-500); /* -20% opacity */
+  --color-brand-dark-surface-secondary: var(--color-primary-500); /* -20% opacity */
+  --color-brand-border: var(--color-primary-300);
+  --color-brand-dark-border: var(--color-primary-300);
+  --color-brand-text: var(--color-primary);
+  --color-brand-dark-text: var(--color-primary);
+  --color-brand-icon: var(--color-primary);
+  --color-brand-dark-icon: var(--color-primary);
+  --color-brand-underlight: var(--color-primary-300);
+  --color-brand-dark-underlight: var(--color-primary-900);
+  }
+}

--- a/assets/js/components/video-handler.js
+++ b/assets/js/components/video-handler.js
@@ -430,17 +430,17 @@
             if (fallbackUrl) {
                 errorHtml += `
                     <div class="flex flex-col sm:flex-row gap-3 justify-center">
-                        <a href="${fallbackUrl}" target="_blank" rel="noopener noreferrer" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded">
+                        <a href="${fallbackUrl}" target="_blank" rel="noopener noreferrer" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-sm">
                             Watch on YouTube
                         </a>
-                        <button class="bg-transparent hover:bg-gray-700 text-white font-semibold py-2 px-4 border border-white hover:border-transparent rounded close-video-btn">
+                        <button class="bg-transparent hover:bg-gray-700 text-white font-semibold py-2 px-4 border border-white hover:border-transparent rounded-sm close-video-btn">
                             Close
                         </button>
                     </div>
                 `;
             } else {
                 errorHtml += `
-                    <button class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded close-video-btn">
+                    <button class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-sm close-video-btn">
                         Close
                     </button>
                 `;

--- a/assets/js/components/video-lightbox.js
+++ b/assets/js/components/video-lightbox.js
@@ -243,13 +243,13 @@
     function createLightboxOverlay() {
         var overlay = document.createElement('div');
         overlay.id = 'video-lightbox-overlay';
-        overlay.className = 'hidden fixed inset-0 bg-black bg-opacity-90 z-[9999] opacity-0 transition-opacity duration-300';
+        overlay.className = 'hidden fixed inset-0 bg-black bg-opacity-90 z-9999 opacity-0 transition-opacity duration-300';
         overlay.setAttribute('role', 'dialog');
         overlay.setAttribute('aria-modal', 'true');
         overlay.setAttribute('aria-label', 'Video player');
         
         overlay.innerHTML = `
-            <button class="fixed top-4 right-4 bg-black bg-opacity-70 border-none text-white text-3xl cursor-pointer z-[10002] w-12 h-12 rounded-full flex items-center justify-center transition-all duration-300 hover:bg-opacity-90 hover:scale-110" id="video-lightbox-close" aria-label="Close video">
+            <button class="fixed top-4 right-4 bg-black bg-opacity-70 border-none text-white text-3xl cursor-pointer z-10002 w-12 h-12 rounded-full flex items-center justify-center transition-all duration-300 hover:bg-opacity-90 hover:scale-110" id="video-lightbox-close" aria-label="Close video">
                 ×
             </button>
             <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-6xl max-h-[90%] bg-black rounded-lg overflow-hidden shadow-[0_25px_50px_rgba(0,0,0,0.5)]">
@@ -479,15 +479,15 @@ function openVideoInLightbox(videoData) {
                     <p class="mb-4">This video cannot be embedded directly in the lightbox.</p>
                     ${fallbackUrl ? `
                         <div class="flex flex-col sm:flex-row gap-3 justify-center">
-                            <a href="${fallbackUrl}" target="_blank" rel="noopener noreferrer" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded">
+                            <a href="${fallbackUrl}" target="_blank" rel="noopener noreferrer" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-sm">
                                 Watch on YouTube
                             </a>
-                            <button class="bg-transparent hover:bg-gray-700 text-white font-semibold py-2 px-4 border border-white hover:border-transparent rounded close-video-btn">
+                            <button class="bg-transparent hover:bg-gray-700 text-white font-semibold py-2 px-4 border border-white hover:border-transparent rounded-sm close-video-btn">
                                 Close
                             </button>
                         </div>
                     ` : `
-                        <button class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded close-video-btn">
+                        <button class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-4 rounded-sm close-video-btn">
                             Close
                         </button>
                     `}

--- a/assets/js/components/youtube-video.js
+++ b/assets/js/components/youtube-video.js
@@ -161,10 +161,10 @@
     function createLightboxOverlay() {
         const overlay = document.createElement('div');
         overlay.id = 'video-lightbox-overlay';
-        overlay.className = 'hidden fixed inset-0 bg-black bg-opacity-90 z-[9999] opacity-0 transition-opacity duration-300';
+        overlay.className = 'hidden fixed inset-0 bg-black bg-opacity-90 z-9999 opacity-0 transition-opacity duration-300';
         
         overlay.innerHTML = `
-            <button class="absolute top-4 right-4 bg-black bg-opacity-70 border-none text-white text-3xl cursor-pointer z-[10002] w-12 h-12 rounded-full flex items-center justify-center transition-all duration-300 hover:bg-opacity-90 hover:scale-110 pointer-events-auto" id="video-lightbox-close" aria-label="Close video">
+            <button class="absolute top-4 right-4 bg-black bg-opacity-70 border-none text-white text-3xl cursor-pointer z-10002 w-12 h-12 rounded-full flex items-center justify-center transition-all duration-300 hover:bg-opacity-90 hover:scale-110 pointer-events-auto" id="video-lightbox-close" aria-label="Close video">
                 ×
             </button>
             <div class="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[90%] max-w-6xl max-h-[90%] bg-black rounded-lg overflow-hidden shadow-[0_25px_50px_rgba(0,0,0,0.5)] pointer-events-auto">

--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -4,14 +4,14 @@
 
 <div class="bg-white dark:bg-gray-900 mt-6">
     <div class="wrapper">
-        <div class="mx-auto max-w-none prose prose-lg hover:prose-a:text-primary">
+        <div class="mx-auto max-w-none prose prose-lg prose-a:hover:text-primary">
 
             <div class="search-container py-6 gap-x-2 relative flex w-full md:w-80">
                 <span class="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
                    {{ partial "icons/magnifying-glass" "w-4 h-4 text-tertiary" }}
                 </span>
                 <input type="search" name="q" id="search-query" autocomplete="off"
-                    class="hide-search-clear px-9 py-1.5 w-full border border-gray-600 dark:border-gray-700 rounded-md focus:outline-none focus:ring-0 focus:ring-transparent focus:border-gray-400 transition" />
+                    class="hide-search-clear px-9 py-1.5 w-full border border-gray-600 dark:border-gray-700 rounded-md focus:outline-hidden focus:ring-0 focus:ring-transparent focus:border-gray-400 transition" />
                 <button type="button" id="clear-search" aria-label="{{ i18n "search_clear_aria" }}"
                     class="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-none cursor-pointer p-0">
                     {{ partial "icons/x-mark" "w-4 h-4 text-tertiary" }}
@@ -26,10 +26,10 @@
             <div id="contact-url" class="hidden" data-url="{{ partial "helpers/get-translated-url.html" (dict "url" "/contact/") }}"></div> 
 
             <script id="search-result-template" type="text/x-js-template">
-                <article id="summary-${key}" class="group relative rounded-2xl not-prose border border-gray-200 surface-secondary p-6 my-6 shadow-lg max-w-[52rem] h-full flex flex-col">
+                <article id="summary-${key}" class="group relative rounded-2xl not-prose border border-gray-200 surface-secondary p-6 my-6 shadow-lg max-w-208 h-full flex flex-col">
                     <div class="flex items-center justify-between items-center flex-wrap md:flex-nowrap gap-x-4">
                         <h3 class="text-lg/6 font-semibold text-heading group-hover:text-primary w-full md:w-3/4">
-                            <a href="${link}" class="hover:text-primary focus:outline-none">
+                            <a href="${link}" class="hover:text-primary focus:outline-hidden">
                             <span class="absolute inset-0" aria-hidden="true"></span>
                             ${title}
                             </a>
@@ -37,7 +37,7 @@
                         <div class="date-reading-time-container flex items-center justify-end text-secondary text-xs mt-3 md:mt-0 w-full md:w-1/4"></div>
                     </div>
 
-                    <p class="mt-5 text-sm/5 text-tertiary line-clamp-3 flex-grow">${snippet}</p>
+                    <p class="mt-5 text-sm/5 text-tertiary line-clamp-3 grow">${snippet}</p>
 
                     <div class="tags-container mt-6 flex flex-wrap gap-2"></div>
                 </article>
@@ -116,7 +116,7 @@
                                 : `<span class="relative ml-3 inline-flex items-center rounded-md border border-gray-primary surface-primary px-4 py-2 text-sm font-semibold text-secondary cursor-not-allowed">Next ${chevronRight}</span>`}
                         </div>`;
                         // Desktop: full pagination
-                        html += `<div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between w-full max-w-[52rem] not-prose">
+                        html += `<div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between w-full max-w-208 not-prose">
                             <div>
                                 <p class="text-sm text-secondary">
                                     Showing <span class="font-semibold">${startItem}</span> to <span class="font-semibold">${endItem}</span> of <span class="font-semibold">${total}</span> results
@@ -135,7 +135,7 @@
 
                                         if (totalPages <= maxVisiblePages) {
                                             return n === page
-                                                ? `<span aria-current="page" class="relative z-10 inline-flex items-center surface-brand px-4 py-2 text-sm font-semibold icon-on-brand focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:surface-brand">${n}</span>`
+                                                ? `<span aria-current="page" class="relative z-10 inline-flex items-center surface-brand px-4 py-2 text-sm font-semibold icon-on-brand focus:z-20 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:surface-brand">${n}</span>`
                                                 : `<button data-page="${n}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-heading ring-1 ring-inset ring-gray-300 hover:surface-secondary focus:z-20 focus:outline-offset-0">${n}</button>`;
                                         } else {
                                             if (
@@ -144,7 +144,7 @@
                                                 (n >= page - halfVisible && n <= page + halfVisible)
                                             ) {
                                                 return n === page
-                                                    ? `<span aria-current="page" class="relative z-10 inline-flex items-center surface-brand px-4 py-2 text-sm font-semibold icon-on-brand focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:surface-brand">${n}</span>`
+                                                    ? `<span aria-current="page" class="relative z-10 inline-flex items-center surface-brand px-4 py-2 text-sm font-semibold icon-on-brand focus:z-20 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:surface-brand">${n}</span>`
                                                     : `<button data-page="${n}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-heading ring-1 ring-inset ring-gray-300 hover:surface-secondary focus:z-20 focus:outline-offset-0">${n}</button>`;
                                             } else if (
                                                 (n === page - halfVisible - 1 && page - halfVisible > 1) ||
@@ -282,10 +282,10 @@
                                 let safeReadingTime = item.readingTime != null ? item.readingTime : '';
 
                                 let articleHtml = `
-                                    <article id="summary-${refIndex}" class="group relative rounded-2xl not-prose border border-gray-200 surface-secondary p-6 my-6 shadow-lg max-w-[52rem] h-full flex flex-col">
+                                    <article id="summary-${refIndex}" class="group relative rounded-2xl not-prose border border-gray-200 surface-secondary p-6 my-6 shadow-lg max-w-208 h-full flex flex-col">
                                         <div class="flex items-center justify-between gap-x-4 items-center flex-wrap md:flex-nowrap">
                                             <h3 class="text-lg/6 font-semibold text-heading group-hover:text-primary w-full md:w-3/4">
-                                                <a href="${safePermalink}" class="hover:text-primary focus:outline-none">
+                                                <a href="${safePermalink}" class="hover:text-primary focus:outline-hidden">
                                                 <span class="absolute inset-0" aria-hidden="true"></span>
                                                 ${safeTitle}
                                                 </a>
@@ -305,7 +305,7 @@
                                 }
 
                                 articleHtml += `
-                                        </div> <p class="mt-5 text-sm/5 text-tertiary line-clamp-3 flex-grow">${snippet}</p>
+                                        </div> <p class="mt-5 text-sm/5 text-tertiary line-clamp-3 grow">${snippet}</p>
                                 `;
 
                                 if (Array.isArray(item.tags) && item.tags.length > 0) {
@@ -313,7 +313,7 @@
                                     let tagsHtml = '';
                                     const maxTags = 3;
                                     const tagBaseUrl = '/tags/';
-                                    const tagClass = 'badge-base badge-gray badge-with-border not-prose whitespace-nowrap [&_a]:no-underline [&_a]:!text-inherit [&_a]:px-0.5 [&_.link-building-link]:!no-underline [&_.link-building-link]:!text-inherit';
+                                    const tagClass = 'badge-base badge-gray badge-with-border not-prose whitespace-nowrap [&_a]:no-underline [&_a]:text-inherit! [&_a]:px-0.5 [&_.link-building-link]:no-underline! [&_.link-building-link]:text-inherit!';
                                     const shownTags = item.tags.slice(0, maxTags);
                                     shownTags.forEach(tag => {
                                         if (tag != null) {

--- a/layouts/_default/website_audit.html
+++ b/layouts/_default/website_audit.html
@@ -10,22 +10,22 @@
 
       <!-- Headline metrics -->
       <div id="audit-metrics" class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-        <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5">
+        <div class="bg-white border border-gray-200 rounded-lg shadow-xs p-5">
           <div class="text-sm text-gray-500">siteFocusScore</div>
           <div id="m-focus" class="text-3xl font-bold text-gray-900">—</div>
           <div class="text-xs text-gray-500 mt-1">1.0 = laser focused</div>
         </div>
-        <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5">
+        <div class="bg-white border border-gray-200 rounded-lg shadow-xs p-5">
           <div class="text-sm text-gray-500">siteRadius</div>
           <div id="m-radius" class="text-3xl font-bold text-gray-900">—</div>
           <div class="text-xs text-gray-500 mt-1">lower = tighter spread</div>
         </div>
-        <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5">
+        <div class="bg-white border border-gray-200 rounded-lg shadow-xs p-5">
           <div class="text-sm text-gray-500">Outlier pages</div>
           <div id="m-outliers" class="text-3xl font-bold text-orange-600">—</div>
           <div class="text-xs text-gray-500 mt-1">refocus or remove</div>
         </div>
-        <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5">
+        <div class="bg-white border border-gray-200 rounded-lg shadow-xs p-5">
           <div class="text-sm text-gray-500">Near-duplicates</div>
           <div id="m-dupes" class="text-3xl font-bold text-red-600">—</div>
           <div class="text-xs text-gray-500 mt-1">merge candidates</div>
@@ -65,13 +65,13 @@
 
       <!-- Side panels -->
       <div class="grid md:grid-cols-2 gap-6 mb-8">
-        <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5">
+        <div class="bg-white border border-gray-200 rounded-lg shadow-xs p-5">
           <h3 class="text-lg font-semibold text-gray-900 mb-3">Weakest sections (lowest cohesion)</h3>
           <div id="audit-sections" class="text-sm">
             <div class="text-gray-500">Loading…</div>
           </div>
         </div>
-        <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5">
+        <div class="bg-white border border-gray-200 rounded-lg shadow-xs p-5">
           <h3 class="text-lg font-semibold text-gray-900 mb-3">Top 50 outliers (highest drift)</h3>
           <div id="audit-outliers" class="text-sm max-h-96 overflow-y-auto">
             <div class="text-gray-500">Loading…</div>
@@ -79,7 +79,7 @@
         </div>
       </div>
 
-      <div class="bg-white border border-gray-200 rounded-lg shadow-sm p-5 mb-8">
+      <div class="bg-white border border-gray-200 rounded-lg shadow-xs p-5 mb-8">
         <h3 class="text-lg font-semibold text-gray-900 mb-3">Top duplicate pairs (merge candidates)</h3>
         <div id="audit-duplicates" class="text-sm max-h-96 overflow-y-auto">
           <div class="text-gray-500">Loading…</div>
@@ -378,7 +378,7 @@
     if (mode === 'section') {
       const sections = state.sectionColor.domain();
       el.innerHTML = sections.map(s => `
-        <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-white border border-gray-200">
+        <span class="inline-flex items-center px-2 py-1 rounded-sm text-xs bg-white border border-gray-200">
           <span class="w-3 h-3 rounded-full mr-1.5" style="background:${state.sectionColor(s)}"></span>${s || '(root)'}
         </span>`).join('');
     } else if (mode === 'cluster') {
@@ -386,14 +386,14 @@
     } else if (mode === 'drift') {
       el.innerHTML = `
         <span class="text-xs text-gray-500">Drift from section centroid:</span>
-        <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#16a34a"></span>low (on-topic)</span>
-        <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#f59e0b"></span>medium</span>
-        <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#dc2626"></span>high (outlier)</span>`;
+        <span class="inline-flex items-center px-2 py-1 rounded-sm text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#16a34a"></span>low (on-topic)</span>
+        <span class="inline-flex items-center px-2 py-1 rounded-sm text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#f59e0b"></span>medium</span>
+        <span class="inline-flex items-center px-2 py-1 rounded-sm text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#dc2626"></span>high (outlier)</span>`;
     } else if (mode === 'flags') {
       el.innerHTML = `
-        <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#dc2626;border:1.5px solid #7f1d1d"></span>near-duplicate (merge)</span>
-        <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#f59e0b"></span>outlier (refocus)</span>
-        <span class="inline-flex items-center px-2 py-1 rounded text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#94a3b8"></span>normal</span>`;
+        <span class="inline-flex items-center px-2 py-1 rounded-sm text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#dc2626;border:1.5px solid #7f1d1d"></span>near-duplicate (merge)</span>
+        <span class="inline-flex items-center px-2 py-1 rounded-sm text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#f59e0b"></span>outlier (refocus)</span>
+        <span class="inline-flex items-center px-2 py-1 rounded-sm text-xs bg-white border border-gray-200"><span class="w-3 h-3 rounded-full mr-1.5" style="background:#94a3b8"></span>normal</span>`;
     }
   }
 

--- a/layouts/_default/website_cluster.html
+++ b/layouts/_default/website_cluster.html
@@ -30,7 +30,7 @@
 
         <!-- Zoom Controls -->
         <div class="flex items-center gap-2">
-          <button id="zoom-out-btn" class="hidden px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-sm">
+          <button id="zoom-out-btn" class="hidden px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-xs">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
             </svg>
@@ -580,7 +580,7 @@
           <td class="px-4 py-3">
             <div class="flex flex-wrap gap-1 max-w-md">
               ${page.keywords.slice(0, 5).map(kw =>
-                `<span class="inline-block bg-gray-100 text-gray-600 px-2 py-0.5 rounded text-xs">${kw}</span>`
+                `<span class="inline-block bg-gray-100 text-gray-600 px-2 py-0.5 rounded-sm text-xs">${kw}</span>`
               ).join('')}
               ${page.keywords.length > 5 ? `<span class="text-gray-400 text-xs">+${page.keywords.length - 5} more</span>` : ''}
             </div>
@@ -1014,7 +1014,7 @@
         <td class="px-4 py-3">
           <div class="flex flex-wrap gap-1 max-w-md">
             ${page.keywords ? page.keywords.slice(0, 5).map(kw =>
-              `<span class="inline-block bg-gray-100 text-gray-600 px-2 py-0.5 rounded text-xs">${kw}</span>`
+              `<span class="inline-block bg-gray-100 text-gray-600 px-2 py-0.5 rounded-sm text-xs">${kw}</span>`
             ).join('') : ''}
             ${page.keywords && page.keywords.length > 5 ? `<span class="text-gray-400 text-xs">+${page.keywords.length - 5} more</span>` : ''}
           </div>

--- a/layouts/author/list.html
+++ b/layouts/author/list.html
@@ -1,14 +1,14 @@
 {{ define "main" }}
 {{ partial "breadcrumbs_default.html" . }}
 
-  <div class="bg-white mt-[4.625rem]">
+  <div class="bg-white mt-18.5">
 
     {{ partial "hero_default.html" . }}
     {{ $letters := slice "0-9" "A" "B" "C" "D" "E" "F" "G" "H" "I" "J" "K" "L" "M" "N" "O" "P" "Q" "R" "S" "T" "U" "V" "W" "X" "Y" "Z" }}
     {{ $authorSection := site.GetPage "/author" }}
     {{ $authors := $authorSection.Pages }}
     {{ $cardHeight := 26.875 }}
-    {{ $cardWrapperClasses := "py-10 px-8 min-h-[26.875rem]" }}
+    {{ $cardWrapperClasses := "py-10 px-8 min-h-107.5" }}
     {{ $imageWrapperClasses := "mx-auto w-56 h-56 overflow-hidden" }}
     {{ $imageClasses := "w-full h-full object-cover rounded-full" }}
     {{ $descriptionLength := 70 }}
@@ -38,7 +38,7 @@
         {{ end }}
       {{ end }}
     {{ end }}
-    <div id="alphabetNav" class="w-full bg-white mt-5 sticky top-20 md:top-[5.25rem] z-[45] transition-all duration-300">
+    <div id="alphabetNav" class="w-full bg-white mt-5 sticky top-20 md:top-21 z-45 transition-all duration-300">
       <div class="wrapper">
         <div class="grid grid-cols-2 lg:hidden">
           <select class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pl-3 pr-8 text-base " id="alphabetSelect">

--- a/layouts/categories/list.html
+++ b/layouts/categories/list.html
@@ -49,9 +49,9 @@
             <h2 class="text-3xl font-bold text-gray-900 border-b border-gray-200 pb-4">{{ $letter }}</h2>
             <ul class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {{ range $categoriesInLetter }}
-                <li class="group relative rounded-xl border border-gray-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
+                <li class="group relative rounded-xl border border-gray-200 bg-white p-6 shadow-xs hover:shadow-md transition-shadow">
                   <h3 class="text-lg font-semibold text-gray-900">
-                    <a href="{{ "/categories/" | relLangURL }}{{ .name | urlize }}/" class="hover:text-indigo-600 focus:outline-none">
+                    <a href="{{ "/categories/" | relLangURL }}{{ .name | urlize }}/" class="hover:text-indigo-600 focus:outline-hidden">
                       <span class="absolute inset-0" aria-hidden="true"></span>
                       {{ .name }}
                     </a>

--- a/layouts/categories/term.html
+++ b/layouts/categories/term.html
@@ -51,7 +51,7 @@
                 </p>
               </div>
               <div>
-                <nav class="isolate inline-flex -space-x-px rounded-xl shadow-sm" aria-label="Pagination">
+                <nav class="isolate inline-flex -space-x-px rounded-xl shadow-xs" aria-label="Pagination">
                   {{ if $paginator.HasPrev }}
                     <a href="{{ $paginator.Prev.URL }}" class="relative inline-flex items-center rounded-l-xl px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-20 focus:outline-offset-0">
                       <span class="sr-only">{{ i18n "pagination_previous" }}</span>
@@ -70,7 +70,7 @@
                   
                   {{ range $paginator.Pagers }}
                     {{ if eq . $paginator }}
-                      <span aria-current="page" class="relative z-10 inline-flex items-center bg-indigo-600 px-4 py-2 text-sm font-semibold text-white focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ .PageNumber }}</span>
+                      <span aria-current="page" class="relative z-10 inline-flex items-center bg-indigo-600 px-4 py-2 text-sm font-semibold text-white focus:z-20 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ .PageNumber }}</span>
                     {{ else }}
                       <a href="{{ .URL }}" class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-20 focus:outline-offset-0">{{ .PageNumber }}</a>
                     {{ end }}

--- a/layouts/discussion/list.html
+++ b/layouts/discussion/list.html
@@ -58,7 +58,7 @@
     <div class="wrapper">
 
       {{/* Forum table */}}
-      <div class="bg-white rounded-lg border border-gray-200 overflow-hidden shadow-sm">
+      <div class="bg-white rounded-lg border border-gray-200 overflow-hidden shadow-xs">
         {{/* Table rows */}}
         <div class="divide-y divide-gray-100">
           {{ range $paginator.Pages }}

--- a/layouts/faq/list.html
+++ b/layouts/faq/list.html
@@ -46,7 +46,7 @@
     {{ $letters := slice "0-9" "A" "B" "C" "D" "E" "F" "G" "H" "I" "J" "K" "L" "M" "N" "O" "P" "Q" "R" "S" "T" "U" "V" "W" "X" "Y" "Z" }}
     {{ $activeLetter := "" }}
     {{ $glossaryTerms := where .Site.RegularPages "Section" "faq" }}
-    <div id="alphabetNav" class="w-full bg-white sticky top-20 md:top-[5.25rem] z-[45] transition-all duration-300">
+    <div id="alphabetNav" class="w-full bg-white sticky top-20 md:top-21 z-45 transition-all duration-300">
       <div class="wrapper px-8 ">
         <div class="grid grid-cols-2 lg:hidden">
           <select class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pl-3 pr-8 text-base " id="alphabetSelect">

--- a/layouts/glossary/list.html
+++ b/layouts/glossary/list.html
@@ -25,7 +25,7 @@
         "items" $items
       ) }}
     {{ end }}
-    <div id="alphabetNav" class="w-full bg-white sticky top-20 md:top-[5.25rem] z-[45] transition-all duration-300">
+    <div id="alphabetNav" class="w-full bg-white sticky top-20 md:top-21 z-45 transition-all duration-300">
       <div class="wrapper px-8 ">
         <div class="grid grid-cols-2 lg:hidden">
           <select class="col-start-1 row-start-1 w-full appearance-none rounded-md bg-white py-2 pl-3 pr-8 text-base " id="alphabetSelect">

--- a/layouts/partials/components/blog-card-small.html
+++ b/layouts/partials/components/blog-card-small.html
@@ -8,14 +8,14 @@
 
 {{ $post := .post }}
 {{ $imagePosition := .imagePosition | default "left" }}
-{{ $tagClasses := "inline-flex items-center px-2 py-1 font-medium text-gray-500 border border-gray-400/20 bg-gray-100 dark:bg-blue-900/30 dark:text-primary-300 rounded" }}
+{{ $tagClasses := "inline-flex items-center px-2 py-1 font-medium text-gray-500 border border-gray-400/20 bg-gray-100 dark:bg-blue-900/30 dark:text-primary-300 rounded-sm" }}
 
 {{ if $post }}
 <article class="group relative">
   <a href="{{ $post.RelPermalink }}" class="flex items-stretch {{ if eq $imagePosition "right" }}flex-row-reverse{{ else }}flex-row{{ end }} gap-4 items-start">
     {{/* Thumbnail Image */}}
     {{ if $post.Params.image }}
-      <div class="flex-shrink-0 w-2/5 md:w-[30%] lg:w-[140px] lg:h-[90px] overflow-hidden rounded-lg border border-gray-200 group-hover:border-primary-600 transition-colors duration-300">
+      <div class="shrink-0 w-2/5 md:w-[30%] lg:w-[140px] lg:h-[90px] overflow-hidden rounded-lg border border-gray-200 group-hover:border-primary-600 transition-colors duration-300">
         {{ partial "components/media/lazyimg.html" (dict
             "src" $post.Params.image
             "alt" ($post.Params.imageAlt | default $post.Title)

--- a/layouts/partials/components/breadcrumbs/basic.html
+++ b/layouts/partials/components/breadcrumbs/basic.html
@@ -36,9 +36,9 @@
     {{- $isLast := eq (add $index 1) (len $items) -}}
     <li class="flex items-center">
       {{- if $isLast -}}
-      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $item.url) }}" class="text-sm font-medium text-heading hover:text-gray-700 break-words" aria-current="page">{{ $item.title }}</a>
+      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $item.url) }}" class="text-sm font-medium text-heading hover:text-gray-700 wrap-break-word" aria-current="page">{{ $item.title }}</a>
       {{- else -}}
-      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $item.url) }}" class="text-sm font-medium text-secondary hover:text-gray-700 break-words">{{ $item.title }}</a>
+      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $item.url) }}" class="text-sm font-medium text-secondary hover:text-gray-700 wrap-break-word">{{ $item.title }}</a>
       <span class="mx-2 lg:mx-4 text-gray-300 dark:text-gray-600 whitespace-nowrap">/</span>
       {{- end -}}
     </li>

--- a/layouts/partials/components/cards/discussion_card.html
+++ b/layouts/partials/components/cards/discussion_card.html
@@ -39,13 +39,13 @@
   <div class="flex">
     {{/* Upvote column - Reddit style */}}
     <div class="flex flex-col items-center py-2 px-2 md:px-3 bg-gray-50 gap-0.5">
-      <button class="p-1 text-gray-400 hover:text-orange-500 hover:bg-orange-50 rounded transition-colors">
+      <button class="p-1 text-gray-400 hover:text-orange-500 hover:bg-orange-50 rounded-sm transition-colors">
         <svg class="w-5 h-5 md:w-6 md:h-6" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7"></path>
         </svg>
       </button>
       <span class="font-bold text-xs md:text-sm text-gray-900">{{ $upvotes }}</span>
-      <button class="p-1 text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded transition-colors">
+      <button class="p-1 text-gray-400 hover:text-blue-500 hover:bg-blue-50 rounded-sm transition-colors">
         <svg class="w-5 h-5 md:w-6 md:h-6" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"></path>
         </svg>
@@ -81,19 +81,19 @@
 
       {{/* Action bar - Reddit style */}}
       <div class="flex items-center gap-1 -ml-2">
-        <span class="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-bold text-gray-500 hover:bg-gray-100 rounded transition-colors">
+        <span class="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-bold text-gray-500 hover:bg-gray-100 rounded-sm transition-colors">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
           </svg>
           {{ $commentCount }} Comments
         </span>
-        <span class="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-bold text-gray-500 hover:bg-gray-100 rounded transition-colors">
+        <span class="inline-flex items-center gap-1.5 px-2 py-1 text-xs font-bold text-gray-500 hover:bg-gray-100 rounded-sm transition-colors">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"></path>
           </svg>
           Share
         </span>
-        <span class="hidden md:inline-flex items-center gap-1.5 px-2 py-1 text-xs font-bold text-gray-500 hover:bg-gray-100 rounded transition-colors">
+        <span class="hidden md:inline-flex items-center gap-1.5 px-2 py-1 text-xs font-bold text-gray-500 hover:bg-gray-100 rounded-sm transition-colors">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
           </svg>

--- a/layouts/partials/components/cards/discussion_row.html
+++ b/layouts/partials/components/cards/discussion_row.html
@@ -71,7 +71,7 @@
     {{ if $page.Params.tags }}
     <div class="flex flex-wrap gap-1 mb-1">
       {{ range first 2 $page.Params.tags }}
-        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium bg-brand-50 text-brand-700">
+        <span class="inline-flex items-center px-1.5 py-0.5 rounded-sm text-[10px] font-medium bg-brand-50 text-brand-700">
           {{ . }}
         </span>
       {{ end }}

--- a/layouts/partials/components/cards/icon_card.html
+++ b/layouts/partials/components/cards/icon_card.html
@@ -76,13 +76,13 @@ bg-[#b28b5d] bg-[#611f69] bg-[#95bf47] bg-[#2684fc] bg-[#00ac47] bg-[#0066da] bg
             <div class="{{ $iconBackgroundSize }} flex items-center justify-center rounded-lg {{ $iconBackground}}">
                 {{ if $isIconName }}
                     {{/* Use Hugo icon partial for icon names (e.g., "light-bulb") */}}
-                    {{ partial (printf "icons/%s" $icon) (printf "%s %s flex-shrink-0" $iconSize $iconColor) }}
+                    {{ partial (printf "icons/%s" $icon) (printf "%s %s shrink-0" $iconSize $iconColor) }}
                 {{ else }}
                     {{/* Use lazyimg_internal for file paths (e.g., "/images/icons/icon.svg") */}}
                     {{ partial "components/media/lazyimg_internal.html" (dict
                         "src" $icon
                         "alt" $iconAlt
-                        "class" (printf "%s %s flex-shrink-0" $iconSize $iconColor)
+                        "class" (printf "%s %s shrink-0" $iconSize $iconColor)
                     ) }}
                 {{ end }}
             </div>

--- a/layouts/partials/components/cards/post_card.html
+++ b/layouts/partials/components/cards/post_card.html
@@ -26,7 +26,7 @@
 {{ $section := .Section }}
 {{ $minutesRead := i18n "minutes_read" }}
 
-<article class="group relative rounded-xl border border-gray-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow h-full flex flex-col">
+<article class="group relative rounded-xl border border-gray-200 bg-white p-6 shadow-xs hover:shadow-md transition-shadow h-full flex flex-col">
   {{ if .Date }}
   <!-- Date and Section -->
   <div class="flex items-center gap-x-4 text-xs mb-3">
@@ -39,12 +39,12 @@
 
   <!-- Title and Description -->
   <h3 class="text-lg font-semibold text-gray-900 group-hover:text-indigo-600">
-    <a href="{{ $permalink }}" class="hover:text-indigo-600 focus:outline-none">
+    <a href="{{ $permalink }}" class="hover:text-indigo-600 focus:outline-hidden">
       <span class="absolute inset-0" aria-hidden="true"></span>
       {{ $title }}
     </a>
   </h3>
-  <p class="mt-2 text-sm text-gray-500 line-clamp-3 flex-grow">{{ $description }}</p>
+  <p class="mt-2 text-sm text-gray-500 line-clamp-3 grow">{{ $description }}</p>
   
   <!-- Tags -->
   {{ if .Params.tags }}

--- a/layouts/partials/components/cards/post_card_with_image.html
+++ b/layouts/partials/components/cards/post_card_with_image.html
@@ -21,7 +21,7 @@
   - cardHeight: Minimum height of the card in pixels (optional, default: 556)
   - cardWrapperClasses: Additional CSS classes for wrapper card (optional, default "")
   - imageClasses: Additional CSS classes for the image (optional, default: "w-full h-full object-cover")
-  - imageWrapperClasses: Additional CSS classes for the image wrapper (optional, default: "h-48 min-h-[15.3125rem] overflow-hidden")
+  - imageWrapperClasses: Additional CSS classes for the image wrapper (optional, default: "h-48 min-h-61.25 overflow-hidden")
   - descriptionLength: Maximum length of the description in characters (optional, default: 160)
   - contentPadding: Padding of content path (optional, default "p-8")
   - contentAlign: Alignment of the content within the card (optional, default: "left")
@@ -50,7 +50,7 @@
 {{ end }}
 
 {{ $cardClasses := printf "h-full min-h-[%s] %s" $cardHeight $cardWrapperClasses }}
-{{ $imageWrapperClasses := .imageWrapperClasses | default "h-48 min-h-[15.3125rem] overflow-hidden" }}
+{{ $imageWrapperClasses := .imageWrapperClasses | default "h-48 min-h-61.25 overflow-hidden" }}
 {{ $descriptionLength := .descriptionLength | default 160 }}
 
 {{ $contentPadding := .contentPadding | default "p-8" }}
@@ -103,7 +103,7 @@
     </div>
   {{ end }}
 
-  <div class="flex flex-col flex-grow {{ $contentPadding }} {{ $contentAlignClass }}">
+  <div class="flex flex-col grow {{ $contentPadding }} {{ $contentAlignClass }}">
     {{/* Icon */}}
     {{ if $icon }}
       <div class="mb-2">
@@ -114,7 +114,7 @@
     <h3 class="text-lg/6 font-semibold text-heading group-hover:text-tertiary transition-colors duration-300">
       {{ $displayTitle }}
     </h3>
-    <p class="mt-5 text-sm leading-6 text-secondary font-normal line-clamp-3 flex-grow overflow-hidden">{{ $description }}</p>
+    <p class="mt-5 text-sm leading-6 text-secondary font-normal line-clamp-3 grow overflow-hidden">{{ $description }}</p>
     
     {{/* Date, Reading Time */}}
     {{ if $showDateReadingTime }}

--- a/layouts/partials/components/cards/row_card.html
+++ b/layouts/partials/components/cards/row_card.html
@@ -68,12 +68,12 @@ This component expects a page context (.) that has the following properties:
         </div>
     {{ end }}
 
-    <div class="flex flex-col flex-grow justify-between pt-8 pl-8 gap-8">
+    <div class="flex flex-col grow justify-between pt-8 pl-8 gap-8">
         <!-- Title and Description -->
         <div class="flex flex-col pr-8 gap-5">
             <h3 class="text-lg font-semibold m-0 {{ if $permalink }}group-hover:text-primary{{ end }} text-heading">
                 {{ if $permalink }}
-                    <a href="{{ $permalink }}" class="hover:text-primary focus:outline-none">
+                    <a href="{{ $permalink }}" class="hover:text-primary focus:outline-hidden">
                         <span class="inset-0" aria-hidden="true"></span>
                         {{ $title }}
                     </a>
@@ -93,7 +93,7 @@ This component expects a page context (.) that has the following properties:
         {{ if .code }}
             {{ with .code }}
                 <div class="relative h-[19.3rem] py-5 px-7 bg-gray-900 text-white text-xs rounded-tl-[0.625rem] rounded-br-[0.625rem] scrollbar-custom code-container">
-                    <pre class="bg-gray-900 m-0 py-0 pl-0 pr-5 whitespace-pre-wrap break-words text-left"><code class="text-xs block whitespace-pre-wrap leading-tight pl-0">{{ . }}</code></pre>
+                    <pre class="bg-gray-900 m-0 py-0 pl-0 pr-5 whitespace-pre-wrap wrap-break-word text-left"><code class="text-xs block whitespace-pre-wrap leading-tight pl-0">{{ . }}</code></pre>
                     <button data-copy-code 
                             data-copied-text="{{ i18n "copy_success" | default "Copied!" }}"
                             data-copy-error-text="{{ i18n "copy_error" | default "Copy error" }}"

--- a/layouts/partials/components/items/single_column_with_images_on_dark.html
+++ b/layouts/partials/components/items/single_column_with_images_on_dark.html
@@ -142,7 +142,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -152,7 +152,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
 
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/components/items/three_column_on_dark.html
+++ b/layouts/partials/components/items/three_column_on_dark.html
@@ -131,7 +131,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -141,7 +141,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
 
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/components/items/three_column_with_background_images.html
+++ b/layouts/partials/components/items/three_column_with_background_images.html
@@ -11,7 +11,7 @@
   - centerHeading: Whether to center the heading and description (optional, default: true)
   - cardBgColor: Card background color class (optional, default: "bg-gray-900")
   - cardPadding: Card padding classes (optional, default: "px-8 pt-80 pb-8 sm:pt-48 lg:pt-80")
-  - gradientOverlay: Gradient overlay class for images (optional, default: "bg-gradient-to-t from-gray-900 via-gray-900/40")
+  - gradientOverlay: Gradient overlay class for images (optional, default: "bg-linear-to-t from-gray-900 via-gray-900/40")
   - ringColor: Ring color class (optional, default: "ring-gray-900/10")
   - titleColor: Item title color (optional, default: "text-white")
   - dateColor: Date text color (optional, default: "text-gray-300")
@@ -95,7 +95,7 @@
 {{/* Item styling */}}
 {{ $cardBgColor := .cardBgColor | default "bg-gray-900" }}
 {{ $cardPadding := .cardPadding | default "px-8 pt-80 pb-8 sm:pt-48 lg:pt-80" }}
-{{ $gradientOverlay := .gradientOverlay | default "bg-gradient-to-t from-gray-900 via-gray-900/40" }}
+{{ $gradientOverlay := .gradientOverlay | default "bg-linear-to-t from-gray-900 via-gray-900/40" }}
 {{ $ringColor := .ringColor | default "ring-gray-900/10" }}
 {{ $titleColor := .titleColor | default "text-white" }}
 {{ $dateColor := .dateColor | default "text-gray-300" }}

--- a/layouts/partials/components/items/three_column_with_background_images_on_dark.html
+++ b/layouts/partials/components/items/three_column_with_background_images_on_dark.html
@@ -11,7 +11,7 @@
   - centerHeading: Whether to center the heading and description (optional, default: true)
   - cardBgColor: Card background color class (optional, default: "bg-gray-800")
   - cardPadding: Card padding classes (optional, default: "px-8 pt-80 pb-8 sm:pt-48 lg:pt-80")
-  - gradientOverlay: Gradient overlay class for images (optional, default: "bg-gradient-to-t from-gray-900 via-gray-900/40")
+  - gradientOverlay: Gradient overlay class for images (optional, default: "bg-linear-to-t from-gray-900 via-gray-900/40")
   - ringColor: Ring color class (optional, default: "ring-white/10")
   - titleColor: Item title color (optional, default: "text-white")
   - dateColor: Date text color (optional, default: "text-gray-300")
@@ -95,7 +95,7 @@
 {{/* Item styling */}}
 {{ $cardBgColor := .cardBgColor | default "bg-gray-800" }}
 {{ $cardPadding := .cardPadding | default "px-8 pt-80 pb-8 sm:pt-48 lg:pt-80" }}
-{{ $gradientOverlay := .gradientOverlay | default "bg-gradient-to-t from-gray-900 via-gray-900/40" }}
+{{ $gradientOverlay := .gradientOverlay | default "bg-linear-to-t from-gray-900 via-gray-900/40" }}
 {{ $ringColor := .ringColor | default "ring-white/10" }}
 {{ $titleColor := .titleColor | default "text-white" }}
 {{ $dateColor := .dateColor | default "text-gray-300" }}
@@ -104,7 +104,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -114,7 +114,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
 
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/components/items/three_column_with_images_on_dark.html
+++ b/layouts/partials/components/items/three_column_with_images_on_dark.html
@@ -141,7 +141,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -151,7 +151,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
 
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/components/items/with_featured_post_on_dark.html
+++ b/layouts/partials/components/items/with_featured_post_on_dark.html
@@ -153,7 +153,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -163,7 +163,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
 
   {{ if or $heading $description }}

--- a/layouts/partials/components/items/with_photo_and_list.html
+++ b/layouts/partials/components/items/with_photo_and_list.html
@@ -120,7 +120,7 @@
           {{ partial "components/media/lazyimg.html" (dict 
             "src" $image 
             "alt" $imageAlt
-            "class" "mt-16 aspect-6/5 w-full rounded-2xl {{ $imageBgColor }} object-cover lg:aspect-auto lg:h-[34.5rem]"
+            "class" "mt-16 aspect-6/5 w-full rounded-2xl {{ $imageBgColor }} object-cover lg:aspect-auto lg:h-138"
           ) }}
         {{ end }}
       </div>

--- a/layouts/partials/components/items/with_photo_and_list_on_dark.html
+++ b/layouts/partials/components/items/with_photo_and_list_on_dark.html
@@ -112,7 +112,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -122,7 +122,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
 
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
@@ -134,7 +134,7 @@
           {{ partial "components/media/lazyimg.html" (dict 
             "src" $image 
             "alt" $imageAlt
-            "class" "mt-16 aspect-6/5 w-full rounded-2xl {{ $imageBgColor }} object-cover lg:aspect-auto lg:h-[34.5rem]"
+            "class" "mt-16 aspect-6/5 w-full rounded-2xl {{ $imageBgColor }} object-cover lg:aspect-auto lg:h-138"
           ) }}
         {{ end }}
       </div>

--- a/layouts/partials/components/label/label.html
+++ b/layouts/partials/components/label/label.html
@@ -110,8 +110,8 @@
   </a>
 {{ else }}
   <span class="{{ $badgeClass }} {{ $classes }} not-prose whitespace-nowrap
-    [&_a]:no-underline [&_a]:!text-inherit [&_a]:px-0.5
-    [&_.link-building-link]:!no-underline [&_.link-building-link]:!text-inherit">
+    [&_a]:no-underline [&_a]:text-inherit! [&_a]:px-0.5
+    [&_.link-building-link]:no-underline! [&_.link-building-link]:text-inherit!">
     {{ $content | safeHTML }}
   </span>
 {{ end }}

--- a/layouts/partials/components/liveagent-contact-form.html
+++ b/layouts/partials/components/liveagent-contact-form.html
@@ -1,7 +1,7 @@
 {{ $formId := .formId | default "" }}
 
 {{ if $formId }}
-<div class="flex justify-center w-full outline-none">
+<div class="flex justify-center w-full outline-hidden">
   <!-- Start of LiveAgent integration script: Contact form: FlowHunt Contact US -->
   <script type="text/javascript">
   (function(d, src, c) { var t=d.scripts[d.scripts.length - 1],s=d.createElement('script');s.id='la_x2s6df8d';s.defer=true;s.src=src;s.onload=s.onreadystatechange=function(){var rs=this.readyState;if(rs&&(rs!='complete')&&(rs!='loaded')){return;}c(this);};t.parentElement.insertBefore(s,t.nextSibling);})(document,

--- a/layouts/partials/components/logos/split_with_logos_on_right.html
+++ b/layouts/partials/components/logos/split_with_logos_on_right.html
@@ -117,7 +117,7 @@
         <h2 class="text-4xl font-semibold tracking-tight text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
         <p class="mt-6 text-lg/8 {{ $descriptionColor }}">{{ $description }}</p>
         <div class="mt-8 flex items-center gap-x-6">
-          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryButtonUrl) }}" class="rounded-md {{ $primaryButtonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $primaryButtonTextColor }} shadow-xs {{ $primaryButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $primaryButtonText }}</a>
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryButtonUrl) }}" class="rounded-md {{ $primaryButtonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $primaryButtonTextColor }} shadow-2xs {{ $primaryButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $primaryButtonText }}</a>
           <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $secondaryButtonUrl) }}" class="text-sm font-semibold {{ $secondaryButtonColor }}">{{ $secondaryButtonText }} <span aria-hidden="true">&rarr;</span></a>
         </div>
       </div>

--- a/layouts/partials/components/logos/split_with_logos_on_right_on_dark.html
+++ b/layouts/partials/components/logos/split_with_logos_on_right_on_dark.html
@@ -118,7 +118,7 @@
         <h2 class="text-4xl font-semibold tracking-tight text-pretty {{ $headingColor }} sm:text-5xl">{{ $heading }}</h2>
         <p class="mt-6 text-lg/8 {{ $descriptionColor }}">{{ $description }}</p>
         <div class="mt-8 flex items-center gap-x-6">
-          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryButtonUrl) }}" class="rounded-md {{ $primaryButtonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $primaryButtonTextColor }} shadow-xs {{ $primaryButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $primaryButtonText }}</a>
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryButtonUrl) }}" class="rounded-md {{ $primaryButtonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $primaryButtonTextColor }} shadow-2xs {{ $primaryButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $primaryButtonText }}</a>
           <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $secondaryButtonUrl) }}" class="text-sm font-semibold {{ $secondaryButtonColor }}">{{ $secondaryButtonText }} <span aria-hidden="true">&rarr;</span></a>
         </div>
       </div>

--- a/layouts/partials/components/menus/flyout_menu_full_width.html
+++ b/layouts/partials/components/menus/flyout_menu_full_width.html
@@ -123,7 +123,7 @@
   </button>
 
   <!-- Flyout menu content, hidden by default -->
-  <div id="{{ $menuId }}" class="fixed left-1/2 z-10 mt-5 w-screen max-w-screen-xl -translate-x-1/2 opacity-0 translate-y-1 transition-all duration-200 ease-in hidden">
+  <div id="{{ $menuId }}" class="fixed left-1/2 z-10 mt-5 w-screen max-w-(--breakpoint-xl) -translate-x-1/2 opacity-0 translate-y-1 transition-all duration-200 ease-in hidden">
     <div class="w-full flex-auto overflow-hidden rounded-xl bg-white text-sm/6 ring-1 shadow-lg ring-gray-900/5">
       <div class="mx-auto grid max-w-7xl grid-cols-1 gap-2 p-4 py-6 sm:grid-cols-2 sm:gap-x-4 sm:gap-y-4 sm:py-8 lg:grid-cols-4 lg:gap-4 lg:px-6 xl:gap-6">
         {{ range $menuItems }}

--- a/layouts/partials/components/menus/flyout_menu_full_width_two_columns.html
+++ b/layouts/partials/components/menus/flyout_menu_full_width_two_columns.html
@@ -59,7 +59,7 @@
 {{- $blogTitleColor := .blogTitleColor | default "text-gray-900" -}}
 {{- $blogDescriptionColor := .blogDescriptionColor | default "text-gray-600" -}}
 
-<div class="relative isolate z-50 shadow-sm">
+<div class="relative isolate z-50 shadow-xs">
   <div class="bg-white py-5">
     <div class="mx-auto max-w-7xl px-6 lg:px-8">
       <button type="button" class="inline-flex items-center gap-x-1 text-sm/6 font-semibold {{ $buttonTextColor }}" aria-expanded="false">

--- a/layouts/partials/components/menus/header_menu.html
+++ b/layouts/partials/components/menus/header_menu.html
@@ -155,7 +155,7 @@
     </div>
     <div class="flex flex-1 items-center justify-end gap-x-6">
       <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $loginUrl) }}" class="hidden text-sm/6 font-semibold text-gray-900 lg:block">{{ $loginText }}</a>
-      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="rounded-md {{ $ctaBgColor }} px-3 py-2 text-sm font-semibold {{ $ctaTextColor }} shadow-xs {{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $ctaText }}</a>
+      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="rounded-md {{ $ctaBgColor }} px-3 py-2 text-sm font-semibold {{ $ctaTextColor }} shadow-2xs {{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $ctaText }}</a>
     </div>
     <div class="flex lg:hidden">
       <button type="button" class="-m-2.5 inline-flex items-center justify-center rounded-xl p-2.5 text-gray-700" aria-expanded="false" aria-controls="{{ $mobileMenuId }}">
@@ -181,7 +181,7 @@
             "class" (printf "%s w-auto" $logoHeight)
           ) }}
         </a>
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="ml-auto rounded-md {{ $ctaBgColor }} px-3 py-2 text-sm font-semibold {{ $ctaTextColor }} shadow-xs {{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $ctaText }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="ml-auto rounded-md {{ $ctaBgColor }} px-3 py-2 text-sm font-semibold {{ $ctaTextColor }} shadow-2xs {{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $ctaText }}</a>
         <button type="button" class="-m-2.5 rounded-xl p-2.5 text-gray-700 close-mobile-menu">
           <span class="sr-only">Close menu</span>
           <svg class="size-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">

--- a/layouts/partials/components/menus/header_menu_dark.html
+++ b/layouts/partials/components/menus/header_menu_dark.html
@@ -136,7 +136,7 @@
     </div>
     <div class="flex flex-1 items-center justify-end gap-x-6">
       <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $loginUrl) }}" class="hidden text-sm/6 font-semibold text-white hover:text-white lg:block">{{ $loginText }}</a>
-      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="rounded-md {{ $ctaBgColor }} px-3 py-2 text-sm font-semibold {{ $ctaTextColor }} shadow-xs {{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $ctaText }}</a>
+      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="rounded-md {{ $ctaBgColor }} px-3 py-2 text-sm font-semibold {{ $ctaTextColor }} shadow-2xs {{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $ctaText }}</a>
     </div>
     <div class="flex lg:hidden">
       <button type="button" class="-m-2.5 inline-flex items-center justify-center rounded-xl p-2.5 text-white" aria-expanded="false" aria-controls="{{ $mobileMenuId }}">
@@ -162,7 +162,7 @@
             "class" (printf "%s w-auto" $logoHeight)
           ) }}
         </a>
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="ml-auto rounded-md {{ $ctaBgColor }} px-3 py-2 text-sm font-semibold {{ $ctaTextColor }} shadow-xs {{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $ctaText }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="ml-auto rounded-md {{ $ctaBgColor }} px-3 py-2 text-sm font-semibold {{ $ctaTextColor }} shadow-2xs {{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $ctaText }}</a>
         <button type="button" class="-m-2.5 rounded-xl p-2.5 text-white close-mobile-menu">
           <span class="sr-only">Close menu</span>
           <svg class="size-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">

--- a/layouts/partials/components/pagination/pagination.html
+++ b/layouts/partials/components/pagination/pagination.html
@@ -94,7 +94,7 @@
                     {{ if eq . $current }}
                         <!-- Current page (highlighted) -->
                         <span aria-current="page" 
-                              class="relative z-10 inline-flex items-center surface-brand px-4 py-2 text-sm font-semibold icon-on-brand focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:surface-brand">
+                              class="relative z-10 inline-flex items-center surface-brand px-4 py-2 text-sm font-semibold icon-on-brand focus:z-20 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:surface-brand">
                             {{ . }}
                         </span>
                     {{ else }}

--- a/layouts/partials/components/quote/blockquote.html
+++ b/layouts/partials/components/quote/blockquote.html
@@ -31,10 +31,10 @@
   {{ $logoUrlWithDomain = partial "functions/get-static-url.html" (dict "path" $logoUrl) }}
 {{ end }}
 
-<div class="flex flex-col sm:flex-row items-center gap-4 p-6 bg-gray-50 rounded-lg shadow-sm my-8">
+<div class="flex flex-col sm:flex-row items-center gap-4 p-6 bg-gray-50 rounded-lg shadow-xs my-8">
     {{ if $imageUrl }}
-        <div class="flex-shrink-0">
-            <img src="{{ $imageUrlWithDomain }}" alt="{{ $name }}" class="w-16 h-16 rounded-full object-cover shadow-sm">
+        <div class="shrink-0">
+            <img src="{{ $imageUrlWithDomain }}" alt="{{ $name }}" class="w-16 h-16 rounded-full object-cover shadow-xs">
         </div>
     {{ end }}
 
@@ -51,7 +51,7 @@
     </div>
 
     {{ if $logoUrl }}
-        <div class="flex-shrink-0">
+        <div class="shrink-0">
             <img src="{{ $logoUrlWithDomain }}" alt="Company logo" class="h-12 object-contain">
         </div>
     {{ end }}

--- a/layouts/partials/components/success-stories/double-icon-overlay.html
+++ b/layouts/partials/components/success-stories/double-icon-overlay.html
@@ -24,10 +24,10 @@ Usage:
 {{ $primaryIcon := .primaryIcon }}
 {{ $secondaryIcon := .secondaryIcon }}
 {{ $overlayPosition := .overlayPosition | default "top-12 right-3 xl:-right-10" }}
-{{ $overlaySize := .overlaySize | default "h-[8.75rem]" }}
+{{ $overlaySize := .overlaySize | default "h-35" }}
 {{ $overlayShadowClass := .overlayShadowClass | default "hero-overlay-shadow" }}
 
-<div class="absolute {{ $overlayPosition }} z-10 {{ $overlaySize }} rounded-xl border border-gray-200 bg-gradient-to-b from-gray-50 to-gray-50 opacity-90 flex items-center justify-center backdrop-blur-sm {{ $overlayShadowClass }}">
+<div class="absolute {{ $overlayPosition }} z-10 {{ $overlaySize }} rounded-xl border border-gray-200 bg-linear-to-b from-gray-50 to-gray-50 opacity-90 flex items-center justify-center backdrop-blur-xs {{ $overlayShadowClass }}">
   <div class="hidden sm:flex items-center justify-center h-full py-6 px-8 text-gray-600">
     {{/* Primary Icon (Company Logo) */}}
     {{ if $primaryIcon }}

--- a/layouts/partials/components/timeline/with_icon.html
+++ b/layouts/partials/components/timeline/with_icon.html
@@ -16,13 +16,13 @@
             {{ end }}
         </span>
       </div>
-      <div class="-translate-y-1.5 pb-8 text-slate-600 w-full overflow-hidden break-words">
+      <div class="-translate-y-1.5 pb-8 text-slate-600 w-full overflow-hidden wrap-break-word">
         <p class="font-sans text-base font-bold text-slate-800 antialiased dark:text-white">{{ $item.title }}</p>
         {{ if $item.description }}<small class="mt-2 font-sans text-sm text-slate-600 antialiased">{{ $item.description }}</small>{{end}}
         {{ if $item.code }}
           <p class="mt-2 font-bold font-sans text-sm text-slate-600 antialiased">{{ $sourceCodeTitle | default (i18n "source_code") | default "Code:" }}</p>
-          <pre class="mt-2 rounded-xl bg-gray-800 p-4 text-sm text-white dark:bg-slate-800 w-full whitespace-pre-line break-words">
-            <code class="block w-full text-white whitespace-pre-line break-words">{{ $item.code }}</code>
+          <pre class="mt-2 rounded-xl bg-gray-800 p-4 text-sm text-white dark:bg-slate-800 w-full whitespace-pre-line wrap-break-word">
+            <code class="block w-full text-white whitespace-pre-line wrap-break-word">{{ $item.code }}</code>
           </pre>
         {{ end }}
       </div>

--- a/layouts/partials/components/tooltip/tooltip.html
+++ b/layouts/partials/components/tooltip/tooltip.html
@@ -23,11 +23,11 @@
 {{ end }}
 
 <div class="inline-block whitespace-normal hyphens-auto">
-  <span class="md:group md:relative"><span class="pr-2">{{ .content }}</span><button type="button" class="inline-flex focus:outline-none align-text-bottom">
+  <span class="md:group md:relative"><span class="pr-2">{{ .content }}</span><button type="button" class="inline-flex focus:outline-hidden align-text-bottom">
       {{ partial (printf "icons/%s" $icon) (printf "%s cursor-pointer tooltip-trigger %s" $sizeIcon $colorIcon) }}
     </button>
     <div
-      class="pointer-events-none absolute left-4 right-4 md:left-1/2 md:right-auto bottom-4 md:bottom-auto {{ $tooltipPosition }} z-[9999] md:w-72 rounded-md bg-gray-900 px-4 py-3 text-sm text-white font-normal opacity-0 shadow-xl transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100 tooltip-content leading-relaxed"
+      class="pointer-events-none absolute left-4 right-4 md:left-1/2 md:right-auto bottom-4 md:bottom-auto {{ $tooltipPosition }} z-9999 md:w-72 rounded-md bg-gray-900 px-4 py-3 text-sm text-white font-normal opacity-0 shadow-xl transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100 tooltip-content leading-relaxed"
       data-tooltip
       role="tooltip"
     >

--- a/layouts/partials/cookies-bar.html
+++ b/layouts/partials/cookies-bar.html
@@ -39,7 +39,7 @@
      the inner flex layer, which the JS never touches. Overlay is bg-black/30
      (= rgba(0,0,0,0.3)) with NO close handler, so the page is blocked until the user
      makes a choice. Three EQUAL-weight buttons for GDPR parity, Accept last. */}}
-<div id="{{ $bannerId }}" data-cookie-consent-banner data-consent-v2 class="fixed inset-0 z-[99999] {{ $darkClass }}">
+<div id="{{ $bannerId }}" data-cookie-consent-banner data-consent-v2 class="fixed inset-0 z-99999 {{ $darkClass }}">
     <div class="absolute inset-0 bg-black/30"></div>
     {{/* Mobile: dock the card to the bottom so the (stacked) buttons sit in the
          thumb zone, Accept last = lowest. Desktop (sm+): vertically centered. */}}
@@ -93,7 +93,7 @@
 <!-- Cookie Settings Modal (hidden by default) — Necessary + Analytics as switches.
      Same z as the banner (later in DOM → paints above it); z-50 sat below the
      blocking banner AND below the top promo bar. -->
-<div id="cookie-settings-modal" class="fixed inset-0 z-[99999] hidden {{ $darkClass }}">
+<div id="cookie-settings-modal" class="fixed inset-0 z-99999 hidden {{ $darkClass }}">
     <div class="absolute inset-0 bg-black bg-opacity-50" data-cookie-settings-close></div>
     {{/* Same centering pattern as the banner above: mobile docked to the bottom,
          desktop (sm+) vertically centered — replaces the theme's mx-auto mt-20. */}}
@@ -208,7 +208,7 @@
 {{- $settingsText := i18n "cookie_consent_settings" -}}
 {{- $bannerId := "cookie-consent-banner" -}}
 
-<div id="{{ $bannerId }}" data-cookie-consent-banner class="pointer-events-none fixed inset-x-0 bottom-0 px-6 pb-20 md:pb-6 z-[99999] {{ $darkClass }}">
+<div id="{{ $bannerId }}" data-cookie-consent-banner class="pointer-events-none fixed inset-x-0 bottom-0 px-6 pb-20 md:pb-6 z-99999 {{ $darkClass }}">
     <div class="pointer-events-auto max-w-xl rounded-xl section-bg-light dark:section-bg-dark p-6 ring-1 shadow-lg ring-gray-900/10">
         <p class="text-secondary text-sm/6"><strong class="text-heading text-md mb-4 font-semibold">{{ $title }}</strong><br> {{ $message }} See our <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $policyUrl) }}" class="font-semibold text-primary hover:text-primary-500">{{ $policyText }}</a>.</p>
         <div class="mt-4 flex items-center gap-x-3 gap-y-2 md:gap-y-0 flex-wrap">

--- a/layouts/partials/design-system/gradients.html
+++ b/layouts/partials/design-system/gradients.html
@@ -1,11 +1,11 @@
 <div class="bg-background-alt p-6 rounded-xl">
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <!-- Primary gradient -->
-    <div class="bg-white shadow rounded-xl overflow-hidden">
-      <div class="h-24 bg-gradient-to-r from-primary to-primary-light"></div>
+    <div class="bg-white shadow-sm rounded-xl overflow-hidden">
+      <div class="h-24 bg-linear-to-r from-primary to-primary-light"></div>
       <div class="p-4 border-t">
         <h3 class="font-medium mb-1">Primary gradient</h3>
-        <p class="text-sm font-mono text-text-light">bg-gradient-to-r from-primary to-primary-light</p>
+        <p class="text-sm font-mono text-text-light">bg-linear-to-r from-primary to-primary-light</p>
         <div class="mt-2">
           <pre class="text-xs bg-background-dark p-2 rounded-xl"><code>background: linear-gradient(to right, var(--color-primary), var(--color-primary-light));</code></pre>
         </div>

--- a/layouts/partials/design-system/icons.html
+++ b/layouts/partials/design-system/icons.html
@@ -15,16 +15,16 @@
   <div class="flex flex-wrap items-center gap-4 bg-gray-50 p-3 rounded-xl">
     <div class="flex items-center">
       <label class="text-sm font-medium text-gray-700 mr-2">Style:</label>
-      <div class="flex bg-white rounded-xl shadow-sm p-1 border border-gray-200">
+      <div class="flex bg-white rounded-xl shadow-xs p-1 border border-gray-200">
         <button type="button" id="outline-toggle"
           class="px-3 py-1 text-sm font-medium rounded-xl bg-blue-100 text-blue-700">Outline</button>
         <button type="button" id="solid-toggle"
           class="px-3 py-1 text-sm font-medium rounded-xl text-gray-700">Solid</button>
       </div>
     </div>
-    <div class="flex-grow">
+    <div class="grow">
       <input type="text" id="icon-search" placeholder="Search icons..."
-        class="w-full px-3 py-2 border border-gray-300 rounded-xl shadow-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 text-sm">
+        class="w-full px-3 py-2 border border-gray-300 rounded-xl shadow-xs focus:outline-hidden focus:ring-1 focus:ring-blue-500 focus:border-blue-500 text-sm">
     </div>
   </div>
 
@@ -65,7 +65,7 @@
       {{ $isSolid := findRE "-solid$" $iconName }}
 
       <div
-        class="flex flex-col items-center p-4 rounded-lg bg-white shadow border border-gray-100 hover:border-gray-300 transition-colors icon-card cursor-pointer {{ if $isSolid }}solid-icon hidden{{ else }}outline-icon{{ end }}"
+        class="flex flex-col items-center p-4 rounded-lg bg-white shadow-sm border border-gray-100 hover:border-gray-300 transition-colors icon-card cursor-pointer {{ if $isSolid }}solid-icon hidden{{ else }}outline-icon{{ end }}"
         data-icon-name="{{ $iconName }}">
         <div class="flex items-center justify-center w-12 h-12 bg-gray-50 rounded-xl mb-2">
           {{ partial $partialPath "w-6 h-6 text-gray-500" }}

--- a/layouts/partials/header/menu-item.html
+++ b/layouts/partials/header/menu-item.html
@@ -70,6 +70,6 @@
 </a>
 {{- if and site.Params.promotional.enabled $promo -}}
   {{- $limitedOfferText := i18n "promo_offer_in_menu" | default "-75% OFF" -}}
-  <span class="absolute right-0 pointer-events-none px-2 py-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full whitespace-nowrap shadow-sm top-0 translate-x-0 lg:-top-[17px] lg:translate-x-[70%]">{{- $limitedOfferText -}}</span>
+  <span class="absolute right-0 pointer-events-none px-2 py-0.5 bg-red-500 text-white text-[10px] font-bold rounded-full whitespace-nowrap shadow-xs top-0 translate-x-0 lg:top-[-17px] lg:translate-x-[70%]">{{- $limitedOfferText -}}</span>
 </div>
 {{- end -}}

--- a/layouts/partials/layout/footers/4-column_with_call-to-action.html
+++ b/layouts/partials/layout/footers/4-column_with_call-to-action.html
@@ -148,7 +148,7 @@
       </hgroup>
       <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty {{ $ctaDescriptionColor }}">{{ $ctaDescription }}</p>
       <div class="mt-8 flex justify-center">
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaButtonUrl) }}" class="rounded-md {{ $ctaButtonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $ctaButtonTextColor }} shadow-xs hover:{{ $ctaButtonHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $ctaButtonText }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaButtonUrl) }}" class="rounded-md {{ $ctaButtonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $ctaButtonTextColor }} shadow-2xs hover:{{ $ctaButtonHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $ctaButtonText }}</a>
       </div>
     </div>
     <div class="mt-24 border-t {{ $borderColor }} pt-12 xl:grid xl:grid-cols-3 xl:gap-8">

--- a/layouts/partials/layout/footers/4-column_with_call-to-action_on_dark.html
+++ b/layouts/partials/layout/footers/4-column_with_call-to-action_on_dark.html
@@ -111,7 +111,7 @@
       <p class="mt-2 text-4xl font-semibold tracking-tight text-balance {{ $ctaHeadingColor }} sm:text-5xl">{{ $ctaHeading }}</p>
       <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty {{ $ctaDescriptionColor }}">{{ $ctaDescription }}</p>
       <div class="mt-8 flex justify-center">
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaButtonUrl) }}" class="rounded-md {{ $ctaButtonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $ctaButtonTextColor }} shadow-xs hover:{{ $ctaButtonHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $ctaButtonText }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaButtonUrl) }}" class="rounded-md {{ $ctaButtonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $ctaButtonTextColor }} shadow-2xs hover:{{ $ctaButtonHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $ctaButtonText }}</a>
       </div>
     </div>
     <div class="mt-24 border-t {{ $borderColor }} pt-12 xl:grid xl:grid-cols-3 xl:gap-8">

--- a/layouts/partials/products/with_image_grid.html
+++ b/layouts/partials/products/with_image_grid.html
@@ -117,7 +117,7 @@
     </div>
 
     <!-- Product info -->
-    <div class="mx-auto max-w-2xl px-4 pt-10 pb-16 sm:px-6 lg:grid lg:max-w-7xl lg:grid-cols-3 lg:grid-rows-[auto,auto,1fr] lg:gap-x-8 lg:px-8 lg:pt-16 lg:pb-24">
+    <div class="mx-auto max-w-2xl px-4 pt-10 pb-16 sm:px-6 lg:grid lg:max-w-7xl lg:grid-cols-3 lg:grid-rows-[auto_auto_1fr] lg:gap-x-8 lg:px-8 lg:pt-16 lg:pb-24">
       <div class="lg:col-span-2 lg:border-r lg:border-gray-200 lg:pr-8">
         <h1 class="text-2xl font-bold tracking-tight text-gray-900 sm:text-3xl">{{ $product.title }}</h1>
       </div>

--- a/layouts/partials/products/with_tabs.html
+++ b/layouts/partials/products/with_tabs.html
@@ -250,7 +250,7 @@
                 </dl>
               {{ else if eq $tab.id "license" }}
                 <div class="pt-10">
-                  <div class="text-sm text-gray-500 [&_h4]:mt-5 [&_h4]:font-medium [&_h4]:text-gray-900 [&_li]:pl-2 [&_li::marker]:text-gray-300 [&_p]:my-2 [&_p]:text-sm/6 [&_ul]:my-4 [&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-5 [&_ul]:text-sm/6 [&>:first-child]:mt-0">
+                  <div class="text-sm text-gray-500 [&_h4]:mt-5 [&_h4]:font-medium [&_h4]:text-gray-900 [&_li]:pl-2 [&_li::marker]:text-gray-300 [&_p]:my-2 [&_p]:text-sm/6 [&_ul]:my-4 [&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-5 [&_ul]:text-sm/6 *:first:mt-0">
                     <h4>{{ $tab.content.overview.title }}</h4>
 
                     <p>{{ $tab.content.overview.description }}</p>

--- a/layouts/partials/search_field.html
+++ b/layouts/partials/search_field.html
@@ -20,12 +20,12 @@
 
 <div class="w-full h-full {{ $marginClass }} relative">
     <div class="relative w-full">
-        <input type="text" id="popup-search-input-{{ $searchId }}" class="hide-search-clear w-full pl-3 pr-9 py-1.5 text-sm border border-gray-primary rounded-md surface-primary placeholder:text-placeholder focus:outline-none focus:ring-2 focus:ring-primary transition" placeholder="{{ $placeholder }}" aria-label="{{ $placeholder }}">
-        <button type="button" id="clear-search-{{ $searchId }}" class="absolute right-2 top-1/2 -translate-y-1/2 hidden p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors" aria-label="{{ i18n "search_clear_aria" }}" title="{{ i18n "search_clear_title" }}">
+        <input type="text" id="popup-search-input-{{ $searchId }}" class="hide-search-clear w-full pl-3 pr-9 py-1.5 text-sm border border-gray-primary rounded-md surface-primary placeholder:text-placeholder focus:outline-hidden focus:ring-2 focus:ring-primary transition" placeholder="{{ $placeholder }}" aria-label="{{ $placeholder }}">
+        <button type="button" id="clear-search-{{ $searchId }}" class="absolute right-2 top-1/2 -translate-y-1/2 hidden p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-sm transition-colors" aria-label="{{ i18n "search_clear_aria" }}" title="{{ i18n "search_clear_title" }}">
             {{ partial "icons/x-mark" "w-4 h-4 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300" }}
         </button>
     </div>
-    <div id="search-results-popup-{{ $searchId }}" class="absolute top-full left-0 right-0 mt-2 max-h-[500px] overflow-y-auto bg-white dark:bg-gray-900 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 z-[9999] hidden">
+    <div id="search-results-popup-{{ $searchId }}" class="absolute top-full left-0 right-0 mt-2 max-h-[500px] overflow-y-auto bg-white dark:bg-gray-900 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 z-9999 hidden">
         <div id="popup-search-results-{{ $searchId }}" class="p-2"></div>
         <div class="search-loading-{{ $searchId }} text-center px-3 py-4 text-secondary hidden">{{ i18n "search_loading" }}</div>
         <div class="search-view-all-{{ $searchId }} text-center py-3 border-t border-gray-200 dark:border-gray-700 hidden">
@@ -428,7 +428,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     const permalink = item.permalink || '#';
 
                     const isLast = index === displayResults.length - 1;
-                    const borderClass = 'border border-gray-200 dark:border-gray-700 rounded-md shadow-sm';
+                    const borderClass = 'border border-gray-200 dark:border-gray-700 rounded-md shadow-xs';
                     const marginClass = isLast ? '' : 'mb-3';
 
                     html += `
@@ -581,7 +581,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 <a href="${permalink}" class="block px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${!isLast ? 'border-b border-gray-100 dark:border-gray-800' : ''}">
                     <div class="flex items-start gap-3">
                         ${imageUrl ? `
-                        <div class="flex-shrink-0 w-10 h-10 bg-gray-100 dark:bg-gray-800 rounded-md flex items-center justify-center overflow-hidden">
+                        <div class="shrink-0 w-10 h-10 bg-gray-100 dark:bg-gray-800 rounded-md flex items-center justify-center overflow-hidden">
                             <img src="${imageUrl}" alt="${title}" class="w-full h-full object-contain p-1" loading="lazy">
                         </div>
                         ` : ''}
@@ -630,16 +630,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
         return `
             <li>
-                <article class="group relative rounded-2xl flex flex-col surface-secondary shadow-lg border border-gray-primary overflow-hidden transition-transform duration-300 ease-in-out hover:-translate-y-1 h-full min-h-[15.75rem]">
+                <article class="group relative rounded-2xl flex flex-col surface-secondary shadow-lg border border-gray-primary overflow-hidden transition-transform duration-300 ease-in-out hover:-translate-y-1 h-full min-h-63">
                     <a href="${item.permalink}" class="absolute inset-0" aria-label="Read more: ${item.title}">
                         <span class="sr-only">${item.title}</span>
                     </a>
-                    <div class="flex flex-col flex-grow p-8 items-start text-left">
+                    <div class="flex flex-col grow p-8 items-start text-left">
                         ${isFaq ? `<div class="mb-2">${iconHtml}</div>` : ''}
                         <h3 class="text-lg/6 font-semibold text-heading group-hover:text-tertiary transition-colors duration-300">
                             ${item.title}
                         </h3>
-                        <p class="mt-5 text-sm leading-6 text-secondary font-normal line-clamp-3 flex-grow overflow-hidden">${truncatedContent}</p>
+                        <p class="mt-5 text-sm leading-6 text-secondary font-normal line-clamp-3 grow overflow-hidden">${truncatedContent}</p>
                     </div>
                 </article>
             </li>

--- a/layouts/partials/sections/banners/bottom_aligned.html
+++ b/layouts/partials/sections/banners/bottom_aligned.html
@@ -47,7 +47,7 @@
     </p>
     {{ if $isDismissable }}
     <div class="flex flex-1 justify-end">
-      <button type="button" class="-m-3 p-3 focus-visible:outline-offset-[-4px]" data-dismiss-banner>
+      <button type="button" class="-m-3 p-3 focus-visible:-outline-offset-4" data-dismiss-banner>
         <span class="sr-only">Dismiss</span>
         <svg class="size-5 {{ $dismissButtonColor }}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
           <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />

--- a/layouts/partials/sections/banners/cookie_consent_floating_at_bottom.html
+++ b/layouts/partials/sections/banners/cookie_consent_floating_at_bottom.html
@@ -103,10 +103,10 @@
     </div>
     
     <div class="mt-6 flex justify-end gap-x-3">
-      <button type="button" class="px-3 py-2 text-sm font-semibold rounded-xl bg-white text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50" data-cookie-settings-close>
+      <button type="button" class="px-3 py-2 text-sm font-semibold rounded-xl bg-white text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50" data-cookie-settings-close>
         {{ i18n "cookie_settings_cancel" }}
       </button>
-      <button type="button" class="px-3 py-2 text-sm font-semibold rounded-xl bg-indigo-600 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" data-cookie-settings-save>
+      <button type="button" class="px-3 py-2 text-sm font-semibold rounded-xl bg-indigo-600 text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" data-cookie-settings-save>
         {{ i18n "cookie_settings_save" }}
       </button>
     </div>

--- a/layouts/partials/sections/banners/floating_at_bottom.html
+++ b/layouts/partials/sections/banners/floating_at_bottom.html
@@ -47,7 +47,7 @@
       </a>
     </p>
     {{ if $isDismissable }}
-    <button type="button" class="-m-3 flex-none p-3 focus-visible:outline-offset-[-4px]" data-dismiss-banner>
+    <button type="button" class="-m-3 flex-none p-3 focus-visible:-outline-offset-4" data-dismiss-banner>
       <span class="sr-only">Dismiss</span>
       <svg class="size-5 {{ $dismissButtonColor }}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
         <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />

--- a/layouts/partials/sections/banners/mini-banner-cta.html
+++ b/layouts/partials/sections/banners/mini-banner-cta.html
@@ -37,26 +37,26 @@
 <div class="mini-banner-cta min-h-[72px] rounded-xl border border-gray-200 overflow-hidden my-6">
   <div class="bg-gray-100 min-h-[72px] flex flex-col lg:flex-row lg:items-center gap-4 p-3 md:p-4 lg:py-3">
     <div class="flex items-center gap-3 lg:mr-auto">
-      <div class="bg-gray-100 p-2 flex-shrink-0 rounded-l-lg">
+      <div class="bg-gray-100 p-2 shrink-0 rounded-l-lg">
         {{ $logo := site.Params.logo_icon }}
         {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
           {{ $logoUrl := partial "functions/get-static-url.html" (dict "path" (printf "/images/%s" $logo)) }}
-          <img src="{{ $logoUrl }}" alt="{{ i18n "header.logo_alt" | default "Logo" }}" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
+          <img src="{{ $logoUrl }}" alt="{{ i18n "header.logo_alt" | default "Logo" }}" width="36" class="w-8 md:w-9 object-contain my-0! block!" loading="lazy" />
         {{ else }}
           {{ partial "icons/rocket-launch-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}
       </div>
       <div class="min-w-0 flex-1">
-        <h3 class="text-sm lg:text-base font-semibold leading-tight !my-0 truncate">{{ $heading }}</h3>
-        <p class="text-xs lg:text-sm !my-0 !mt-0.5 line-clamp-2">{{ $description }}</p>
+        <h3 class="text-sm lg:text-base font-semibold leading-tight my-0! truncate">{{ $heading }}</h3>
+        <p class="text-xs lg:text-sm my-0! mt-0.5! line-clamp-2">{{ $description }}</p>
       </div>
     </div>
 
-    <div class="flex flex-col sm:flex-row gap-2 lg:flex-shrink-0">
-      <a href="{{ $primaryUrl }}" class="btn-primary px-3.5 py-2.5 text-center whitespace-nowrap !no-underline not-prose group">
+    <div class="flex flex-col sm:flex-row gap-2 lg:shrink-0">
+      <a href="{{ $primaryUrl }}" class="btn-primary px-3.5 py-2.5 text-center whitespace-nowrap no-underline! not-prose group">
         {{ $primaryText }}
       </a>
-      <a href="{{ $secondaryUrl }}" class="btn-secondary px-3.5 py-2.5 text-sm text-center whitespace-nowrap !no-underline">
+      <a href="{{ $secondaryUrl }}" class="btn-secondary px-3.5 py-2.5 text-sm text-center whitespace-nowrap no-underline!">
         {{ $secondaryText }}
       </a>
     </div>

--- a/layouts/partials/sections/banners/mini-banner-newsletter.html
+++ b/layouts/partials/sections/banners/mini-banner-newsletter.html
@@ -35,22 +35,22 @@
 <div class="newsletter-box min-h-[72px] rounded-xl border border-gray-200 overflow-hidden my-6">
   <div class="bg-gray-100 min-h-[72px] flex flex-col lg:flex-row lg:items-center gap-4 p-3 md:p-4 lg:py-3">
     <div class="flex items-center gap-3 lg:mr-auto">
-      <div class="bg-gray-100 p-2 flex-shrink-0 rounded-l-lg">
+      <div class="bg-gray-100 p-2 shrink-0 rounded-l-lg">
         {{ $logo := site.Params.logo_icon }}
         {{ if and $logo (fileExists (printf "cdn-assets/%s" $logo)) }}
           {{ $logoUrl := partial "functions/get-static-url.html" (dict "path" (printf "/images/%s" $logo)) }}
-          <img src="{{ $logoUrl }}" alt="{{ i18n "header.logo_alt" | default "Logo" }}" width="36" class="w-8 md:w-9 object-contain !my-0 !block" loading="lazy" />
+          <img src="{{ $logoUrl }}" alt="{{ i18n "header.logo_alt" | default "Logo" }}" width="36" class="w-8 md:w-9 object-contain my-0! block!" loading="lazy" />
         {{ else }}
           {{ partial "icons/envelope-solid" "w-8 md:w-9 text-primary-600" }}
         {{ end }}
       </div>
       <div class="min-w-0 flex-1">
-        <h3 class="text-sm lg:text-base font-semibold leading-tight !my-0 truncate">{{ $heading }}</h3>
-        <p class="text-xs lg:text-sm !my-0 !mt-0.5 line-clamp-2">{{ $description }}</p>
+        <h3 class="text-sm lg:text-base font-semibold leading-tight my-0! truncate">{{ $heading }}</h3>
+        <p class="text-xs lg:text-sm my-0! mt-0.5! line-clamp-2">{{ $description }}</p>
       </div>
     </div>
 
-    <form class="flex-shrink-0 w-full lg:w-auto newsletter-form"
+    <form class="shrink-0 w-full lg:w-auto newsletter-form"
       data-error-email="{{ i18n "newsletter.error_email" | default "Please enter a valid email address" }}"
       action="{{ $action }}"
       method="post"
@@ -68,7 +68,7 @@
             autocomplete="email"
             required
             placeholder="{{ $placeholder }}"
-            class="w-full lg:w-64 px-3.5 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 bg-white border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            class="w-full lg:w-64 px-3.5 py-2.5 text-sm text-gray-900 placeholder:text-gray-400 bg-white border border-gray-300 rounded-lg focus:outline-hidden focus:ring-2 focus:ring-primary focus:border-transparent"
           />
           <div style="position: absolute; left: -5000px;" aria-hidden="true">
             <input type="text" name="b_18d6ab6093f8e6cdbbd783635_22b687a6cc" tabindex="-1" value="">

--- a/layouts/partials/sections/banners/on_brand.html
+++ b/layouts/partials/sections/banners/on_brand.html
@@ -40,7 +40,7 @@
   </p>
   {{ if $isDismissable }}
   <div class="flex flex-1 justify-end">
-    <button type="button" class="-m-3 p-3 focus-visible:outline-offset-[-4px]" data-dismiss-banner>
+    <button type="button" class="-m-3 p-3 focus-visible:-outline-offset-4" data-dismiss-banner>
       <span class="sr-only">Dismiss</span>
       <svg class="size-5 {{ $dismissButtonColor }}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
         <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />

--- a/layouts/partials/sections/banners/on_dark.html
+++ b/layouts/partials/sections/banners/on_dark.html
@@ -40,7 +40,7 @@
   </p>
   {{ if $isDismissable }}
   <div class="flex flex-1 justify-end">
-    <button type="button" class="-m-3 p-3 focus-visible:outline-offset-[-4px]" data-dismiss-banner>
+    <button type="button" class="-m-3 p-3 focus-visible:-outline-offset-4" data-dismiss-banner>
       <span class="sr-only">Dismiss</span>
       <svg class="size-5 {{ $dismissButtonColor }}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
         <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />

--- a/layouts/partials/sections/banners/privacy_notice_centered.html
+++ b/layouts/partials/sections/banners/privacy_notice_centered.html
@@ -50,7 +50,7 @@
   <div class="pointer-events-auto mx-auto max-w-xl rounded-xl {{ $backgroundColor }} p-6 ring-1 shadow-lg ring-gray-900/10">
     <p class="text-sm/6 {{ $textColor }}">{{ $message }} See our <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $policyUrl) }}" class="font-semibold {{ $linkColor }}">{{ $policyText }}</a>.</p>
     <div class="mt-4 flex items-center gap-x-5">
-      <button type="button" data-dismiss-banner class="rounded-md {{ $acceptButtonBackgroundColor }} px-3 py-2 text-sm font-semibold {{ $acceptButtonTextColor }} shadow-xs {{ $acceptButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $acceptButtonFocusColor }}">{{ $acceptText }}</button>
+      <button type="button" data-dismiss-banner class="rounded-md {{ $acceptButtonBackgroundColor }} px-3 py-2 text-sm font-semibold {{ $acceptButtonTextColor }} shadow-2xs {{ $acceptButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $acceptButtonFocusColor }}">{{ $acceptText }}</button>
       <button type="button" data-dismiss-banner class="text-sm/6 font-semibold {{ $rejectButtonTextColor }}">{{ $rejectText }}</button>
     </div>
   </div>

--- a/layouts/partials/sections/banners/privacy_notice_full_width.html
+++ b/layouts/partials/sections/banners/privacy_notice_full_width.html
@@ -51,7 +51,7 @@
 <div id="{{ $bannerId }}" data-banner class="fixed inset-x-0 bottom-0 flex flex-col justify-between gap-x-8 gap-y-4 {{ $backgroundColor }} p-6 ring-1 ring-gray-900/10 md:flex-row md:items-center lg:px-8 z-50">
   <p class="max-w-4xl text-sm/6 {{ $textColor }}">{{ $message }} See our <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $policyUrl) }}" class="font-semibold {{ $linkColor }}">{{ $policyText }}</a>.</p>
   <div class="flex flex-none items-center gap-x-5">
-    <button type="button" data-dismiss-banner class="rounded-md {{ $acceptButtonBackgroundColor }} px-3 py-2 text-sm font-semibold {{ $acceptButtonTextColor }} shadow-xs {{ $acceptButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $acceptButtonFocusColor }}">{{ $acceptText }}</button>
+    <button type="button" data-dismiss-banner class="rounded-md {{ $acceptButtonBackgroundColor }} px-3 py-2 text-sm font-semibold {{ $acceptButtonTextColor }} shadow-2xs {{ $acceptButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $acceptButtonFocusColor }}">{{ $acceptText }}</button>
     <button type="button" data-dismiss-banner class="text-sm/6 font-semibold {{ $rejectButtonTextColor }}">{{ $rejectText }}</button>
   </div>
 </div>

--- a/layouts/partials/sections/banners/privacy_notice_left_aligned.html
+++ b/layouts/partials/sections/banners/privacy_notice_left_aligned.html
@@ -52,7 +52,7 @@
   <div class="pointer-events-auto max-w-xl rounded-xl {{ $backgroundColor }} p-6 ring-1 shadow-lg ring-gray-900/10">
     <p class="text-sm/6 {{ $textColor }}">{{ $message }} See our <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $policyUrl) }}" class="font-semibold {{ $linkColor }}">{{ $policyText }}</a>.</p>
     <div class="mt-4 flex items-center gap-x-5">
-      <button type="button" data-dismiss-banner class="rounded-md {{ $acceptButtonBackgroundColor }} px-3 py-2 text-sm font-semibold {{ $acceptButtonTextColor }} shadow-xs {{ $acceptButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $acceptButtonFocusColor }}">{{ $acceptText }}</button>
+      <button type="button" data-dismiss-banner class="rounded-md {{ $acceptButtonBackgroundColor }} px-3 py-2 text-sm font-semibold {{ $acceptButtonTextColor }} shadow-2xs {{ $acceptButtonHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $acceptButtonFocusColor }}">{{ $acceptText }}</button>
       <button type="button" data-dismiss-banner class="text-sm/6 font-semibold {{ $rejectButtonTextColor }}">{{ $rejectText }}</button>
     </div>
   </div>

--- a/layouts/partials/sections/banners/with_background_glow.html
+++ b/layouts/partials/sections/banners/with_background_glow.html
@@ -40,10 +40,10 @@
 
 <div id="{{ $bannerId }}" data-banner class="relative isolate flex items-center gap-x-6 overflow-hidden {{ $backgroundColor }} px-6 py-2.5 sm:px-3.5 sm:before:flex-1 z-50">
   <div class="absolute top-1/2 left-[max(-7rem,calc(50%-52rem))] -z-10 -translate-y-1/2 transform-gpu blur-2xl" aria-hidden="true">
-    <div class="aspect-577/310 w-[36.0625rem] bg-gradient-to-r {{ $gradientFromColor }} {{ $gradientToColor }} opacity-30" style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
+    <div class="aspect-577/310 w-144.25 bg-linear-to-r {{ $gradientFromColor }} {{ $gradientToColor }} opacity-30" style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
   </div>
   <div class="absolute top-1/2 left-[max(45rem,calc(50%+8rem))] -z-10 -translate-y-1/2 transform-gpu blur-2xl" aria-hidden="true">
-    <div class="aspect-577/310 w-[36.0625rem] bg-gradient-to-r {{ $gradientFromColor }} {{ $gradientToColor }} opacity-30" style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
+    <div class="aspect-577/310 w-144.25 bg-linear-to-r {{ $gradientFromColor }} {{ $gradientToColor }} opacity-30" style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
   </div>
   <p class="text-sm/6 {{ $textColor }}">
     <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $url) }}">
@@ -52,7 +52,7 @@
   </p>
   {{ if $isDismissable }}
   <div class="flex flex-1 justify-end">
-    <button type="button" class="-m-3 p-3 focus-visible:outline-offset-[-4px]" data-dismiss-banner>
+    <button type="button" class="-m-3 p-3 focus-visible:-outline-offset-4" data-dismiss-banner>
       <span class="sr-only">Dismiss</span>
       <svg class="size-5 {{ $dismissButtonColor }}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
         <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />

--- a/layouts/partials/sections/banners/with_button.html
+++ b/layouts/partials/sections/banners/with_button.html
@@ -54,20 +54,20 @@
 
 <div id="{{ $bannerId }}" data-banner class="relative isolate flex items-center gap-x-6 overflow-hidden {{ $backgroundColor }} px-6 py-2.5 sm:px-3.5 sm:before:flex-1 z-50">
   <div class="absolute top-1/2 left-[max(-7rem,calc(50%-52rem))] -z-10 -translate-y-1/2 transform-gpu blur-2xl" aria-hidden="true">
-    <div class="aspect-577/310 w-[36.0625rem] bg-gradient-to-r {{ $gradientFromColor }} {{ $gradientToColor }} opacity-30" style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
+    <div class="aspect-577/310 w-144.25 bg-linear-to-r {{ $gradientFromColor }} {{ $gradientToColor }} opacity-30" style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
   </div>
   <div class="absolute top-1/2 left-[max(45rem,calc(50%+8rem))] -z-10 -translate-y-1/2 transform-gpu blur-2xl" aria-hidden="true">
-    <div class="aspect-577/310 w-[36.0625rem] bg-gradient-to-r {{ $gradientFromColor }} {{ $gradientToColor }} opacity-30" style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
+    <div class="aspect-577/310 w-144.25 bg-linear-to-r {{ $gradientFromColor }} {{ $gradientToColor }} opacity-30" style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
   </div>
   <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
     <p class="text-sm/6 {{ $textColor }}">
       <strong class="font-semibold">{{ $title }}</strong><svg viewBox="0 0 2 2" class="mx-2 inline size-0.5 fill-current" aria-hidden="true"><circle cx="1" cy="1" r="1" /></svg>{{ $message }}
     </p>
-    <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $buttonUrl) }}" class="flex-none rounded-full {{ $buttonBackgroundColor }} px-3.5 py-1 text-sm font-semibold {{ $buttonTextColor }} shadow-xs {{ $buttonHoverColor }} focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 {{ $buttonFocusColor }}">{{ $buttonText }} <span aria-hidden="true">&rarr;</span></a>
+    <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $buttonUrl) }}" class="flex-none rounded-full {{ $buttonBackgroundColor }} px-3.5 py-1 text-sm font-semibold {{ $buttonTextColor }} shadow-2xs {{ $buttonHoverColor }} focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 {{ $buttonFocusColor }}">{{ $buttonText }} <span aria-hidden="true">&rarr;</span></a>
   </div>
   {{ if $isDismissable }}
   <div class="flex flex-1 justify-end">
-    <button type="button" class="-m-3 p-3 focus-visible:outline-offset-[-4px]" data-dismiss-banner>
+    <button type="button" class="-m-3 p-3 focus-visible:-outline-offset-4" data-dismiss-banner>
       <span class="sr-only">Dismiss</span>
       <svg class="size-5 {{ $dismissButtonColor }}" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
         <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />

--- a/layouts/partials/sections/banners/with_image.html
+++ b/layouts/partials/sections/banners/with_image.html
@@ -56,7 +56,7 @@
                     <h2 class="{{ $textClasses }}">{{ $text | safeHTML }}</h2>
                 </div>
             </div>
-            <div class="absolute w-[561px] h-[481px] left-10 -bottom-96 rotate-12 rounded-full bg-gradient-to-tr {{ $gradientFromColor }} {{ $gradientToColor }} opacity-50 blur-2xl z-0"></div>
+            <div class="absolute w-[561px] h-[481px] left-10 -bottom-96 rotate-12 rounded-full bg-linear-to-tr {{ $gradientFromColor }} {{ $gradientToColor }} opacity-50 blur-2xl z-0"></div>
         </div>
     </div>
 </section>

--- a/layouts/partials/sections/bentogrids/bento_grid_squared_images_on_dark.html
+++ b/layouts/partials/sections/bentogrids/bento_grid_squared_images_on_dark.html
@@ -108,8 +108,8 @@
           {{/* Large cards (4 columns) - at positions 0, 3, 4, 7, 8, 11, etc. */}}
           <div class="flex p-px lg:col-span-4">
             <div class="overflow-hidden rounded-lg bg-gray-800 ring-1 ring-white/15 w-full
-              {{ if and $isFirst (eq $modulo 0) }}max-lg:rounded-t-[2rem] lg:rounded-tl-[2rem]{{ end }}
-              {{ if and $isLast (eq $modulo 3) }}max-lg:rounded-b-[2rem] lg:rounded-br-[2rem]{{ end }}
+              {{ if and $isFirst (eq $modulo 0) }}max-lg:rounded-t-4xl lg:rounded-tl-4xl{{ end }}
+              {{ if and $isLast (eq $modulo 3) }}max-lg:rounded-b-4xl lg:rounded-br-4xl{{ end }}
               {{ if and (not $isFirst) (not $isLast) (eq $modulo 0) }}lg:rounded-l-lg{{ end }}
               {{ if and (not $isFirst) (not $isLast) (eq $modulo 3) }}lg:rounded-r-lg{{ end }}">
               {{ if $card.url }}
@@ -147,8 +147,8 @@
           {{/* Small cards (2 columns) - at positions 1, 2, 5, 6, 9, 10, etc. */}}
           <div class="flex p-px lg:col-span-2">
             <div class="overflow-hidden rounded-lg bg-gray-800 ring-1 ring-white/15 w-full
-              {{ if and $isFirst (eq $modulo 1) }}max-lg:rounded-t-[2rem] lg:rounded-tr-[2rem]{{ end }}
-              {{ if and $isLast (eq $modulo 2) }}max-lg:rounded-b-[2rem] lg:rounded-bl-[2rem]{{ end }}
+              {{ if and $isFirst (eq $modulo 1) }}max-lg:rounded-t-4xl lg:rounded-tr-4xl{{ end }}
+              {{ if and $isLast (eq $modulo 2) }}max-lg:rounded-b-4xl lg:rounded-bl-4xl{{ end }}
               {{ if and (eq $modulo 1) (not $isFirst) }}lg:rounded-r-lg{{ end }}
               {{ if and (eq $modulo 2) (not $isLast) }}lg:rounded-l-lg{{ end }}">
               {{ if $card.url }}

--- a/layouts/partials/sections/bentogrids/dynamic_bento_grid_on_dark.html
+++ b/layouts/partials/sections/bentogrids/dynamic_bento_grid_on_dark.html
@@ -113,7 +113,7 @@
                 {{ if $largeCard.url }}
                 <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $largeCard.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                 {{ end }}
-                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-[2rem] lg:rounded-tl-[2rem]{{ end }}">
+                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-4xl lg:rounded-tl-4xl{{ end }}">
                   {{ partial "components/media/lazyimg.html" (dict 
                     "src" $largeCard.image
                     "alt" $largeCard.imageAlt
@@ -131,7 +131,7 @@
                     {{ if $smallCard1.url }}
                     <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $smallCard1.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                     {{ end }}
-                    <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}lg:rounded-tr-[2rem]{{ end }}">
+                    <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}lg:rounded-tr-4xl{{ end }}">
                       {{ partial "components/media/lazyimg.html" (dict 
                         "src" $smallCard1.image
                         "alt" $smallCard1.imageAlt
@@ -145,7 +145,7 @@
                     {{ if $smallCard2.url }}
                     <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $smallCard2.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                     {{ end }}
-                    <div class="w-full h-full overflow-hidden rounded-lg {{ if and (eq $rowIndex (div (sub (len $cards) 1) 3)) (eq (mod (len $cards) 3) 0) }}max-lg:rounded-b-[2rem] lg:rounded-br-[2rem]{{ end }}">
+                    <div class="w-full h-full overflow-hidden rounded-lg {{ if and (eq $rowIndex (div (sub (len $cards) 1) 3)) (eq (mod (len $cards) 3) 0) }}max-lg:rounded-b-4xl lg:rounded-br-4xl{{ end }}">
                       {{ partial "components/media/lazyimg.html" (dict 
                         "src" $smallCard2.image
                         "alt" $smallCard2.imageAlt
@@ -167,7 +167,7 @@
                     {{ if $smallCard1.url }}
                     <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $smallCard1.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                     {{ end }}
-                    <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}lg:rounded-tl-[2rem]{{ end }}">
+                    <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}lg:rounded-tl-4xl{{ end }}">
                       {{ partial "components/media/lazyimg.html" (dict 
                         "src" $smallCard1.image
                         "alt" $smallCard1.imageAlt
@@ -181,7 +181,7 @@
                     {{ if $smallCard2.url }}
                     <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $smallCard2.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                     {{ end }}
-                    <div class="w-full h-full overflow-hidden rounded-lg {{ if and (eq $rowIndex (div (sub (len $cards) 1) 3)) (eq (mod (len $cards) 3) 0) }}max-lg:rounded-b-[2rem] lg:rounded-bl-[2rem]{{ end }}">
+                    <div class="w-full h-full overflow-hidden rounded-lg {{ if and (eq $rowIndex (div (sub (len $cards) 1) 3)) (eq (mod (len $cards) 3) 0) }}max-lg:rounded-b-4xl lg:rounded-bl-4xl{{ end }}">
                       {{ partial "components/media/lazyimg.html" (dict 
                         "src" $smallCard2.image
                         "alt" $smallCard2.imageAlt
@@ -198,7 +198,7 @@
                 {{ if $largeCard.url }}
                 <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $largeCard.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                 {{ end }}
-                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-[2rem] lg:rounded-tr-[2rem]{{ end }}">
+                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-4xl lg:rounded-tr-4xl{{ end }}">
                   {{ partial "components/media/lazyimg.html" (dict 
                     "src" $largeCard.image
                     "alt" $largeCard.imageAlt
@@ -218,7 +218,7 @@
                 {{ if $largeCard.url }}
                 <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $largeCard.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                 {{ end }}
-                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-[2rem] lg:rounded-tl-[2rem]{{ end }}">
+                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-4xl lg:rounded-tl-4xl{{ end }}">
                   {{ partial "components/media/lazyimg.html" (dict 
                     "src" $largeCard.image
                     "alt" $largeCard.imageAlt
@@ -233,7 +233,7 @@
                 {{ if $smallCard.url }}
                 <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $smallCard.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                 {{ end }}
-                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}lg:rounded-tr-[2rem]{{ end }} max-lg:rounded-b-[2rem] lg:rounded-br-[2rem]">
+                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}lg:rounded-tr-4xl{{ end }} max-lg:rounded-b-4xl lg:rounded-br-4xl">
                   {{ partial "components/media/lazyimg.html" (dict 
                     "src" $smallCard.image
                     "alt" $smallCard.imageAlt
@@ -250,7 +250,7 @@
                 {{ if $smallCard.url }}
                 <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $smallCard.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                 {{ end }}
-                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}lg:rounded-tl-[2rem]{{ end }} max-lg:rounded-b-[2rem] lg:rounded-bl-[2rem]">
+                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}lg:rounded-tl-4xl{{ end }} max-lg:rounded-b-4xl lg:rounded-bl-4xl">
                   {{ partial "components/media/lazyimg.html" (dict 
                     "src" $smallCard.image
                     "alt" $smallCard.imageAlt
@@ -265,7 +265,7 @@
                 {{ if $largeCard.url }}
                 <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $largeCard.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
                 {{ end }}
-                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-[2rem] lg:rounded-tr-[2rem]{{ end }}">
+                <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-4xl lg:rounded-tr-4xl{{ end }}">
                   {{ partial "components/media/lazyimg.html" (dict 
                     "src" $largeCard.image
                     "alt" $largeCard.imageAlt
@@ -284,7 +284,7 @@
               {{ if $largeCard.url }}
               <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $largeCard.url) }}" class="block w-full h-full transition-opacity hover:opacity-90">
               {{ end }}
-              <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-[2rem] lg:rounded-tl-[2rem]{{ end }} max-lg:rounded-b-[2rem] lg:rounded-br-[2rem]">
+              <div class="w-full h-full overflow-hidden rounded-lg {{ if eq $rowIndex 0 }}max-lg:rounded-t-4xl lg:rounded-tl-4xl{{ end }} max-lg:rounded-b-4xl lg:rounded-br-4xl">
                 {{ partial "components/media/lazyimg.html" (dict 
                   "src" $largeCard.image
                   "alt" $largeCard.imageAlt

--- a/layouts/partials/sections/bentogrids/three_column_bento_grid.html
+++ b/layouts/partials/sections/bentogrids/three_column_bento_grid.html
@@ -125,13 +125,13 @@ interest. Card heights are dynamically calculated based on their content.
             {{ $cornerClass := "" }}
             {{ if $roundedCorners }}
             {{ if and $isFirstInRow $isFirstRow }}
-            {{ $cornerClass = "lg:rounded-tl-[2rem]" }}
+            {{ $cornerClass = "lg:rounded-tl-4xl" }}
             {{ else if and $isThirdInRow $isFirstRow }}
-            {{ $cornerClass = "lg:rounded-tr-[2rem]" }}
+            {{ $cornerClass = "lg:rounded-tr-4xl" }}
             {{ else if and $isFirstInRow $isLastRow }}
-            {{ $cornerClass = "lg:rounded-bl-[2rem]" }}
+            {{ $cornerClass = "lg:rounded-bl-4xl" }}
             {{ else if and $isThirdInRow $isLastRow }}
-            {{ $cornerClass = "lg:rounded-br-[2rem]" }}
+            {{ $cornerClass = "lg:rounded-br-4xl" }}
             {{ end }}
             {{ end }}
             <li class="relative group splide__slide md:h-full rounded-2xl {{ $cornerClass }}">

--- a/layouts/partials/sections/bentogrids/two_row_bento_grid_on_dark.html
+++ b/layouts/partials/sections/bentogrids/two_row_bento_grid_on_dark.html
@@ -104,8 +104,8 @@
           {{/* Large cards (4 columns) - at positions 0, 3, 4, 7, 8, 11, etc. */}}
           <div class="flex p-px lg:col-span-4">
             <div class="overflow-hidden rounded-lg bg-gray-800 ring-1 ring-white/15 w-full
-              {{ if and $isFirst (eq $modulo 0) }}max-lg:rounded-t-[2rem] lg:rounded-tl-[2rem]{{ end }}
-              {{ if and $isLast (eq $modulo 3) }}max-lg:rounded-b-[2rem] lg:rounded-br-[2rem]{{ end }}
+              {{ if and $isFirst (eq $modulo 0) }}max-lg:rounded-t-4xl lg:rounded-tl-4xl{{ end }}
+              {{ if and $isLast (eq $modulo 3) }}max-lg:rounded-b-4xl lg:rounded-br-4xl{{ end }}
               {{ if and (not $isFirst) (not $isLast) (eq $modulo 0) }}lg:rounded-l-lg{{ end }}
               {{ if and (not $isFirst) (not $isLast) (eq $modulo 3) }}lg:rounded-r-lg{{ end }}">
               {{ partial "components/media/lazyimg.html" (dict 
@@ -125,8 +125,8 @@
           {{/* Small cards (2 columns) - at positions 1, 2, 5, 6, 9, 10, etc. */}}
           <div class="flex p-px lg:col-span-2">
             <div class="overflow-hidden rounded-lg bg-gray-800 ring-1 ring-white/15 w-full
-              {{ if and $isFirst (eq $modulo 1) }}max-lg:rounded-t-[2rem] lg:rounded-tr-[2rem]{{ end }}
-              {{ if and $isLast (eq $modulo 2) }}max-lg:rounded-b-[2rem] lg:rounded-bl-[2rem]{{ end }}
+              {{ if and $isFirst (eq $modulo 1) }}max-lg:rounded-t-4xl lg:rounded-tr-4xl{{ end }}
+              {{ if and $isLast (eq $modulo 2) }}max-lg:rounded-b-4xl lg:rounded-bl-4xl{{ end }}
               {{ if and (eq $modulo 1) (not $isFirst) }}lg:rounded-r-lg{{ end }}
               {{ if and (eq $modulo 2) (not $isLast) }}lg:rounded-l-lg{{ end }}">
               {{ partial "components/media/lazyimg.html" (dict 

--- a/layouts/partials/sections/categories/preview_three_column_with_description.html
+++ b/layouts/partials/sections/categories/preview_three_column_with_description.html
@@ -80,7 +80,7 @@
     <div class="mt-10 space-y-12 lg:grid lg:grid-cols-3 lg:gap-x-8 lg:space-y-0">
       {{ range $categories }}
       <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .url) }}" class="group block">
-        <div class="aspect-[3/2] overflow-hidden rounded-xl group-hover:opacity-75 lg:aspect-[5/2]">
+        <div class="aspect-3/2 overflow-hidden rounded-xl group-hover:opacity-75 lg:aspect-5/2">
           {{ partial "components/media/lazyimg.html" (dict 
             "src" .imageUrl 
             "alt" .imageAlt

--- a/layouts/partials/sections/categories/preview_three_column_with_description.html
+++ b/layouts/partials/sections/categories/preview_three_column_with_description.html
@@ -80,11 +80,12 @@
     <div class="mt-10 space-y-12 lg:grid lg:grid-cols-3 lg:gap-x-8 lg:space-y-0">
       {{ range $categories }}
       <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .url) }}" class="group block">
-        <div class="aspect-w-3 aspect-h-2 overflow-hidden rounded-xl group-hover:opacity-75 lg:aspect-w-5">
+        <div class="aspect-[3/2] overflow-hidden rounded-xl group-hover:opacity-75 lg:aspect-[5/2]">
           {{ partial "components/media/lazyimg.html" (dict 
             "src" .imageUrl 
             "alt" .imageAlt
             "class" "size-full object-cover object-center"
+            "figureClass" "size-full"
             "maxWidth" 600
           ) }}
         </div>

--- a/layouts/partials/sections/categories/product_list_card_with_full_details.html
+++ b/layouts/partials/sections/categories/product_list_card_with_full_details.html
@@ -89,7 +89,7 @@
     <div class="grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-10 lg:grid-cols-3 lg:gap-x-8">
       {{ range $products }}
       <div class="group relative flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white">
-        <div class="aspect-[4/5] sm:overflow-hidden sm:rounded-xl lg:aspect-[3/4]">
+        <div class="aspect-4/5 sm:overflow-hidden sm:rounded-xl lg:aspect-3/4">
           {{ partial "components/media/lazyimg.html" (dict 
             "src" .imageUrl 
             "alt" .imageAlt

--- a/layouts/partials/sections/categories/product_list_card_with_full_details.html
+++ b/layouts/partials/sections/categories/product_list_card_with_full_details.html
@@ -89,11 +89,12 @@
     <div class="grid grid-cols-1 gap-y-4 sm:grid-cols-2 sm:gap-x-6 sm:gap-y-10 lg:grid-cols-3 lg:gap-x-8">
       {{ range $products }}
       <div class="group relative flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white">
-        <div class="aspect-w-4 aspect-h-5 sm:overflow-hidden sm:rounded-xl lg:aspect-w-3 lg:aspect-h-4">
+        <div class="aspect-[4/5] sm:overflow-hidden sm:rounded-xl lg:aspect-[3/4]">
           {{ partial "components/media/lazyimg.html" (dict 
             "src" .imageUrl 
             "alt" .imageAlt
             "class" "size-full object-cover object-center"
+            "figureClass" "size-full"
             "maxWidth" 800
           ) }}
         </div>

--- a/layouts/partials/sections/categories/product_list_with_image_overlay_and_add_button.html
+++ b/layouts/partials/sections/categories/product_list_with_image_overlay_and_add_button.html
@@ -102,7 +102,7 @@
       {{ range $products }}
       <div>
         <div class="relative">
-          <div class="aspect-[4/3] overflow-hidden rounded-xl bg-gray-100">
+          <div class="aspect-4/3 overflow-hidden rounded-xl bg-gray-100">
             {{ partial "components/media/lazyimg.html" (dict 
               "src" .imageUrl 
               "alt" .imageAlt

--- a/layouts/partials/sections/categories/product_list_with_image_overlay_and_add_button.html
+++ b/layouts/partials/sections/categories/product_list_with_image_overlay_and_add_button.html
@@ -102,11 +102,12 @@
       {{ range $products }}
       <div>
         <div class="relative">
-          <div class="aspect-w-4 aspect-h-3 overflow-hidden rounded-xl bg-gray-100">
+          <div class="aspect-[4/3] overflow-hidden rounded-xl bg-gray-100">
             {{ partial "components/media/lazyimg.html" (dict 
               "src" .imageUrl 
               "alt" .imageAlt
               "class" "size-full object-cover object-center group-hover:opacity-75"
+              "figureClass" "size-full"
               "maxWidth" 400
             ) }}
           </div>

--- a/layouts/partials/sections/categories/product_list_with_inline_price_and_cta_link.html
+++ b/layouts/partials/sections/categories/product_list_with_inline_price_and_cta_link.html
@@ -94,11 +94,12 @@
       {{ range $products }}
       <div class="group relative">
         <div class="relative">
-          <div class="aspect-w-4 aspect-h-3 overflow-hidden rounded-xl bg-gray-100">
+          <div class="aspect-[4/3] overflow-hidden rounded-xl bg-gray-100">
             {{ partial "components/media/lazyimg.html" (dict 
               "src" .imageUrl
               "alt" .imageAlt
               "class" "h-full w-full object-cover object-center group-hover:opacity-75"
+              "figureClass" "size-full"
               "maxWidth" 400
             ) }}
           </div>

--- a/layouts/partials/sections/categories/product_list_with_inline_price_and_cta_link.html
+++ b/layouts/partials/sections/categories/product_list_with_inline_price_and_cta_link.html
@@ -94,7 +94,7 @@
       {{ range $products }}
       <div class="group relative">
         <div class="relative">
-          <div class="aspect-[4/3] overflow-hidden rounded-xl bg-gray-100">
+          <div class="aspect-4/3 overflow-hidden rounded-xl bg-gray-100">
             {{ partial "components/media/lazyimg.html" (dict 
               "src" .imageUrl
               "alt" .imageAlt
@@ -104,7 +104,7 @@
             ) }}
           </div>
           <div class="absolute inset-0 flex items-end p-4 opacity-0 group-hover:opacity-100" aria-hidden="true">
-            <div class="w-full rounded-md bg-white/75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur-sm backdrop-filter">{{ $ctaText }}</div>
+            <div class="w-full rounded-md bg-white/75 px-4 py-2 text-center text-sm font-medium text-gray-900 backdrop-blur-xs backdrop-filter">{{ $ctaText }}</div>
           </div>
         </div>
         <div class="mt-4 flex items-center justify-between space-x-8 text-base font-medium text-gray-900">

--- a/layouts/partials/sections/categories/product_list_with_tall_images.html
+++ b/layouts/partials/sections/categories/product_list_with_tall_images.html
@@ -74,11 +74,12 @@
     <div class="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-3 xl:gap-x-8">
       {{ range $products }}
       <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .url) }}" class="group">
-        <div class="aspect-w-1 aspect-h-1 w-full overflow-hidden rounded-xl bg-gray-200 xl:aspect-w-7 xl:aspect-h-8">
+        <div class="aspect-square w-full overflow-hidden rounded-xl bg-gray-200 xl:aspect-[7/8]">
           {{ partial "components/media/lazyimg.html" (dict 
             "src" .imageUrl
             "alt" .imageAlt
             "class" "h-full w-full object-cover object-center group-hover:opacity-75"
+            "figureClass" "size-full"
             "maxWidth" 400
           ) }}
         </div>

--- a/layouts/partials/sections/categories/product_list_with_tall_images.html
+++ b/layouts/partials/sections/categories/product_list_with_tall_images.html
@@ -74,7 +74,7 @@
     <div class="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-3 xl:gap-x-8">
       {{ range $products }}
       <a href="{{ partial "helpers/get-translated-url.html" (dict "url" .url) }}" class="group">
-        <div class="aspect-square w-full overflow-hidden rounded-xl bg-gray-200 xl:aspect-[7/8]">
+        <div class="aspect-square w-full overflow-hidden rounded-xl bg-gray-200 xl:aspect-7/8">
           {{ partial "components/media/lazyimg.html" (dict 
             "src" .imageUrl
             "alt" .imageAlt

--- a/layouts/partials/sections/contact/offices.html
+++ b/layouts/partials/sections/contact/offices.html
@@ -17,7 +17,7 @@
         <p class="font-medium">{{ .company }}</p>
         {{ end }}
         <div class="flex items-start">
-          <span class="mr-3 flex-shrink-0">
+          <span class="mr-3 shrink-0">
             {{ partial "components/media/icon.html" (dict "icon" "map" "class" "h-4 w-4 mt-1") }}
           </span>
           <div>

--- a/layouts/partials/sections/contact/split-with-pattern.html
+++ b/layouts/partials/sections/contact/split-with-pattern.html
@@ -19,7 +19,7 @@
     <div class="relative px-6 pt-24 pb-20 sm:pt-24 lg:static lg:px-8 lg:py-24">
       <div class="mx-auto max-w-xl lg:mx-0 lg:max-w-lg">
         <div class="absolute inset-y-0 left-0 -z-10 w-full overflow-hidden bg-gray-100 ring-1 ring-gray-900/10 lg:w-1/2">
-          <svg class="absolute inset-0 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+          <svg class="absolute inset-0 size-full stroke-gray-200 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
             <defs>
               <pattern id="83fd4e5a-9d52-42fc-97b6-718e5d7ee527" width="200" height="200" x="100%" y="-1" patternUnits="userSpaceOnUse">
                 <path d="M130 200V.5M.5 .5H200" fill="none" />

--- a/layouts/partials/sections/content/centered_on_dark.html
+++ b/layouts/partials/sections/content/centered_on_dark.html
@@ -133,7 +133,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -143,7 +143,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
 
   <div class="mx-auto max-w-3xl text-base/7 {{ $contentColor }}">

--- a/layouts/partials/sections/content/split_with_chatbot.html
+++ b/layouts/partials/sections/content/split_with_chatbot.html
@@ -44,7 +44,7 @@ Parameters:
   <div class="wrapper flex flex-col lg:flex-row lg:justify-between lg:items-stretch gap-x-8 lg:flex-row-reverse">
     {{/* Right side: Chatbot */}}
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0">
-      <div class="relative rounded-lg py-6 flex items-start justify-center w-full overflow-hidden mx-auto max-w-[38rem] max-h-[35rem]">
+      <div class="relative rounded-lg py-6 flex items-start justify-center w-full overflow-hidden mx-auto max-w-152 max-h-140">
         {{ if $chatbotId }}
         <div id="fh-chatbot-container-{{ $chatbotId }}" class="w-full h-full overflow-hidden">
         </div>

--- a/layouts/partials/sections/content/split_with_image.html
+++ b/layouts/partials/sections/content/split_with_image.html
@@ -114,7 +114,7 @@ Design Tokens:
   {{ end }}
   <div class="wrapper flex flex-col lg:flex-row lg:justify-between lg:items-stretch {{ if not $videoUrl }}gap-x-8{{ end }}{{ if eq $layout "image-right" }} lg:flex-row-reverse{{ end }}">
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 {{ if eq $layout "image-right" }}xl:left-0{{ else }}xl:right-0{{ end }}">
-      <div class="group/video relative rounded-lg {{ $mediaContainerPaddingY }} flex items-start justify-center w-full mx-auto max-w-[38rem] {{ if $videoUrl }}h-full overflow-hidden max-h-[35rem]{{ end }}">
+      <div class="group/video relative rounded-lg {{ $mediaContainerPaddingY }} flex items-start justify-center w-full mx-auto max-w-152 {{ if $videoUrl }}h-full overflow-hidden max-h-140{{ end }}">
         {{ if $videoUrl }}
           <div class="relative flex w-full h-full">
             {{/* Display video */}}
@@ -128,8 +128,8 @@ Design Tokens:
                   "pureVideo" $pureVideo
                   "useLightbox" true
                   "showPlayOverlay" true
-                  "playBtnClass" "white-circle-bounce size-[5.5rem] md:size-[7.75rem] rounded-full backdrop-blur-[3px]"
-                  "playBtnInnerClass" "bg-white relative size-[4.5rem] md:size-24 rounded-full hover:scale-105 transition-transform duration-300"
+                  "playBtnClass" "white-circle-bounce size-22 md:size-31 rounded-full backdrop-blur-[3px]"
+                  "playBtnInnerClass" "bg-white relative size-18 md:size-24 rounded-full hover:scale-105 transition-transform duration-300"
                   "svgClass" "size-10 md:size-14 ml-1 text-[#4F46E5] absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
               ) }}
               {{ if or $videoTitle $videoDescription }}
@@ -267,7 +267,7 @@ Design Tokens:
 
         {{/* Main content */}}
         {{ if $markdownContent }}
-          <div class="mt-10 max-w-full text-secondary prose-links lg:max-w-full [&_p]:mb-5 [&_h1]:mb-5 [&_h2]:mb-5 [&_h3]:mb-5 [&_h4]:mb-5 [&_h5]:mb-5 [&_h6]:mb-5 [&_ul]:mb-5 [&_ol]:mb-5 [&_*:last-child]:mb-0 [&_pre]:overflow-x-hidden [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&_pre]:font-sans [&_code]:whitespace-pre-wrap [&_code]:break-words [&_code]:font-sans">
+          <div class="mt-10 max-w-full text-secondary prose-links lg:max-w-full [&_p]:mb-5 [&_h1]:mb-5 [&_h2]:mb-5 [&_h3]:mb-5 [&_h4]:mb-5 [&_h5]:mb-5 [&_h6]:mb-5 [&_ul]:mb-5 [&_ol]:mb-5 [&_*:last-child]:mb-0 [&_pre]:overflow-x-hidden [&_pre]:whitespace-pre-wrap [&_pre]:wrap-break-word [&_pre]:font-sans [&_code]:whitespace-pre-wrap [&_code]:wrap-break-word [&_code]:font-sans">
             {{ if $contentAsHTML }}
                 {{ $markdownContent | safeHTML }}
             {{ else }}

--- a/layouts/partials/sections/content/split_with_image_cards.html
+++ b/layouts/partials/sections/content/split_with_image_cards.html
@@ -79,10 +79,10 @@ Example:
                         {{ end }}
                         
                         <div class="relative z-10 flex flex-col h-full bg-[#F9FAFB]">
-                            <div class="flex-grow bg-[#F9FAFB]"></div>
+                            <div class="grow bg-[#F9FAFB]"></div>
 
                             {{ if $cardVideoUrl }}
-                                <div class="flex-shrink-0">
+                                <div class="shrink-0">
                                     {{ if eq $cardVideoProvider "youtube" }}
                                         {{ partial "components/media/video.html" (dict
                                             "src" $cardVideoUrl
@@ -107,7 +107,7 @@ Example:
                                     {{ end }}
                                 </div>
                             {{ else if $cardSchemaImage }}
-                                <div class="flex-shrink-0">
+                                <div class="shrink-0">
                                     {{ partial "components/media/lazyimg.html" (dict
                                         "src" $cardSchemaImage
                                         "alt" $cardImageAlt
@@ -117,10 +117,10 @@ Example:
                                 </div>
                             {{ end }}
 
-                            <div class="flex-grow bg-[#F9FAFB]"></div>
+                            <div class="grow bg-[#F9FAFB]"></div>
 
-                            <div class="flex flex-col gap-8 mt-2 lg:items-start gap-x-7 py-6 px-8 bg-gray-100 text-black flex-shrink-0">
-                                <div class="content flex-grow">
+                            <div class="flex flex-col gap-8 mt-2 lg:items-start gap-x-7 py-6 px-8 bg-gray-100 text-black shrink-0">
+                                <div class="content grow">
                                     {{ with .title }}
                                         <h3 class="text-2xl mb-4 leading-tight">{{ . | safeHTML }}</h3>
                                     {{ end }}
@@ -130,7 +130,7 @@ Example:
                                 </div>
                                 
                                 {{ if and .cta .cta.text .cta.url }}
-                                    <div class="cta flex-shrink-0">
+                                    <div class="cta shrink-0">
                                             {{ partial "components/buttons/buttons.html" (dict
                                                 "text" .cta.text
                                                 "url" .cta.url

--- a/layouts/partials/sections/content/split_with_image_grid.html
+++ b/layouts/partials/sections/content/split_with_image_grid.html
@@ -57,7 +57,7 @@
             {{ if $image }}
             <div class="relative">
               {{/* Decorative background gradient */}}
-              <div class="absolute inset-0 bg-gradient-to-br from-primary/30 via-primary/10 to-transparent rounded-2xl blur-2xl"></div>
+              <div class="absolute inset-0 bg-linear-to-br from-primary/30 via-primary/10 to-transparent rounded-2xl blur-2xl"></div>
               {{/* Image with frame */}}
               <div class="relative bg-white p-2 rounded-xl shadow-2xl ring-1 ring-gray-900/10 dark:bg-gray-800 dark:ring-white/10">
                 {{ if $link }}

--- a/layouts/partials/sections/content/split_with_image_on_dark.html
+++ b/layouts/partials/sections/content/split_with_image_on_dark.html
@@ -46,7 +46,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -56,7 +56,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
   
   <div class="mx-auto max-w-7xl lg:flex lg:justify-between lg:px-8 xl:justify-end">

--- a/layouts/partials/sections/content/two_columns_with_screenshot.html
+++ b/layouts/partials/sections/content/two_columns_with_screenshot.html
@@ -47,7 +47,7 @@
       </div>
       {{ if $showButton }}
       <div class="mt-10 flex">
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $buttonUrl) }}" class="rounded-md {{ $buttonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $buttonTextColor }} shadow-xs {{ $buttonHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $buttonFocusColor }}">{{ $buttonText }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $buttonUrl) }}" class="rounded-md {{ $buttonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $buttonTextColor }} shadow-2xs {{ $buttonHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $buttonFocusColor }}">{{ $buttonText }}</a>
       </div>
       {{ end }}
     </div>

--- a/layouts/partials/sections/content/two_columns_with_screenshot_on_dark.html
+++ b/layouts/partials/sections/content/two_columns_with_screenshot_on_dark.html
@@ -28,7 +28,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -38,7 +38,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
@@ -58,7 +58,7 @@
       {{ end }}
       {{ if $buttonUrl }}
       <div class="mt-10 flex">
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $buttonUrl) }}" class="rounded-md {{ $buttonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $buttonTextColor }} shadow-xs {{ $buttonHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $buttonFocusColor }}">{{ $buttonText }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $buttonUrl) }}" class="rounded-md {{ $buttonBgColor }} px-3.5 py-2.5 text-sm font-semibold {{ $buttonTextColor }} shadow-2xs {{ $buttonHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 {{ $buttonFocusColor }}">{{ $buttonText }}</a>
       </div>
       {{ end }}
     </div>

--- a/layouts/partials/sections/content/two_columns_with_videos.html
+++ b/layouts/partials/sections/content/two_columns_with_videos.html
@@ -107,8 +107,8 @@
                         "provider" "youtube"
                         "useLightbox" true
                         "showPlayOverlay" true
-                        "playBtnClass" "white-circle-bounce size-[5.5rem] md:size-[7.75rem] rounded-full backdrop-blur-sm"
-                        "playBtnInnerClass" "bg-white relative size-[4.5rem] md:size-24 rounded-full hover:scale-105 transition-transform duration-300"
+                        "playBtnClass" "white-circle-bounce size-22 md:size-31 rounded-full backdrop-blur-xs"
+                        "playBtnInnerClass" "bg-white relative size-18 md:size-24 rounded-full hover:scale-105 transition-transform duration-300"
                         "svgClass" "size-10 md:size-12 ml-1 text-primary absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
                     ) }}
                   {{ else }}

--- a/layouts/partials/sections/content/visual-section.html
+++ b/layouts/partials/sections/content/visual-section.html
@@ -75,9 +75,9 @@ Parameters:
 {{ end }}
 
 <div class="visual-section section-bg-light {{ $padding }}">
-  <div class="wrapper flex flex-wrap gap-y-[0.625rem] items-center text-center">
+  <div class="wrapper flex flex-wrap gap-y-2.5 items-center text-center">
     <div class="flex-col w-full">
-        <div class="flex flex-col gap-y-[1.875rem] max-w-2xl mx-auto">
+        <div class="flex flex-col gap-y-7.5 max-w-2xl mx-auto">
             {{ if $heading }}
                 <h2 class="text-4xl sm:text-5xl font-semibold lg:text-7xl text-heading leading-none text-pretty">{{ $heading }}</h2>
             {{ end }}
@@ -102,8 +102,8 @@ Parameters:
                   "controlsList" $controlsList
                   "useLightbox" (not $pureVideo)
                   "showPlayOverlay" (not $pureVideo)
-                  "playBtnClass" "white-circle-bounce size-[5.5rem] md:size-[7.75rem] rounded-full backdrop-blur-[3px]"
-                  "playBtnInnerClass" "bg-white relative size-[4.5rem] md:size-24 rounded-full hover:scale-105 transition-transform duration-300"
+                  "playBtnClass" "white-circle-bounce size-22 md:size-31 rounded-full backdrop-blur-[3px]"
+                  "playBtnInnerClass" "bg-white relative size-18 md:size-24 rounded-full hover:scale-105 transition-transform duration-300"
                   "svgClass" "size-10 md:size-14 ml-1 text-[#4F46E5] absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
               ) }}
               {{ if or $videoTitle $videoDescription }}

--- a/layouts/partials/sections/content/with_image_tiles_on_dark.html
+++ b/layouts/partials/sections/content/with_image_tiles_on_dark.html
@@ -76,7 +76,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -89,7 +89,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
   
   <div class="mx-auto max-w-2xl px-6 lg:max-w-7xl lg:px-8">

--- a/layouts/partials/sections/content/with_sticky_product_screenshot.html
+++ b/layouts/partials/sections/content/with_sticky_product_screenshot.html
@@ -52,7 +52,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }} lg:overflow-visible lg:px-0">
   <div class="absolute inset-0 -z-10 overflow-hidden">
-    <svg class="absolute top-0 left-[max(50%,25rem)] h-[64rem] w-[128rem] -translate-x-1/2 {{ $patternColor }} [mask-image:radial-gradient(64rem_64rem_at_top,white,transparent)]" aria-hidden="true">
+    <svg class="absolute top-0 left-[max(50%,25rem)] h-256 w-[128rem] -translate-x-1/2 {{ $patternColor }} mask-[radial-gradient(64rem_64rem_at_top,white,transparent)]" aria-hidden="true">
       <defs>
         <pattern id="e813992c-7d03-4cc4-a2bd-151760b470a0" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
           <path d="M100 200V.5M.5 .5H200" fill="none" />
@@ -78,7 +78,7 @@
       {{ partial "components/media/lazyimg.html" (dict 
         "src" $screenshot 
         "alt" $screenshotAlt
-        "class" "w-[48rem] max-w-none rounded-xl bg-gray-900 ring-1 shadow-xl ring-gray-400/10 sm:w-[57rem]"
+        "class" "w-3xl max-w-none rounded-xl bg-gray-900 ring-1 shadow-xl ring-gray-400/10 sm:w-228"
       ) }}
     </div>
     <div class="lg:col-span-2 lg:col-start-1 lg:row-start-2 lg:mx-auto lg:grid lg:w-full lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">

--- a/layouts/partials/sections/content/with_sticky_product_screenshot_on_dark.html
+++ b/layouts/partials/sections/content/with_sticky_product_screenshot_on_dark.html
@@ -52,7 +52,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }} lg:overflow-visible lg:px-0">
   <div class="absolute inset-0 -z-10 overflow-hidden">
-    <svg class="absolute top-0 left-[max(50%,25rem)] h-[64rem] w-[128rem] -translate-x-1/2 {{ $patternColor }} [mask-image:radial-gradient(64rem_64rem_at_top,white,transparent)]" aria-hidden="true">
+    <svg class="absolute top-0 left-[max(50%,25rem)] h-256 w-[128rem] -translate-x-1/2 {{ $patternColor }} mask-[radial-gradient(64rem_64rem_at_top,white,transparent)]" aria-hidden="true">
       <defs>
         <pattern id="e813992c-7d03-4cc4-a2bd-151760b470a0" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
           <path d="M100 200V.5M.5 .5H200" fill="none" />
@@ -78,7 +78,7 @@
       {{ partial "components/media/lazyimg.html" (dict 
         "src" $screenshot 
         "alt" $screenshotAlt
-        "class" "w-[48rem] max-w-none rounded-xl bg-gray-800 ring-1 shadow-xl ring-gray-700/10 sm:w-[57rem]"
+        "class" "w-3xl max-w-none rounded-xl bg-gray-800 ring-1 shadow-xl ring-gray-700/10 sm:w-228"
       ) }}
     </div>
     <div class="lg:col-span-2 lg:col-start-1 lg:row-start-2 lg:mx-auto lg:grid lg:w-full lg:max-w-7xl lg:grid-cols-2 lg:gap-x-8 lg:px-8">

--- a/layouts/partials/sections/content/with_testimonial.html
+++ b/layouts/partials/sections/content/with_testimonial.html
@@ -62,7 +62,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <div class="absolute -top-80 left-[max(6rem,33%)] -z-10 transform-gpu blur-3xl sm:left-1/2 md:top-20 lg:ml-20 xl:top-3 xl:ml-56" aria-hidden="true">
-    <div class="aspect-801/1036 w-[50.0625rem] bg-linear-to-tr {{ $gradientFrom }} {{ $gradientTo }} {{ $gradientOpacity }}" style="clip-path: polygon(63.1% 29.6%, 100% 17.2%, 76.7% 3.1%, 48.4% 0.1%, 44.6% 4.8%, 54.5% 25.4%, 59.8% 49.1%, 55.3% 57.9%, 44.5% 57.3%, 27.8% 48%, 35.1% 81.6%, 0% 97.8%, 39.3% 100%, 35.3% 81.5%, 97.2% 52.8%, 63.1% 29.6%)"></div>
+    <div class="aspect-801/1036 w-200.25 bg-linear-to-tr {{ $gradientFrom }} {{ $gradientTo }} {{ $gradientOpacity }}" style="clip-path: polygon(63.1% 29.6%, 100% 17.2%, 76.7% 3.1%, 48.4% 0.1%, 44.6% 4.8%, 54.5% 25.4%, 59.8% 49.1%, 55.3% 57.9%, 44.5% 57.3%, 27.8% 48%, 35.1% 81.6%, 0% 97.8%, 39.3% 100%, 35.3% 81.5%, 97.2% 52.8%, 63.1% 29.6%)"></div>
   </div>
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto max-w-2xl lg:mx-0">
@@ -72,7 +72,7 @@
     </div>
     <div class="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 lg:mx-0 lg:mt-10 lg:max-w-none lg:grid-cols-12">
       <div class="relative lg:order-last lg:col-span-5">
-        <svg class="absolute -top-[40rem] left-1 -z-10 h-[64rem] w-[175.5rem] -translate-x-1/2 {{ $patternColor }} [mask-image:radial-gradient(64rem_64rem_at_111.5rem_0%,white,transparent)]" aria-hidden="true">
+        <svg class="absolute -top-160 left-1 -z-10 h-256 w-[175.5rem] -translate-x-1/2 {{ $patternColor }} mask-[radial-gradient(64rem_64rem_at_111.5rem_0%,white,transparent)]" aria-hidden="true">
           <defs>
             <pattern id="e87443c8-56e4-4c20-9111-55b82fa704e3" width="200" height="200" patternUnits="userSpaceOnUse">
               <path d="M0.5 0V200M200 0.5L0 0.499983" />

--- a/layouts/partials/sections/content/with_testimonial_and_stats.html
+++ b/layouts/partials/sections/content/with_testimonial_and_stats.html
@@ -69,7 +69,7 @@
           ) }}
           <div class="absolute inset-0 {{ $testimonialBgColor }} mix-blend-multiply"></div>
           <div class="absolute top-1/2 left-1/2 -ml-16 -translate-x-1/2 -translate-y-1/2 transform-gpu blur-3xl" aria-hidden="true">
-            <div class="aspect-1097/845 w-[68.5625rem] bg-linear-to-tr {{ $gradientFrom }} {{ $gradientTo }} {{ $gradientOpacity }}" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+            <div class="aspect-1097/845 w-274.25 bg-linear-to-tr {{ $gradientFrom }} {{ $gradientTo }} {{ $gradientOpacity }}" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
           </div>
           <figure class="relative isolate">
             <svg viewBox="0 0 162 128" fill="none" aria-hidden="true" class="absolute -top-4 -left-2 -z-10 h-32 stroke-white/20">

--- a/layouts/partials/sections/content/with_testimonial_and_stats_on_dark.html
+++ b/layouts/partials/sections/content/with_testimonial_and_stats_on_dark.html
@@ -59,7 +59,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -69,7 +69,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
@@ -83,7 +83,7 @@
           ) }}
           <div class="absolute inset-0 {{ $testimonialBgColor }} mix-blend-multiply"></div>
           <div class="absolute top-1/2 left-1/2 -ml-16 -translate-x-1/2 -translate-y-1/2 transform-gpu blur-3xl" aria-hidden="true">
-            <div class="aspect-1097/845 w-[68.5625rem] bg-linear-to-tr {{ $gradientFrom }} {{ $gradientTo }} {{ $gradientOpacity }}" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+            <div class="aspect-1097/845 w-274.25 bg-linear-to-tr {{ $gradientFrom }} {{ $gradientTo }} {{ $gradientOpacity }}" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
           </div>
           <figure class="relative isolate">
             <svg viewBox="0 0 162 128" fill="none" aria-hidden="true" class="absolute -top-4 -left-2 -z-10 h-32 stroke-white/20">

--- a/layouts/partials/sections/content/with_testimonial_on_dark.html
+++ b/layouts/partials/sections/content/with_testimonial_on_dark.html
@@ -62,7 +62,7 @@
 
 <div class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <div class="absolute -top-80 left-[max(6rem,33%)] -z-10 transform-gpu blur-3xl sm:left-1/2 md:top-20 lg:ml-20 xl:top-3 xl:ml-56" aria-hidden="true">
-    <div class="aspect-801/1036 w-[50.0625rem] bg-linear-to-tr {{ $gradientFrom }} {{ $gradientTo }} {{ $gradientOpacity }}" style="clip-path: polygon(63.1% 29.6%, 100% 17.2%, 76.7% 3.1%, 48.4% 0.1%, 44.6% 4.8%, 54.5% 25.4%, 59.8% 49.1%, 55.3% 57.9%, 44.5% 57.3%, 27.8% 48%, 35.1% 81.6%, 0% 97.8%, 39.3% 100%, 35.3% 81.5%, 97.2% 52.8%, 63.1% 29.6%)"></div>
+    <div class="aspect-801/1036 w-200.25 bg-linear-to-tr {{ $gradientFrom }} {{ $gradientTo }} {{ $gradientOpacity }}" style="clip-path: polygon(63.1% 29.6%, 100% 17.2%, 76.7% 3.1%, 48.4% 0.1%, 44.6% 4.8%, 54.5% 25.4%, 59.8% 49.1%, 55.3% 57.9%, 44.5% 57.3%, 27.8% 48%, 35.1% 81.6%, 0% 97.8%, 39.3% 100%, 35.3% 81.5%, 97.2% 52.8%, 63.1% 29.6%)"></div>
   </div>
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <div class="mx-auto max-w-2xl lg:mx-0">
@@ -72,7 +72,7 @@
     </div>
     <div class="mx-auto mt-16 grid max-w-2xl grid-cols-1 gap-x-8 gap-y-16 lg:mx-0 lg:mt-10 lg:max-w-none lg:grid-cols-12">
       <div class="relative lg:order-last lg:col-span-5">
-        <svg class="absolute -top-[40rem] left-1 -z-10 h-[64rem] w-[175.5rem] -translate-x-1/2 {{ $patternColor }} [mask-image:radial-gradient(64rem_64rem_at_111.5rem_0%,white,transparent)]" aria-hidden="true">
+        <svg class="absolute -top-160 left-1 -z-10 h-256 w-[175.5rem] -translate-x-1/2 {{ $patternColor }} mask-[radial-gradient(64rem_64rem_at_111.5rem_0%,white,transparent)]" aria-hidden="true">
           <defs>
             <pattern id="e87443c8-56e4-4c20-9111-55b82fa704e3" width="200" height="200" patternUnits="userSpaceOnUse">
               <path d="M0.5 0V200M200 0.5L0 0.499983" />

--- a/layouts/partials/sections/content/workflow-section.html
+++ b/layouts/partials/sections/content/workflow-section.html
@@ -33,7 +33,7 @@ Parameters:
 {{ end }}
 
 <div class="split-with-image-hero section-bg-light {{ $padding }}">
-  <div class="wrapper flex flex-wrap items-center text-center mx-auto gap-y-[4.5rem]">
+  <div class="wrapper flex flex-wrap items-center text-center mx-auto gap-y-18">
     <div class="flex-col w-full">
         <div class="max-w-2xl mx-auto">
             {{ if $heading }}

--- a/layouts/partials/sections/courses/courses-content.html
+++ b/layouts/partials/sections/courses/courses-content.html
@@ -300,7 +300,7 @@
                         <ul role="list" class="space-y-3 gap-y-1.5 not-prose">
                             {{ range $feature.items }}
                                 <li class="flex gap-x-3 mt-0 items-start">
-                                    {{ partial "icons/check-circle-solid" "mt-1 flex-shrink-0 w-5 h-5 product-icon" }}
+                                    {{ partial "icons/check-circle-solid" "mt-1 shrink-0 w-5 h-5 product-icon" }}
                                     <span class="text-base text-heading">{{ . }}</span>
                                 </li>
                             {{ end }}

--- a/layouts/partials/sections/courses/courses-video.html
+++ b/layouts/partials/sections/courses/courses-video.html
@@ -83,7 +83,7 @@
 {{ $bannerImage := .bannerImage | default "/images/landing-pages/ai-training-sertificate.png" }}
 {{ $bannerImageAlt := .bannerImageAlt | default "" }}
 {{ $bannerTextColor := .bannerTextColor | default "text-white" }}
-{{ $bannerBackgroundColor := .bannerBackgroundColor | default "bg-gradient-to-l from-[#1a1a1a] to-[#0f1f5c] bg-opacity-10" }}
+{{ $bannerBackgroundColor := .bannerBackgroundColor | default "bg-linear-to-l from-[#1a1a1a] to-[#0f1f5c] bg-opacity-10" }}
 
 <section class="{{ $sectionClass }} {{ $bgColor }} {{ $padding }} rounded-2xl mx-6 sm:mx-8">
     <!-- Icons Section - Technology Partners -->

--- a/layouts/partials/sections/cta/centered_on_dark_panel.html
+++ b/layouts/partials/sections/cta/centered_on_dark_panel.html
@@ -45,10 +45,10 @@
       <h2 class="text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">{{ $heading }}</h2>
       <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-gray-300">{{ $description }}</p>
       <div class="mt-10 flex items-center justify-center gap-x-6">
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-xs hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">{{ $primaryCta.text }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-2xs hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">{{ $primaryCta.text }}</a>
         <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $secondaryCta.url) }}" class="text-sm/6 font-semibold text-white">{{ $secondaryCta.text }} <span aria-hidden="true">→</span></a>
       </div>
-      <svg viewBox="0 0 1024 1024" class="absolute top-1/2 left-1/2 -z-10 size-[64rem] -translate-x-1/2 [mask-image:radial-gradient(closest-side,white,transparent)]" aria-hidden="true">
+      <svg viewBox="0 0 1024 1024" class="absolute top-1/2 left-1/2 -z-10 size-256 -translate-x-1/2 mask-[radial-gradient(closest-side,white,transparent)]" aria-hidden="true">
         <circle cx="512" cy="512" r="512" fill="url(#{{ $gradientId }})" fill-opacity="0.7" />
         <defs>
           <radialGradient id="{{ $gradientId }}">

--- a/layouts/partials/sections/cta/dark_panel_with_app_screenshot.html
+++ b/layouts/partials/sections/cta/dark_panel_with_app_screenshot.html
@@ -59,7 +59,7 @@
 <div class="bg-white">
   <div class="mx-auto max-w-7xl my-24 sm:px-6 sm:my-32 lg:px-8">
     <div class="relative isolate overflow-hidden bg-gray-900 px-6 pt-16 shadow-2xl sm:rounded-xl sm:px-16 md:pt-24 lg:flex lg:gap-x-20 lg:px-24 lg:pt-0">
-      <svg viewBox="0 0 1024 1024" class="absolute top-1/2 left-1/2 -z-10 size-[64rem] -translate-y-1/2 [mask-image:radial-gradient(closest-side,white,transparent)] sm:left-full sm:-ml-80 lg:left-1/2 lg:ml-0 lg:-translate-x-1/2 lg:translate-y-0" aria-hidden="true">
+      <svg viewBox="0 0 1024 1024" class="absolute top-1/2 left-1/2 -z-10 size-256 -translate-y-1/2 mask-[radial-gradient(closest-side,white,transparent)] sm:left-full sm:-ml-80 lg:left-1/2 lg:ml-0 lg:-translate-x-1/2 lg:translate-y-0" aria-hidden="true">
         <circle cx="512" cy="512" r="512" fill="url(#{{ $gradientId }})" fill-opacity="0.7" />
         <defs>
           <radialGradient id="{{ $gradientId }}">
@@ -72,7 +72,7 @@
         <h2 class="text-3xl font-semibold tracking-tight text-balance text-white sm:text-4xl">{{ $heading }}</h2>
         <p class="mt-6 text-lg/8 text-pretty text-gray-300">{{ $description }}</p>
         <div class="mt-10 flex items-center justify-center gap-x-6 lg:justify-start">
-          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-xs hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">{{ $primaryCta.text }}</a>
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-900 shadow-2xs hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">{{ $primaryCta.text }}</a>
           <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $secondaryCta.url) }}" class="text-sm/6 font-semibold text-white">{{ $secondaryCta.text }} <span aria-hidden="true">→</span></a>
         </div>
       </div>
@@ -82,7 +82,7 @@
           "alt" $screenshot.alt 
           "width" $screenshot.width 
           "height" $screenshot.height 
-          "class" "absolute top-0 left-0 w-[57rem] max-w-none rounded-md bg-white/5 ring-1 ring-white/10"
+          "class" "absolute top-0 left-0 w-228 max-w-none rounded-md bg-white/5 ring-1 ring-white/10"
           "maxWidth" 1024
         ) }}
       </div>

--- a/layouts/partials/sections/cta/simple_centered.html
+++ b/layouts/partials/sections/cta/simple_centered.html
@@ -65,7 +65,7 @@
         {{/* Primary CTA Button */}}
         {{ if $useLegacyColors }}
           {{/* Legacy mode: use custom color classes for backward compatibility */}}
-          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-2xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
         {{ else }}
           {{/* Modern mode: use buttons partial */}}
           {{ partial "components/buttons/buttons.html" (dict

--- a/layouts/partials/sections/cta/simple_centered_grid.html
+++ b/layouts/partials/sections/cta/simple_centered_grid.html
@@ -57,7 +57,7 @@
             </div>
           </div>
         </div>
-        <div class="absolute top-1/2 left-1/2 -z-10 size-[64rem] -translate-x-1/2 translate-y-0 rounded-full opacity-70 [mask-image:radial-gradient(closest-side,white,transparent)]" style="background: radial-gradient(circle, {{ $gradientStartColor }} 0%, {{ $gradientEndColor }} 100%)" aria-hidden="true"></div>
+        <div class="absolute top-1/2 left-1/2 -z-10 size-256 -translate-x-1/2 translate-y-0 rounded-full opacity-70 mask-[radial-gradient(closest-side,white,transparent)]" style="background: radial-gradient(circle, {{ $gradientStartColor }} 0%, {{ $gradientEndColor }} 100%)" aria-hidden="true"></div>
       </div>
     </div>
   </div>

--- a/layouts/partials/sections/cta/simple_centered_on_brand.html
+++ b/layouts/partials/sections/cta/simple_centered_on_brand.html
@@ -49,7 +49,7 @@
       <h2 class="text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl">{{ $heading }}</h2>
       <p class="mx-auto mt-6 max-w-xl text-lg/8 text-pretty text-{{ $brandLightColor }}">{{ $description }}</p>
       <div class="mt-10 flex items-center justify-center gap-x-6">
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-{{ $primaryCtaColor }} shadow-xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">{{ $primaryCta.text }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-white px-3.5 py-2.5 text-sm font-semibold text-{{ $primaryCtaColor }} shadow-2xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">{{ $primaryCta.text }}</a>
         <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $secondaryCta.url) }}" class="text-sm/6 font-semibold text-white">{{ $secondaryCta.text }} <span aria-hidden="true">→</span></a>
       </div>
     </div>

--- a/layouts/partials/sections/cta/simple_centered_on_dark.html
+++ b/layouts/partials/sections/cta/simple_centered_on_dark.html
@@ -62,6 +62,6 @@
       </div>
     </div>
   </div>
-  <div class="absolute top-1/2 left-1/2 -z-10 size-[64rem] -translate-x-1/2 translate-y-0 rounded-full opacity-70 [mask-image:radial-gradient(closest-side,white,transparent)]" style="background: radial-gradient(circle, {{ $gradientStartColor }} 0%, {{ $gradientEndColor }} 100%)" aria-hidden="true"></div>
+  <div class="absolute top-1/2 left-1/2 -z-10 size-256 -translate-x-1/2 translate-y-0 rounded-full opacity-70 mask-[radial-gradient(closest-side,white,transparent)]" style="background: radial-gradient(circle, {{ $gradientStartColor }} 0%, {{ $gradientEndColor }} 100%)" aria-hidden="true"></div>
 </div>
 </div>

--- a/layouts/partials/sections/cta/simple_justified.html
+++ b/layouts/partials/sections/cta/simple_justified.html
@@ -38,7 +38,7 @@
   <div class="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:flex lg:items-center lg:justify-between lg:px-8">
     <h2 class="max-w-2xl text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">{{ $heading | safeHTML }}</h2>
     <div class="mt-10 flex items-center gap-x-6 lg:mt-0 lg:shrink-0">
-      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
+      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-2xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
       <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $secondaryCta.url) }}" class="text-sm/6 font-semibold text-gray-900">{{ $secondaryCta.text }} <span aria-hidden="true">→</span></a>
     </div>
   </div>

--- a/layouts/partials/sections/cta/simple_justified_on_light_brand.html
+++ b/layouts/partials/sections/cta/simple_justified_on_light_brand.html
@@ -41,7 +41,7 @@
   <div class="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:flex lg:items-center lg:justify-between lg:px-8">
     <h2 class="max-w-2xl text-4xl font-semibold tracking-tight text-gray-900 sm:text-5xl">{{ $heading | safeHTML }}</h2>
     <div class="mt-10 flex items-center gap-x-6 lg:mt-0 lg:shrink-0">
-      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
+      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-2xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
       <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $secondaryCta.url) }}" class="text-sm/6 font-semibold text-gray-900">{{ $secondaryCta.text }} <span aria-hidden="true">→</span></a>
     </div>
   </div>

--- a/layouts/partials/sections/cta/simple_stacked.html
+++ b/layouts/partials/sections/cta/simple_stacked.html
@@ -39,7 +39,7 @@
   <div class="mx-auto max-w-7xl px-6 py-24 sm:py-32 lg:px-8">
     <h2 class="max-w-2xl text-4xl font-semibold tracking-tight text-balance text-gray-900 sm:text-5xl">{{ $heading }}</h2>
     <div class="mt-10 flex items-center gap-x-6">
-      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
+      <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-2xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $primaryCta.text }}</a>
       <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $secondaryCta.url) }}" class="text-sm/6 font-semibold text-gray-900">{{ $secondaryCta.text }} <span aria-hidden="true">→</span></a>
     </div>
   </div>

--- a/layouts/partials/sections/cta/two_columns_with_photo_on_dark.html
+++ b/layouts/partials/sections/cta/two_columns_with_photo_on_dark.html
@@ -84,7 +84,7 @@
       </div>
     </div>
     <div class="absolute inset-x-0 -top-16 -z-10 flex transform-gpu justify-center overflow-hidden blur-3xl" aria-hidden="true">
-      <div class="aspect-1318/752 w-[82.375rem] flex-none bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-25" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+      <div class="aspect-1318/752 w-329.5 flex-none bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-25" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
     </div>
   </div>
 </div>

--- a/layouts/partials/sections/cta/with_image_tiles.html
+++ b/layouts/partials/sections/cta/with_image_tiles.html
@@ -27,7 +27,7 @@
           (dict 
               "url" "/images/team/office-collaboration.jpg"
               "alt" "Team collaboration session"
-              "class" "aspect-7/5 w-[37rem] max-w-none rounded-2xl bg-gray-50 object-cover"
+              "class" "aspect-7/5 w-148 max-w-none rounded-2xl bg-gray-50 object-cover"
           )
           (dict 
               "url" "/images/team/team-meeting.jpg"
@@ -37,7 +37,7 @@
           (dict 
               "url" "/images/team/workspace.jpg"
               "alt" "Modern workspace"
-              "class" "aspect-7/5 w-[37rem] max-w-none flex-none rounded-2xl bg-gray-50 object-cover"
+              "class" "aspect-7/5 w-148 max-w-none flex-none rounded-2xl bg-gray-50 object-cover"
           )
           (dict 
               "url" "/images/team/team-building.jpg"
@@ -63,7 +63,7 @@
   (dict 
     "url" "https://images.unsplash.com/photo-1670272502246-768d249768ca?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1152&q=80"
     "alt" ""
-    "class" "aspect-7/5 w-[37rem] max-w-none rounded-2xl bg-gray-50 object-cover"
+    "class" "aspect-7/5 w-148 max-w-none rounded-2xl bg-gray-50 object-cover"
   )
   (dict 
     "url" "https://images.unsplash.com/photo-1605656816944-971cd5c1407f?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=768&h=604&q=80"
@@ -73,7 +73,7 @@
   (dict 
     "url" "https://images.unsplash.com/photo-1568992687947-868a62a9f521?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1152&h=842&q=80"
     "alt" ""
-    "class" "aspect-7/5 w-[37rem] max-w-none flex-none rounded-2xl bg-gray-50 object-cover"
+    "class" "aspect-7/5 w-148 max-w-none flex-none rounded-2xl bg-gray-50 object-cover"
   )
   (dict 
     "url" "https://images.unsplash.com/photo-1612872087720-bb876e2e67d1?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=768&h=604&q=80"
@@ -92,7 +92,7 @@
         <p class="mt-6 text-xl/8 text-gray-600">{{ $description1 }}</p>
         <p class="mt-6 text-base/7 text-gray-600">{{ $description2 }}</p>
         <div class="mt-10 flex">
-          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $cta.text }} <span aria-hidden="true">&rarr;</span></a>
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.url) }}" class="rounded-md bg-{{ $primaryCtaColor }} px-3.5 py-2.5 text-sm font-semibold text-white shadow-2xs hover:bg-{{ $primaryCtaHoverColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $primaryCtaColor }}">{{ $cta.text }} <span aria-hidden="true">&rarr;</span></a>
         </div>
       </div>
       <div class="flex flex-wrap items-start justify-end gap-6 sm:gap-8 lg:contents">
@@ -105,7 +105,7 @@
           ) }}
           <div class="absolute inset-0 rounded-xl ring-1 ring-inset ring-gray-900/10"></div>
         </div>
-        <div class="contents lg:col-span-2 lg:col-end-2 lg:ml-auto lg:flex lg:w-[37rem] lg:items-start lg:justify-end lg:gap-x-8">
+        <div class="contents lg:col-span-2 lg:col-end-2 lg:ml-auto lg:flex lg:w-148 lg:items-start lg:justify-end lg:gap-x-8">
           <div class="order-first flex w-64 flex-none justify-end self-end lg:w-auto">
             {{ partial "components/media/lazyimg.html" (dict 
               "src" (index $images 1 "url") 

--- a/layouts/partials/sections/faq/centered_accordion_grid.html
+++ b/layouts/partials/sections/faq/centered_accordion_grid.html
@@ -70,7 +70,7 @@
                         aria-expanded="true"
                         onclick="toggleFAQTwoCol(this, 'faq-two-col-{{ $index }}')">
                   <span class="text-base font-medium">{{ .question }}</span>
-                  <span class="ml-6 flex-shrink-0">
+                  <span class="ml-6 shrink-0">
                     <svg class="size-5 chevron-icon transition-transform duration-200 rotate-180" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                     </svg>

--- a/layouts/partials/sections/features/contained_in_panel.html
+++ b/layouts/partials/sections/features/contained_in_panel.html
@@ -41,7 +41,7 @@
           "alt" $screenshot.alt
           "width" $screenshot.width
           "height" $screenshot.height
-          "class" "relative -z-20 max-w-xl min-w-full rounded-xl ring-1 shadow-xl ring-white/10 lg:row-span-4 lg:w-[64rem] lg:max-w-none"
+          "class" "relative -z-20 max-w-xl min-w-full rounded-xl ring-1 shadow-xl ring-white/10 lg:row-span-4 lg:w-5xl lg:max-w-none"
         ) }}
         <div class="max-w-xl lg:row-start-3 lg:mt-10 lg:max-w-md lg:border-t lg:border-white/10 lg:pt-10">
           <dl class="max-w-xl space-y-8 text-base/7 text-gray-300 lg:max-w-none">
@@ -57,8 +57,8 @@
           </dl>
         </div>
       </div>
-      <div class="pointer-events-none absolute top-1/2 left-12 -z-10 -translate-y-1/2 transform-gpu blur-3xl lg:top-auto lg:bottom-[-12rem] lg:translate-y-0 lg:transform-gpu" aria-hidden="true">
-        <div class="aspect-1155/678 w-[72.1875rem] bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-25" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+      <div class="pointer-events-none absolute top-1/2 left-12 -z-10 -translate-y-1/2 transform-gpu blur-3xl lg:top-auto lg:-bottom-48 lg:translate-y-0 lg:transform-gpu" aria-hidden="true">
+        <div class="aspect-1155/678 w-288.75 bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-25" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
       </div>
     </div>
   </div>

--- a/layouts/partials/sections/features/grid_with_cards.html
+++ b/layouts/partials/sections/features/grid_with_cards.html
@@ -90,7 +90,7 @@
             {{/* Number Badge */}}
             {{ with $card.number }}
             <div class="mb-4">
-              <span class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-primary text-white text-sm font-semibold shadow-sm">
+              <span class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-primary text-white text-sm font-semibold shadow-xs">
                 {{ . }}
               </span>
             </div>

--- a/layouts/partials/sections/features/simple_three_column_with_large_icons.html
+++ b/layouts/partials/sections/features/simple_three_column_with_large_icons.html
@@ -66,7 +66,7 @@
 {{ $darkClass := cond $isDark "dark" "" }}
 {{ $gridGap := .gridGap | default "gap-x-16 gap-y-12 lg:gap-y-24" }}
 
-{{ $iconClass := "w-7 h-7 p-1 rounded-lg flex-shrink-0 product-icon" }}
+{{ $iconClass := "w-7 h-7 p-1 rounded-lg shrink-0 product-icon" }}
 {{ $iconWrapperClass := "size-10 p-2 surface-brand rounded-lg flex items-center justify-center" }}
 
 <div class="{{ $theme }}">
@@ -90,7 +90,7 @@
           {{ range $features }}
           <div class="relative pl-0">
             {{ if .icon }}
-              <div class="{{ $iconWrapperClass }} mb-6 flex-shrink-0">
+              <div class="{{ $iconWrapperClass }} mb-6 shrink-0">
                 {{ partial "components/media/icon.html" (dict "icon" .icon "class" (printf "%s icon-on-brand" $iconClass)) }}
               </div>
             {{ end }}

--- a/layouts/partials/sections/features/three_column_grid.html
+++ b/layouts/partials/sections/features/three_column_grid.html
@@ -18,7 +18,7 @@
 {{ $isDark := eq $theme "dark" }}
 {{ $darkClass := cond $isDark "dark" "" }}
 
-{{ $iconClass := "w-7 h-7 p-1 rounded-lg flex-shrink-0 product-icon" }}
+{{ $iconClass := "w-7 h-7 p-1 rounded-lg shrink-0 product-icon" }}
 {{ $iconWrapperClass := "size-10 p-2 surface-brand rounded-lg flex items-center justify-center" }}
 
 <div class="{{ $darkClass }}">
@@ -87,7 +87,7 @@
           {{ range $index, $feature := $features }}
           <div class="relative px-6 lg:px-8 py-8 {{ if lt $index (sub $featuresLen 1) }}lg:border-r border-gray-200 dark:border-gray-700{{ end }} {{ if ge $index 3 }}border-t border-gray-200 dark:border-gray-700{{ end }}">
             {{ if .icon }}
-              <div class="{{ $iconWrapperClass }} mb-6 flex-shrink-0">
+              <div class="{{ $iconWrapperClass }} mb-6 shrink-0">
                 {{ partial "components/media/icon.html" (dict "icon" .icon "class" (printf "%s icon-on-brand" $iconClass)) }}
               </div>
             {{ end }}

--- a/layouts/partials/sections/features/vertical_with_image_grid.html
+++ b/layouts/partials/sections/features/vertical_with_image_grid.html
@@ -13,8 +13,8 @@
 {{ $theme := .theme | default "light" }}
 {{ $isDark := eq $theme "dark" }}
 
-{{ $iconClass := "w-5 h-5 flex-shrink-0" }}
-{{ $iconWrapperClass := "size-10 p-2 surface-brand rounded-lg flex items-center justify-center flex-shrink-0" }}
+{{ $iconClass := "w-5 h-5 shrink-0" }}
+{{ $iconWrapperClass := "size-10 p-2 surface-brand rounded-lg flex items-center justify-center shrink-0" }}
 
 <section class="bg-white dark:bg-gray-900 relative overflow-hidden">
 

--- a/layouts/partials/sections/features/with_alternating_sections.html
+++ b/layouts/partials/sections/features/with_alternating_sections.html
@@ -112,7 +112,7 @@
                 <ul class="mt-4 pl-0 space-y-2">
                   {{ range $feature.listItems }}
                     <li class="flex items-start pl-0">
-                      <svg class="h-4 w-4 text-primary mt-0.5 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                      <svg class="h-4 w-4 text-primary mt-0.5 mr-2 shrink-0" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
                       </svg>
                       <span class="{{ $textClasses }} text-gray-600">{{ . }}</span>
@@ -152,7 +152,7 @@
             <div class="flex-auto {{ $imageColClasses }} {{ if eq $layoutSize "balanced" }}lg:col-start-7{{ else if eq $layoutSize "wide-text" }}lg:col-start-8 xl:col-start-9{{ else }}lg:col-start-6 xl:col-start-5{{ end }} lg:row-start-1">
               <!-- Image with frame, shadow and decorative gradient -->
               <div class="relative">
-                <div class="absolute -inset-x-4 -bottom-4 top-8 bg-gradient-to-r from-primary/20 via-primary/10 to-transparent rounded-2xl blur-xl"></div>
+                <div class="absolute -inset-x-4 -bottom-4 top-8 bg-linear-to-r from-primary/20 via-primary/10 to-transparent rounded-2xl blur-xl"></div>
                 <div class="relative bg-white p-2 rounded-xl shadow-2xl ring-1 ring-gray-900/10">
                   {{ partial "components/media/lazyimg.html" (dict
                     "src" $feature.imageUrl
@@ -170,7 +170,7 @@
                 <ul class="mt-4 pl-0 space-y-2">
                   {{ range $feature.listItems }}
                     <li class="flex items-start pl-0">
-                      {{ partial "icons/check" "w-4 h-4 text-primary mt-0.5 mr-2 flex-shrink-0" }}
+                      {{ partial "icons/check" "w-4 h-4 text-primary mt-0.5 mr-2 shrink-0" }}
                       <span class="{{ $textClasses }} text-gray-600">{{ . }}</span>
                     </li>
                   {{ end }}
@@ -208,7 +208,7 @@
             <div class="flex-auto {{ $imageColClasses }} {{ $imageColStartClasses }} lg:row-start-1">
               <!-- Image with frame, shadow and decorative gradient -->
               <div class="relative">
-                <div class="absolute -inset-x-4 -bottom-4 top-8 bg-gradient-to-l from-primary/20 via-primary/10 to-transparent rounded-2xl blur-xl"></div>
+                <div class="absolute -inset-x-4 -bottom-4 top-8 bg-linear-to-l from-primary/20 via-primary/10 to-transparent rounded-2xl blur-xl"></div>
                 <div class="relative bg-white p-2 rounded-xl shadow-2xl ring-1 ring-gray-900/10">
                   {{ partial "components/media/lazyimg.html" (dict
                     "src" $feature.imageUrl

--- a/layouts/partials/sections/features/with_fading_image.html
+++ b/layouts/partials/sections/features/with_fading_image.html
@@ -54,7 +54,7 @@
       "alt" $imageAlt
       "class" "h-96 w-full object-cover rounded-lg"
     ) }}
-    <div class="absolute inset-0 bg-gradient-to-t from-white"></div>
+    <div class="absolute inset-0 bg-linear-to-t from-white"></div>
   </div>
 
   <div class="relative mx-auto -mt-12 max-w-7xl px-4 pb-16 sm:px-6 sm:pb-24 lg:px-8">

--- a/layouts/partials/sections/features/with_intro_and_tabs.html
+++ b/layouts/partials/sections/features/with_intro_and_tabs.html
@@ -92,7 +92,7 @@
     {{ $content | safeHTML }}
   {{ else if eq $type "code" }}
     <div class="bg-gray-900 text-white p-5 rounded-lg not-prose">
-      <code class="p-0 m-0 whitespace-pre-wrap break-words">{{ $content }}</code>
+      <code class="p-0 m-0 whitespace-pre-wrap wrap-break-word">{{ $content }}</code>
     </div>
   {{ else if eq $type "button" }}
     <div class="mt-6 not-prose">
@@ -106,7 +106,7 @@
     <ul class="pl-0 space-y-4 {{ if eq $listType "checks" }}my-10{{ else }}mt-10{{ end }}">
       {{ range $index, $item := $items }}
         <li class="flex pl-0">
-          <span class="flex-shrink-0 flex mt-2 mr-3 {{ if eq $listType "numbers" }}items-center justify-center rounded-full bg-primary icon-on-brand text-[10px] h-5 w-5{{ else if eq $listType "checks" }}product-icon{{ else }}justify-center product-icon{{ end }}">
+          <span class="shrink-0 flex mt-2 mr-3 {{ if eq $listType "numbers" }}items-center justify-center rounded-full bg-primary icon-on-brand text-[10px] h-5 w-5{{ else if eq $listType "checks" }}product-icon{{ else }}justify-center product-icon{{ end }}">
             {{ if eq $listType "checks" }}
               {{ partial "icons/check-circle-solid" "w-5 h-5 product-icon" }}
             {{ else if eq $listType "numbers" }}
@@ -180,7 +180,7 @@
         </div>
 
         <div class="w-full mx-auto">
-          <div class="flex overflow-x-auto w-full md:-mx-[2rem]">
+          <div class="flex overflow-x-auto w-full md:-mx-8">
             <div class="flex-auto border-b border-gray-primary w-full">
               <div class="flex md:px-8 w-full" aria-orientation="horizontal" role="tablist">
                 {{ range $index, $tab := $tabs }}

--- a/layouts/partials/sections/features/with_large_bordered_screenshot.html
+++ b/layouts/partials/sections/features/with_large_bordered_screenshot.html
@@ -8,8 +8,8 @@
 <div class="overflow-hidden bg-white py-24 sm:py-32">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <p class="max-w-2xl text-5xl font-semibold tracking-tight text-pretty text-gray-900 sm:text-6xl sm:text-balance">{{ $heading }}</p>
-    <div class="relative mt-16 aspect-2432/1442 h-[36rem] sm:h-auto sm:w-[calc(var(--container-7xl)-calc(var(--spacing)*16))]">
-      <div class="absolute -inset-2 rounded-xl-[calc(var(--radius-xl)+calc(var(--spacing)*2))] ring-1 shadow-xs ring-black/5"></div>
+    <div class="relative mt-16 aspect-2432/1442 h-144 sm:h-auto sm:w-[calc(var(--container-7xl)-(--spacing(16)))]">
+      <div class="absolute -inset-2 rounded-xl-[calc(var(--radius-xl)+calc(var(--spacing)*2))] ring-1 shadow-2xs ring-black/5"></div>
       {{ partial "components/media/lazyimg.html" (dict 
         "src" $screenshot.url 
         "alt" $screenshot.alt

--- a/layouts/partials/sections/features/with_large_bordered_screenshot_dark.html
+++ b/layouts/partials/sections/features/with_large_bordered_screenshot_dark.html
@@ -8,8 +8,8 @@
 <div class="overflow-hidden bg-gray-900 py-24 sm:py-32">
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     <p class="max-w-2xl text-5xl font-semibold tracking-tight text-pretty text-white sm:text-6xl sm:text-balance">{{ $heading }}</p>
-    <div class="relative mt-16 aspect-2432/1442 h-[36rem] sm:h-auto sm:w-[calc(var(--container-7xl)-calc(var(--spacing)*16))]">
-      <div class="absolute -inset-2 rounded-xl-[calc(var(--radius-xl)+calc(var(--spacing)*2))] bg-white/[2.5%] ring-1 shadow-[inset_0_0_2px_1px_rgb(255_255_255/2.5%)] ring-white/10"></div>
+    <div class="relative mt-16 aspect-2432/1442 h-144 sm:h-auto sm:w-[calc(var(--container-7xl)-(--spacing(16)))]">
+      <div class="absolute -inset-2 rounded-xl-[calc(var(--radius-xl)+calc(var(--spacing)*2))] bg-white/2.5 ring-1 shadow-[inset_0_0_2px_1px_rgb(255_255_255/2.5%)] ring-white/10"></div>
       {{ partial "components/media/lazyimg.html" (dict 
         "src" $screenshot.url 
         "alt" $screenshot.alt

--- a/layouts/partials/sections/features/with_product_screenshot.html
+++ b/layouts/partials/sections/features/with_product_screenshot.html
@@ -58,7 +58,7 @@
         {{ partial "components/media/lazyimg.html" (dict 
           "src" $screenshot.url 
           "alt" $screenshot.alt 
-          "class" "w-[48rem] max-w-none rounded-2xl ring-1 ring-gray-400/10 sm:w-[57rem] md:-ml-4 lg:-ml-0"
+          "class" "w-3xl max-w-none rounded-2xl ring-1 ring-gray-400/10 sm:w-228 md:-ml-4 lg:ml-0"
           "width" $screenshot.width
           "height" $screenshot.height
         ) }}

--- a/layouts/partials/sections/features/with_product_screenshot_dark.html
+++ b/layouts/partials/sections/features/with_product_screenshot_dark.html
@@ -49,7 +49,7 @@
           "alt" $screenshot.alt
           "width" $screenshot.width
           "height" $screenshot.height
-          "class" "w-[48rem] max-w-none rounded-xl ring-1 shadow-xl ring-white/10 sm:w-[57rem] md:-ml-4 lg:-ml-0"
+          "class" "w-3xl max-w-none rounded-xl ring-1 shadow-xl ring-white/10 sm:w-228 md:-ml-4 lg:ml-0"
         ) }}
       </div>
     </div>

--- a/layouts/partials/sections/features/with_product_screenshot_panel.html
+++ b/layouts/partials/sections/features/with_product_screenshot_panel.html
@@ -65,7 +65,7 @@
               "alt" $screenshot.alt
               "width" $screenshot.width
               "height" $screenshot.height
-              "class" "-mb-12 w-[57rem] max-w-none rounded-tl-xl bg-gray-800 ring-1 ring-white/10"
+              "class" "-mb-12 w-228 max-w-none rounded-tl-xl bg-gray-800 ring-1 ring-white/10"
             ) }}
           </div>
           <div class="pointer-events-none absolute inset-0 ring-1 ring-black/10 ring-inset sm:rounded-xl" aria-hidden="true"></div>

--- a/layouts/partials/sections/features/with_split_image.html
+++ b/layouts/partials/sections/features/with_split_image.html
@@ -41,7 +41,7 @@
             <p class="{{ if $subheading }}mt-4 {{ end }}text-5xl sm:text-7xl font-semibold tracking-tight text-heading">{{ $heading }}</p>
             <p class="mt-9 text-tertiary prose-links prose-a:text-tertiary">{{ $description | safeHTML }}</p>
           </div>
-          <div class="mt-[4.5rem] rounded-xl">
+          <div class="mt-18 rounded-xl">
             {{ partial "components/media/lazyimg.html" (dict 
               "src" $imageUrl
               "alt" $imageAlt

--- a/layouts/partials/sections/features/with_testimonial.html
+++ b/layouts/partials/sections/features/with_testimonial.html
@@ -35,7 +35,7 @@
             {{ $description | safeHTML }}
           </p>
           <div class="mt-8">
-            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.url) }}" class="inline-flex rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $cta.text }}</a>
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.url) }}" class="inline-flex rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-2xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $cta.text }}</a>
           </div>
           <figure class="mt-16 border-l border-gray-200 pl-8 text-gray-600">
             <blockquote class="text-base/7">
@@ -57,7 +57,7 @@
         "alt" $screenshot.alt
         "width" $screenshot.width
         "height" $screenshot.height
-        "class" "w-[48rem] max-w-none rounded-xl ring-1 shadow-xl ring-gray-400/10 sm:w-[57rem] md:-ml-4 lg:ml-0"
+        "class" "w-3xl max-w-none rounded-xl ring-1 shadow-xl ring-gray-400/10 sm:w-228 md:-ml-4 lg:ml-0"
       ) }}
     </div>
   </div>

--- a/layouts/partials/sections/hero/grid_with_assets.html
+++ b/layouts/partials/sections/hero/grid_with_assets.html
@@ -82,7 +82,7 @@
 {{ $badgeColorClass := index $badgeColors $headingBadgeColor | default (index $badgeColors "primary") }}
 
 <div class="{{ $darkClass }}">
-  <div class="section-bg-light dark:section-bg-dark relative z-[1]">
+  <div class="section-bg-light dark:section-bg-dark relative z-1">
     <div class="relative isolate overflow-hidden">
 
       {{/* Full-height vertical lines at wrapper edges */}}
@@ -120,11 +120,11 @@
             <rect width="100%" height="100%" stroke-width="0" fill="url(#hero-grid-pattern)" />
           </svg>
           {{/* Bottom gradient fade - center */}}
-          <div class="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white dark:from-gray-900 to-transparent"></div>
+          <div class="absolute bottom-0 left-0 right-0 h-24 bg-linear-to-t from-white dark:from-gray-900 to-transparent"></div>
           {{/* Bottom left corner gradient */}}
-          <div class="absolute bottom-0 left-0 w-1/3 h-32 bg-gradient-to-tr from-white dark:from-gray-900 to-transparent"></div>
+          <div class="absolute bottom-0 left-0 w-1/3 h-32 bg-linear-to-tr from-white dark:from-gray-900 to-transparent"></div>
           {{/* Bottom right corner gradient */}}
-          <div class="absolute bottom-0 right-0 w-1/3 h-32 bg-gradient-to-tl from-white dark:from-gray-900 to-transparent"></div>
+          <div class="absolute bottom-0 right-0 w-1/3 h-32 bg-linear-to-tl from-white dark:from-gray-900 to-transparent"></div>
         </div>
 
         {{/* Content area with top/bottom padding */}}
@@ -148,7 +148,7 @@
               {{ $placeholder := printf "[%s]" $headingBadge }}
               {{ if $headingBadgeIcon }}
                 {{/* Icon badge - rounded box with icon */}}
-                {{ $badgeHTML := printf `<span class="inline-flex items-center justify-center rounded-xl %s p-2 align-middle mx-2 shadow-sm ring-1 ring-inset ring-gray-900/10"><svg class="h-6 w-6 sm:h-8 sm:w-8" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" /></svg></span>` $badgeColorClass }}
+                {{ $badgeHTML := printf `<span class="inline-flex items-center justify-center rounded-xl %s p-2 align-middle mx-2 shadow-xs ring-1 ring-inset ring-gray-900/10"><svg class="h-6 w-6 sm:h-8 sm:w-8" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" /></svg></span>` $badgeColorClass }}
                 {{ $processedHeading = replace $processedHeading $placeholder $badgeHTML }}
               {{ else }}
                 {{/* Text badge - pill style */}}
@@ -259,10 +259,10 @@
                      data-video-use-lightbox="true"
                      data-video-fallback-url="https://www.youtube.com/watch?v={{ $videoID }}">
                   {{/* Video preview card - no thumbnail, just play icon and text */}}
-                  <div class="lazy-video-thumbnail bg-gray-900 backdrop-blur rounded-lg shadow-xl cursor-pointer hover:scale-105 transition-transform p-3" data-video-trigger="true">
+                  <div class="lazy-video-thumbnail bg-gray-900 backdrop-blur-sm rounded-lg shadow-xl cursor-pointer hover:scale-105 transition-transform p-3" data-video-trigger="true">
                     <div class="flex gap-3 items-center">
                       {{/* Play icon in frame */}}
-                      <div class="flex-shrink-0 w-12 h-12 rounded-lg bg-primary-600 flex items-center justify-center">
+                      <div class="shrink-0 w-12 h-12 rounded-lg bg-primary-600 flex items-center justify-center">
                         <svg class="w-6 h-6 text-white ml-0.5" fill="currentColor" viewBox="0 0 24 24">
                           <path d="M8 5v14l11-7z"/>
                         </svg>

--- a/layouts/partials/sections/hero/profile_hero.html
+++ b/layouts/partials/sections/hero/profile_hero.html
@@ -46,9 +46,9 @@
 <section class="wrapper my-16 lg:my-24">
   <div class="flex flex-col md:flex-row py-2.5">
       <!-- Left Column - Content -->
-      <div class="mx-auto py-8 pr-8 w-full md:w-1/2 flex items-center flex-shrink-0 order-2 md:order-1">
+      <div class="mx-auto py-8 pr-8 w-full md:w-1/2 flex items-center shrink-0 order-2 md:order-1">
         <div>
-          <h1 class="mb-[1.875rem] text-5xl sm:text-6xl lg:text-7xl font-semibold tracking-tight text-heading">
+          <h1 class="mb-7.5 text-5xl sm:text-6xl lg:text-7xl font-semibold tracking-tight text-heading">
             {{ $heading }}
           </h1>
           {{ if $description }}
@@ -94,7 +94,7 @@
       <!-- Right Column - Image -->
       <div class="mx-auto w-full md:w-1/2 order-1 md:order-2">
         <div class="relative max-w-3xl flex-none sm:max-w-5xl lg:max-w-none">
-          <div class="{{ $avatarContainerSize }} p-3 flex items-center justify-center absolute top-20 rounded-full bg-white/80 backdrop-blur-sm border ">
+          <div class="{{ $avatarContainerSize }} p-3 flex items-center justify-center absolute top-20 rounded-full bg-white/80 backdrop-blur-xs border ">
             <div class="[&>picture]:object-fit rounded-full {{ $avatarSize }} overflow-hidden">
               {{ partial "components/media/lazyimg.html" (dict
                   "src" $imageSrc

--- a/layouts/partials/sections/hero/simple_centered.html
+++ b/layouts/partials/sections/hero/simple_centered.html
@@ -101,7 +101,7 @@
 {{ $search := merge (dict "searchFields" (slice "title" "content" "tags" "categories")) $search }}
 
 <div class="{{ $darkClass }}">
-  <div class="section-bg-light dark:section-bg-dark relative z-[1]">
+  <div class="section-bg-light dark:section-bg-dark relative z-1">
     <div class="relative isolate">
         <div class="wrapper {{ $padding }}">
           <div class="mx-auto max-w-2xl text-center">
@@ -174,11 +174,11 @@
           </div>
 
           {{ if $image.src }}
-            <div class="max-md:hidden mt-16 flow-root sm:mt-[4.5rem]">
+            <div class="max-md:hidden mt-16 flow-root sm:mt-18">
               <div class="relative mx-auto max-w-[1145px]">
                 <!-- Decorative background gradient -->
-                <div class="absolute -inset-4 bg-gradient-to-r from-primary/20 via-primary/10 to-primary/20 rounded-2xl blur-xl"></div>
-                <div class="absolute -inset-1 bg-gradient-to-br from-primary/30 via-transparent to-primary/30 rounded-xl"></div>
+                <div class="absolute -inset-4 bg-linear-to-r from-primary/20 via-primary/10 to-primary/20 rounded-2xl blur-xl"></div>
+                <div class="absolute -inset-1 bg-linear-to-br from-primary/30 via-transparent to-primary/30 rounded-xl"></div>
                 <!-- Image with frame -->
                 <div class="relative bg-white p-2 rounded-xl shadow-2xl ring-1 ring-gray-900/10 {{ $imgBgClass }}">
                   {{ $isYouTube := or (findRE `youtube\.com` $image.src) (findRE `youtu\.be` $image.src) }}

--- a/layouts/partials/sections/hero/split_right_media.html
+++ b/layouts/partials/sections/hero/split_right_media.html
@@ -15,11 +15,11 @@
     - mode: "svg" | "image" - type of overlay content
     - icon: Icon/image source for overlay
     - color: Color class for SVG icons (e.g., "text-green-600")
-    - position: Position classes (default: "top-[5.69rem] left-[1.25rem]")
+    - position: Position classes (default: "top-[5.69rem] left-5")
     - positionRight: Boolean - if true, positions overlay on right side
     - size: Size classes for overlay container (default: "w-[7.88rem] h-[7.88rem]")
-    - iconSizeImage: Size classes for image icons (default: "w-[6.25rem] h-[6.25rem]")
-    - iconSizeSvg: Size classes for SVG icons (default: "w-[4.25rem] h-[4.25rem]")
+    - iconSizeImage: Size classes for image icons (default: "w-25 h-25")
+    - iconSizeSvg: Size classes for SVG icons (default: "w-17 h-17")
     - shadowClass: CSS class for shadow (default: "hero-overlay-shadow")
 @example:
   {{ partial "sections/hero/split_right_media.html" (dict
@@ -46,17 +46,17 @@
 {{ $overlayIcon := $overlay.icon | default "" }}
 {{ $overlayColor := $overlay.color | default "" }}
 {{ $overlayPositionRight := $overlay.positionRight | default false }}
-{{ $overlayPosition := $overlay.position | default "top-[5.69rem] left-[1.25rem]" }}
+{{ $overlayPosition := $overlay.position | default "top-[5.69rem] left-5" }}
 {{ $overlaySize := $overlay.size | default "w-[7.88rem] h-[7.88rem]" }}
-{{ $overlayIconSizeImage := $overlay.iconSizeImage | default "w-[6.25rem] h-[6.25rem]" }}
-{{ $overlayIconSizeSvg := $overlay.iconSizeSvg | default "w-[4.25rem] h-[4.25rem]" }}
+{{ $overlayIconSizeImage := $overlay.iconSizeImage | default "w-25 h-25" }}
+{{ $overlayIconSizeSvg := $overlay.iconSizeSvg | default "w-17 h-17" }}
 {{ $overlayShadowClass := $overlay.shadowClass | default "hero-overlay-shadow" }}
 {{ $overflowClass := "overflow-hidden" }}
 
 {{/* Override position for right-side overlay */}}
 {{ if $overlayPositionRight }}
   {{ $overlayPosition = "top-12 right-3 xl:-right-10" }}
-  {{ $overlaySize = $overlay.size | default "w-auto h-[8.75rem]" }}
+  {{ $overlaySize = $overlay.size | default "w-auto h-35" }}
   {{ $overflowClass = "overflow-hidden xl:overflow-visible" }}
 {{ end }}
 
@@ -74,7 +74,7 @@
 {{ end }}
 
 <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 xl:left-0">
-  <div class="relative rounded-lg py-6 flex items-start justify-center w-full {{ $overflowClass }} mx-auto max-w-[38rem] max-h-[35rem]">
+  <div class="relative rounded-lg py-6 flex items-start justify-center w-full {{ $overflowClass }} mx-auto max-w-152 max-h-140">
     {{ if and $video $video.enabled }}
       {{/* Display video with popup */}}
       {{ partial "components/media/video.html" (dict 
@@ -93,7 +93,7 @@
     {{ else }}
       {{/* Display regular image with optional overlay */}}
       {{ if and $showOverlay $overlayIcon }}
-        <div class="absolute {{ $overlayPosition }} z-10 {{ $overlaySize }} rounded-xl border border-gray-200 bg-gradient-to-b from-gray-50 to-gray-50 opacity-80 flex items-center justify-center backdrop-blur-sm {{ $overlayShadowClass }}">
+        <div class="absolute {{ $overlayPosition }} z-10 {{ $overlaySize }} rounded-xl border border-gray-200 bg-linear-to-b from-gray-50 to-gray-50 opacity-80 flex items-center justify-center backdrop-blur-xs {{ $overlayShadowClass }}">
           {{ if eq $overlayMode "image" }}
             {{/* Image Overlay (integrations, success-stories) */}}
             {{ partial "components/media/lazyimg.html" (dict

--- a/layouts/partials/sections/hero/split_with_chatbot.html
+++ b/layouts/partials/sections/hero/split_with_chatbot.html
@@ -34,7 +34,7 @@ Design Tokens:
 <div class="split-with-chatbot-hero {{ if .backgroundColor }}{{ .backgroundColor }}{{ else }}section-bg-light{{ end }} {{ $sectionPaddingY }}">
   <div class="wrapper lg:flex lg:justify-between lg:items-stretch gap-x-8 lg:flex-row-reverse">
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 xl:left-0">
-      <div class="relative rounded-lg py-6 flex items-start justify-center w-full overflow-hidden mx-auto max-w-[38rem] max-h-[35rem]">
+      <div class="relative rounded-lg py-6 flex items-start justify-center w-full overflow-hidden mx-auto max-w-152 max-h-140">
         <!-- Chatbot Integration -->
         {{ if .chatbotId }}
         <div class="w-full h-full overflow-hidden">

--- a/layouts/partials/sections/hero/split_with_image.html
+++ b/layouts/partials/sections/hero/split_with_image.html
@@ -43,10 +43,10 @@ Parameters:
   - wordAlternatives: Comma separated words to alternate with
 - sectionPaddingY: Custom vertical padding using Tailwind classes (default: "max-md:pt-0 py-12 lg:py-16")
 - backgroundColor: Custom background color class
-- overlayPosition: Position of icon overlay (default: "top-[5.69rem] left-[1.25rem]", for success-stories: "top-12 right-3 xl:-right-10")
+- overlayPosition: Position of icon overlay (default: "top-[5.69rem] left-5", for success-stories: "top-12 right-3 xl:-right-10")
 - overlaySize: Size of overlay container (default: "w-[7.88rem] h-[7.88rem]")
-- overlayIconSizeIntegrations: Size of integration icons (default: "w-[6.25rem] h-[6.25rem]")
-- overlayIconSizeFeatures: Size of feature icons (default: "w-[4.25rem] h-[4.25rem]")
+- overlayIconSizeIntegrations: Size of integration icons (default: "w-25 h-25")
+- overlayIconSizeFeatures: Size of feature icons (default: "w-17 h-17")
 - overlayShadowClass: CSS class for overlay shadow (default: "hero-overlay-shadow")
 - contentLeftPadding: Left padding for content area (default: "lg:pr-0")
 - customBackground: Custom background image path for integrations type (optional)
@@ -146,10 +146,10 @@ Design Tokens:
 {{ $headingTracking := "tracking-[-2.832px]" }}
 
 {{/* Overlay configuration */}}
-{{ $overlayPosition := .overlayPosition | default "top-[5.69rem] left-[1.25rem]" }}
+{{ $overlayPosition := .overlayPosition | default "top-[5.69rem] left-5" }}
 {{ $overlaySize := .overlaySize | default "w-[7.88rem] h-[7.88rem]" }}
-{{ $overlayIconSizeIntegrations := .overlayIconSizeIntegrations | default "w-[6.25rem] h-[6.25rem]" }}
-{{ $overlayIconSizeFeatures := .overlayIconSizeFeatures | default "w-[4.25rem] h-[4.25rem]" }}
+{{ $overlayIconSizeIntegrations := .overlayIconSizeIntegrations | default "w-25 h-25" }}
+{{ $overlayIconSizeFeatures := .overlayIconSizeFeatures | default "w-17 h-17" }}
 {{ $overlayShadowClass := .overlayShadowClass | default "hero-overlay-shadow" }}
 {{ $overflowClass := "overflow-hidden" }}
 
@@ -201,14 +201,14 @@ Design Tokens:
 {{/* Overlay position - right for success-stories, left for others */}}
 {{ if $config.overlayPositionRight }}
   {{ $overlayPosition = "top-12 right-3 xl:-right-10" }}
-  {{ $overlaySize = "w-auto h-[8.75rem]" }}
+  {{ $overlaySize = "w-auto h-35" }}
   {{ $overflowClass = "overflow-hidden xl:overflow-visible" }}
 {{ end }}
 
 <div class="split-with-image-hero {{ if $backgroundColor }}{{ $backgroundColor }}{{ else if $isDark }}dark section-bg-dark{{ else if $isAlternate }}section-bg-alternate{{ else }}section-bg-light{{ end }} {{ $sectionPaddingY }}">
   <div class="wrapper lg:flex lg:justify-between lg:items-stretch gap-x-8 lg:flex-row-reverse">
     <div class="hidden lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 xl:left-0">
-      <div class="relative rounded-lg {{ $imageContainerPaddingY }} flex items-start justify-center w-full {{ $overflowClass }} mx-auto max-w-[38rem] max-h-full">
+      <div class="relative rounded-lg {{ $imageContainerPaddingY }} flex items-start justify-center w-full {{ $overflowClass }} mx-auto max-w-152 max-h-full">
         {{ if and $video $video.enabled }}
           {{/* Display video with popup */}}
           {{ partial "components/media/video.html" (dict 
@@ -237,7 +237,7 @@ Design Tokens:
               ) }}
             {{ else }}
               {{/* Standard Single Icon Overlay */}}
-              <div class="absolute {{ $overlayPosition }} z-10 {{ $overlaySize }} rounded-xl border border-gray-200 bg-gradient-to-b from-gray-50 to-gray-50 opacity-80 flex items-center justify-center backdrop-blur-sm {{ $overlayShadowClass }}">
+              <div class="absolute {{ $overlayPosition }} z-10 {{ $overlaySize }} rounded-xl border border-gray-200 bg-linear-to-b from-gray-50 to-gray-50 opacity-80 flex items-center justify-center backdrop-blur-xs {{ $overlayShadowClass }}">
                 {{ if eq $config.overlayMode "image" }}
                   {{/* Integration logo (Image Overlay) */}}
                   {{ partial "components/media/lazyimg.html" (dict

--- a/layouts/partials/sections/hero/split_with_image_tiles.html
+++ b/layouts/partials/sections/hero/split_with_image_tiles.html
@@ -73,7 +73,7 @@
 {{ $search := merge (dict "searchFields" (slice "title" "content" "tags" "categories")) $search }}
 
 <div class="relative isolate">
-  <svg class="absolute inset-x-0 top-0 -z-10 h-[64rem] w-full stroke-gray-200 [mask-image:radial-gradient(32rem_32rem_at_center,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-x-0 top-0 -z-10 h-256 w-full stroke-gray-200 mask-[radial-gradient(32rem_32rem_at_center,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="1f932ae7-37de-4c0a-a8b0-a6e3b4d44b84" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -85,7 +85,7 @@
     <rect width="100%" height="100%" stroke-width="0" fill="url(#1f932ae7-37de-4c0a-a8b0-a6e3b4d44b84)" />
   </svg>
   <div class="absolute top-0 right-0 left-1/2 -z-10 -ml-24 transform-gpu overflow-hidden blur-3xl lg:ml-24 xl:ml-48" aria-hidden="true">
-    <div class="aspect-801/1036 w-[50.0625rem] bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-30" style="clip-path: polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%)"></div>
+    <div class="aspect-801/1036 w-200.25 bg-linear-to-tr from-[#ff80b5] to-[#9089fc] opacity-30" style="clip-path: polygon(63.1% 29.5%, 100% 17.1%, 76.6% 3%, 48.4% 0%, 44.6% 4.7%, 54.5% 25.3%, 59.8% 49%, 55.2% 57.8%, 44.4% 57.2%, 27.8% 47.9%, 35.1% 81.5%, 0% 97.7%, 39.2% 100%, 35.2% 81.4%, 97.2% 52.8%, 63.1% 29.5%)"></div>
   </div>
   <div class="overflow-visible">
     <div class="mx-auto max-w-7xl px-6 pt-36 pb-32 sm:pt-60 lg:px-8 lg:pt-10">
@@ -96,7 +96,7 @@
           {{ if or $primaryCtaText $secondaryCtaText }}
           <div class="mt-10 flex items-center gap-x-6">
             {{ if $primaryCtaText }}
-            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCtaUrl) }}" class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $primaryCtaText }}</a>
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $primaryCtaUrl) }}" class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-2xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $primaryCtaText }}</a>
             {{ end }}
             {{ if $secondaryCtaText }}
             <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $secondaryCtaUrl) }}" class="text-sm/6 font-semibold text-gray-900">{{ $secondaryCtaText }} <span aria-hidden="true">→</span></a>
@@ -116,7 +116,7 @@
           {{ end }}
         </div>
         <div class="mt-14 flex justify-start gap-6 sm:-mt-44 sm:justify-start sm:pl-0 lg:mt-0 lg:pl-0 lg:-ml-10">
-          <div class="ml-auto w-44 flex-none space-y-8 pt-32 sm:ml-0 sm:pt-80 lg:order-last lg:pt-36 xl:order-none xl:pt-80">
+          <div class="ml-auto w-44 flex-none space-y-8 pt-32 sm:ml-0 sm:pt-80 lg:order-last lg:pt-36 xl:order-0 xl:pt-80">
             <div class="relative">
               {{ partial "components/media/lazyimg.html" (dict 
                 "src" (index $images 0 "url") 

--- a/layouts/partials/sections/hero/split_with_offset_image.html
+++ b/layouts/partials/sections/hero/split_with_offset_image.html
@@ -75,7 +75,7 @@
       <div class="mt-6 max-w-xl lg:mt-0 xl:col-end-1 xl:row-start-1">
         <p class="text-lg font-medium text-pretty text-gray-500 sm:text-xl/8">{{ $description }}</p>
         <div class="mt-10 flex items-center gap-x-6">
-          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.primary.url) }}" class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $cta.primary.text }}</a>
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.primary.url) }}" class="rounded-md bg-indigo-600 px-3.5 py-2.5 text-sm font-semibold text-white shadow-2xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $cta.primary.text }}</a>
           <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.secondary.url) }}" class="text-sm/6 font-semibold text-gray-900">{{ $cta.secondary.text }} <span aria-hidden="true">→</span></a>
         </div>
         

--- a/layouts/partials/sections/hero/split_with_screenshot.html
+++ b/layouts/partials/sections/hero/split_with_screenshot.html
@@ -58,7 +58,7 @@
 ) }}
 
 <div class="relative isolate overflow-hidden bg-white">
-  <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 size-full stroke-gray-200 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="0787a7c5-978c-4f66-83c7-11c213f99cb7" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -76,7 +76,7 @@
           "alt" (default "App screenshot" $screenshot.alt)
           "width" (default "2432" $screenshot.width)
           "height" (default "1442" $screenshot.height)
-          "class" "w-[76rem] rounded-md shadow-2xl ring-1 ring-gray-900/10"
+          "class" "w-304 rounded-md shadow-2xl ring-1 ring-gray-900/10"
           "style" (printf "max-height: calc(%s - 32rem); width: auto; object-fit: contain;" $maxSectionHeight)
         ) }}
     </div>

--- a/layouts/partials/sections/hero/split_with_screenshot_dark.html
+++ b/layouts/partials/sections/hero/split_with_screenshot_dark.html
@@ -81,7 +81,7 @@
 {{ $search := merge (dict "searchFields" (slice "title" "content" "tags" "categories")) $search }}
 
 <div class="relative isolate overflow-hidden bg-gray-900">
-  <svg class="absolute inset-0 -z-10 size-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 size-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -93,7 +93,7 @@
     <rect width="100%" height="100%" stroke-width="0" fill="url(#983e3e4c-de6d-4c3f-8d64-b9761d1534cc)" />
   </svg>
   <div class="absolute top-10 left-[calc(50%-4rem)] -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:top-[calc(50%-30rem)] lg:left-48 xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-1108/632 w-[69.25rem] bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
   <div class="mx-auto max-w-7xl px-6 pt-10 pb-24 sm:pb-32 lg:flex lg:px-8 lg:py-40">
     <div class="mx-auto max-w-2xl shrink-0 lg:mx-0 lg:pt-8">
@@ -116,7 +116,7 @@
       <h1 class="mt-10 text-5xl font-semibold tracking-tight text-pretty text-white sm:text-7xl"{{ if $typewriter.enabled }} data-typewriter data-typewriter-words="{{ $typewriter.words }}" data-typewriter-word-alternatives="{{$typewriter.wordAlternatives}}" data-typewriter-speed="{{ $typewriter.speed }}" data-typewriter-delete-speed="{{ $typewriter.deleteSpeed }}" data-typewriter-pause="{{ $typewriter.pause }}" data-typewriter-color="{{ $typewriter.color }}"{{ end }}>{{ $heading }}</h1>
       <p class="mt-8 text-lg font-medium text-pretty text-gray-400 sm:text-xl/8">{{ $description }}</p>
       <div class="mt-10 flex items-center gap-x-6">
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.primary.url) }}" class="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $cta.primary.text }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.primary.url) }}" class="rounded-md bg-indigo-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-2xs hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400">{{ $cta.primary.text }}</a>
         <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $cta.secondary.url) }}" class="text-sm/6 font-semibold text-white">{{ $cta.secondary.text }} <span aria-hidden="true">→</span></a>
       </div>
       
@@ -139,7 +139,7 @@
             "alt" $screenshot.alt 
             "width" $screenshot.width 
             "height" $screenshot.height 
-            "class" "w-[76rem] rounded-md bg-white/5 ring-1 shadow-2xl ring-white/10"
+            "class" "w-304 rounded-md bg-white/5 ring-1 shadow-2xl ring-white/10"
             "maxWidth" 800
           ) }}
         </div>

--- a/layouts/partials/sections/hero/split_with_youtube_video.html
+++ b/layouts/partials/sections/hero/split_with_youtube_video.html
@@ -43,7 +43,7 @@ Parameters:
 <div class="split-with-video-hero {{ if .backgroundColor }}{{ .backgroundColor }}{{ else }}section-bg-light{{ end }} {{ $sectionPaddingY }}">
   <div class="wrapper lg:flex lg:justify-between lg:items-stretch gap-x-8 lg:flex-row-reverse">
     <div class="lg:flex lg:w-1/2 lg:items-start lg:shrink lg:grow-0 xl:relative xl:inset-y-0 xl:left-0">
-      <div class="relative rounded-lg py-6 flex items-start justify-center w-full overflow-hidden mx-auto max-w-[38rem] max-h-[35rem]">
+      <div class="relative rounded-lg py-6 flex items-start justify-center w-full overflow-hidden mx-auto max-w-152 max-h-140">
         {{ partial "components/media/video.html" (dict
           "videoID" $videoID 
           "title" ($videoTitle | default "YouTube Video")

--- a/layouts/partials/sections/pricing/base.html
+++ b/layouts/partials/sections/pricing/base.html
@@ -146,18 +146,18 @@
     <div class="isolate mx-auto mt-16 grid items-stretch grid-cols-1 {{ $columnsClass }} gap-y-8 sm:gap-x-4 sm:gap-y-4 sm:mt-20 lg:gap-x-5">
       {{ range $tier := $tiers }}
       <div class='flex flex-col h-full rounded-3xl p-8 {{ if $tier.darkTheme }}bg-slate-900 ring-1 ring-slate-700{{ else }}bg-white ring-1 ring-gray-200{{ end }} {{ if $tier.popular }}ring-2 ring-primary{{ end }} xl:p-10 w-full'>
-        <div class="flex flex-col flex-grow">
+        <div class="flex flex-col grow">
           <div class="flex items-start justify-between gap-x-4">
             <h3 id="{{ $tier.id }}" class="mb-5 not-prose text-lg/8 font-semibold {{ if $tier.darkTheme }}text-white{{ else }}text-heading{{ end }} {{ if $tier.popular }}text-primary{{ end }} min-h-14 flex flex-wrap">{{ i18n $tier.name }}</h3>
             {{ if $tier.popular }}
             <p class="rounded-full not-prose bg-indigo-50 px-2.5 py-1 text-xs/4 font-semibold text-center text-primary">{{ i18n ($tier.popularText | default "pricing_popular_badge") }}</p>
             {{ end }}
           </div>
-          <p class="mt-auto mb-6 text-sm/6 {{ if $tier.darkTheme }}text-gray-300{{ else }}text-gray-600{{ end }} sm:min-h-[5rem]">{{ i18n $tier.description }}</p>
+          <p class="mt-auto mb-6 text-sm/6 {{ if $tier.darkTheme }}text-gray-300{{ else }}text-gray-600{{ end }} sm:min-h-20">{{ i18n $tier.description }}</p>
           {{ if $promo  }}
             <div class="mb-2.5">
               {{ if $tier.promoPrice }}
-                <span class="inline-flex bg-red-500 text-white text-xs font-bold rounded-[100px] py-1 px-2.5 backdrop-blur-sm">Limited offer{{/*  {{ i18n "promo_offer" }}  */}}</span>
+                <span class="inline-flex bg-red-500 text-white text-xs font-bold rounded-[100px] py-1 px-2.5 backdrop-blur-xs">Limited offer{{/*  {{ i18n "promo_offer" }}  */}}</span>
               {{ else }}
                 <span class="inline-flex h-6"></span>
               {{ end }}
@@ -228,7 +228,7 @@
               ) }}
             {{ end }}
           </div>
-          <ul role="list" class="mt-0 mb-0 px-0 space-y-3 text-sm/6 {{ if $tier.darkTheme }}text-gray-300{{ else }}text-gray-600{{ end }} flex-grow min-h-[12rem]">
+          <ul role="list" class="mt-0 mb-0 px-0 space-y-3 text-sm/6 {{ if $tier.darkTheme }}text-gray-300{{ else }}text-gray-600{{ end }} grow min-h-48">
             {{ range $feature := $tier.features }}
             <li class="flex pl-0 gap-x-3 not-prose">
                 {{ partial "icons/check" (printf "h-6 w-5 flex-none %s" (cond $tier.darkTheme "text-white" "text-primary")) }}

--- a/layouts/partials/sections/pricing/four_tiers_with_toggle.html
+++ b/layouts/partials/sections/pricing/four_tiers_with_toggle.html
@@ -313,7 +313,7 @@
           </p>
           
           {{ if $tier.emphasized }}
-            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-6 block rounded-md bg-{{ $tier.ctaBgColor }} px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier.cta.text }}</a>
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-6 block rounded-md bg-{{ $tier.ctaBgColor }} px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-2xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier.cta.text }}</a>
           {{ else }}
             <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-6 block rounded-md px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} ring-1 ring-{{ $tier.ctaBorderColor }} ring-inset hover:ring-{{ $tier.ctaHoverBorderColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier.cta.text }}</a>
           {{ end }}

--- a/layouts/partials/sections/pricing/section.html
+++ b/layouts/partials/sections/pricing/section.html
@@ -99,14 +99,14 @@
       {{ range $index, $tier := $tiers }}
         {{ if and (ge $index $startColumn) (lt $index (add $startColumn $columnsInt)) }}
         <div class='flex flex-col h-full rounded-3xl p-8 {{ if $tier.darkTheme }}bg-slate-900 ring-1 ring-slate-700{{ else }}bg-white ring-1 ring-gray-200{{ end }} {{ if $tier.popular }}ring-2 ring-primary{{ end }} xl:p-10 w-full'>
-          <div class="flex flex-col flex-grow">
+          <div class="flex flex-col grow">
         <div class="flex items-start justify-between gap-x-4">
           <h3 id="{{ $tier.id }}" class="mb-5 not-prose text-lg/8 font-semibold {{ if $tier.darkTheme }}text-white{{ else }}text-heading{{ end }} {{ if $tier.popular }}text-primary{{ end }}">{{ i18n $tier.name }}</h3>
           {{ if $tier.popular }}
           <p class="rounded-full not-prose bg-indigo-50 px-2.5 py-1 text-xs/4 font-semibold text-center text-primary">{{ i18n ($tier.popularText | default "pricing_popular_badge") }}</p>
           {{ end }}
         </div>
-        <p class="mt-auto mb-4 text-sm/6 {{ if $tier.darkTheme }}text-gray-300{{ else }}text-gray-600{{ end }} sm:min-h-[5rem]">{{ i18n $tier.description }}</p>
+        <p class="mt-auto mb-4 text-sm/6 {{ if $tier.darkTheme }}text-gray-300{{ else }}text-gray-600{{ end }} sm:min-h-20">{{ i18n $tier.description }}</p>
         <div class="mt-auto mb-6 h-9">
           {{ if $tier.priceBeforeText }}<span class="text-sm/6 font-semibold {{ if $tier.darkTheme }}text-tertiary{{ else }}text-secondary{{ end }} ring-gray-200 mr-1">{{ i18n $tier.priceBeforeText }}</span>{{ end }}
           
@@ -155,7 +155,7 @@
           {{ end }}
         </div>
         {{ if $showCheckbox }}
-        <ul role="list" class="mt-0 mb-0 px-0 space-y-3 text-sm/6 {{ if $tier.darkTheme }}text-gray-300{{ else }}text-gray-600{{ end }} flex-grow min-h-[12rem]">
+        <ul role="list" class="mt-0 mb-0 px-0 space-y-3 text-sm/6 {{ if $tier.darkTheme }}text-gray-300{{ else }}text-gray-600{{ end }} grow min-h-48">
           {{ range $feature := $tier.features }}
           <li class="flex pl-0 gap-x-3 not-prose">
           {{ partial "icons/check" (printf "h-6 w-5 flex-none %s" (cond $tier.darkTheme "text-white" "text-primary")) }}

--- a/layouts/partials/sections/pricing/single_price_with_details.html
+++ b/layouts/partials/sections/pricing/single_price_with_details.html
@@ -138,7 +138,7 @@
               <span class="text-5xl font-semibold tracking-tight text-{{ $priceColor }}">{{ $price }}</span>
               <span class="text-sm/6 font-semibold tracking-wide text-{{ $currencyColor }}">{{ $currency }}</span>
             </p>
-            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="mt-10 block w-full rounded-md bg-{{ $ctaBgColor }} px-3 py-2 text-center text-sm font-semibold text-{{ $ctaTextColor }} shadow-xs hover:bg-{{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $ctaBgColor }}">{{ $ctaText }}</a>
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $ctaUrl) }}" class="mt-10 block w-full rounded-md bg-{{ $ctaBgColor }} px-3 py-2 text-center text-sm font-semibold text-{{ $ctaTextColor }} shadow-2xs hover:bg-{{ $ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $ctaBgColor }}">{{ $ctaText }}</a>
             <p class="mt-6 text-xs/5 text-{{ $footnoteColor }}">{{ $footnote }}</p>
           </div>
         </div>

--- a/layouts/partials/sections/pricing/three_tiers_with_dividers.html
+++ b/layouts/partials/sections/pricing/three_tiers_with_dividers.html
@@ -217,7 +217,7 @@
             <span class="text-sm/6 font-semibold text-{{ $tier.intervalColor }}">{{ $tier.interval }}</span>
           </p>
           <p class="mt-3 text-sm/6 text-{{ $tier.annualPriceColor }}">{{ $tier.annualPrice }}</p>
-          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-10 block rounded-md bg-{{ $tier.ctaBgColor }} px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $tier.ctaBgColor }}">{{ $tier.cta.text }}</a>
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-10 block rounded-md bg-{{ $tier.ctaBgColor }} px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-2xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $tier.ctaBgColor }}">{{ $tier.cta.text }}</a>
           <p class="mt-10 text-sm/6 font-semibold text-{{ $tier.summaryColor }}">{{ $tier.summary }}</p>
           <ul role="list" class="mt-6 space-y-3 text-sm/6 text-{{ $tier.featureColor }}">
             {{ range $feature := $tier.features }}

--- a/layouts/partials/sections/pricing/three_tiers_with_emphasized_tier.html
+++ b/layouts/partials/sections/pricing/three_tiers_with_emphasized_tier.html
@@ -263,7 +263,7 @@
           <span class="text-sm/6 font-semibold text-{{ $tier.intervalColor }}">{{ $tier.interval }}</span>
           {{ end }}
         </p>
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-6 block rounded-md bg-{{ $tier.ctaBgColor }} px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ if $tier.emphasized }}white{{ else }}{{ $tier.ctaBgColor }}{{ end }}">{{ $tier.cta.text }}</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-6 block rounded-md bg-{{ $tier.ctaBgColor }} px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-2xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ if $tier.emphasized }}white{{ else }}{{ $tier.ctaBgColor }}{{ end }}">{{ $tier.cta.text }}</a>
         <ul role="list" class="mt-8 space-y-3 text-sm/6 text-{{ $tier.featureColor }} xl:mt-10">
           {{ range $feature := $tier.features }}
           <li class="flex gap-x-3">

--- a/layouts/partials/sections/pricing/three_tiers_with_feature_comparison.html
+++ b/layouts/partials/sections/pricing/three_tiers_with_feature_comparison.html
@@ -203,7 +203,7 @@
           </div>
         </div>
         <div class="relative mx-auto mt-10 grid max-w-md grid-cols-1 gap-y-8 lg:mx-0 lg:-mb-14 lg:max-w-none lg:grid-cols-3">
-          <svg viewBox="0 0 1208 1024" aria-hidden="true" class="absolute -bottom-48 left-1/2 h-[64rem] -translate-x-1/2 translate-y-1/2 [mask-image:radial-gradient(closest-side,white,transparent)] lg:-top-48 lg:bottom-auto lg:translate-y-0">
+          <svg viewBox="0 0 1208 1024" aria-hidden="true" class="absolute -bottom-48 left-1/2 h-256 -translate-x-1/2 translate-y-1/2 mask-[radial-gradient(closest-side,white,transparent)] lg:-top-48 lg:bottom-auto lg:translate-y-0">
             <ellipse cx="604" cy="512" fill="url(#d25c25d4-6d43-4bf9-b9ac-1842a30a4867)" rx="604" ry="512" />
             <defs>
               <radialGradient id="d25c25d4-6d43-4bf9-b9ac-1842a30a4867">
@@ -259,7 +259,7 @@
                     <p class="text-gray-500 billing-text-annually hidden">{{ $tier2BillingTextAnnual }}</p>
                   </div>
                 </div>
-                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier2ButtonUrl) }}" aria-describedby="{{ $tier2Id }}" class="rounded-md bg-indigo-600 px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier2ButtonText }}</a>
+                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier2ButtonUrl) }}" aria-describedby="{{ $tier2Id }}" class="rounded-md bg-indigo-600 px-3 py-2 text-center text-sm/6 font-semibold text-white shadow-2xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier2ButtonText }}</a>
               </div>
               <div class="mt-8 flow-root sm:mt-10">
                 <ul role="list" class="-my-2 divide-y divide-gray-900/5 border-t border-gray-900/5 text-sm/6 text-gray-600 lg:border-t-0">

--- a/layouts/partials/sections/pricing/three_tiers_with_logos_and_feature_comparison.html
+++ b/layouts/partials/sections/pricing/three_tiers_with_logos_and_feature_comparison.html
@@ -278,7 +278,7 @@
                 </div>
               </div>
               <div class="mt-8">
-                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.ctaUrl) }}" aria-label="{{ $tier.ctaText }} on the {{ $tier.name }} plan" class="inline-block rounded-md bg-indigo-600 px-3.5 py-2 text-center text-sm/6 font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier.ctaText }}</a>
+                <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.ctaUrl) }}" aria-label="{{ $tier.ctaText }} on the {{ $tier.name }} plan" class="inline-block rounded-md bg-indigo-600 px-3.5 py-2 text-center text-sm/6 font-semibold text-white shadow-2xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier.ctaText }}</a>
               </div>
               <div class="mt-8">
                 <h3 class="text-sm/6 font-medium text-gray-950">Start selling with:</h3>
@@ -332,7 +332,7 @@
           <th class="p-0"></th>
           {{ range $tier := $tiers }}
           <td class="px-0 pt-3 pb-0">
-            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.ctaUrl) }}" aria-label="Get started with the {{ $tier.name }} plan" class="inline-block rounded-xl bg-white px-2.5 py-1.5 text-center text-sm/6 font-semibold text-gray-900 ring-1 shadow-xs ring-gray-300 ring-inset hover:bg-gray-50">Get started</a>
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.ctaUrl) }}" aria-label="Get started with the {{ $tier.name }} plan" class="inline-block rounded-xl bg-white px-2.5 py-1.5 text-center text-sm/6 font-semibold text-gray-900 ring-1 shadow-2xs ring-gray-300 ring-inset hover:bg-gray-50">Get started</a>
           </td>
           {{ end }}
         </tr>
@@ -407,7 +407,7 @@
 
       {{ range $tierIndex, $tier := $tiers }}
       <div id="tabs-1-panel-{{ add $tierIndex 1 }}" aria-labelledby="tabs-1-tab-{{ add $tierIndex 1 }}" role="tabpanel" tabindex="0">
-        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.ctaUrl) }}" class="mt-8 block rounded-xl bg-white px-3.5 py-2.5 text-center text-sm font-semibold text-gray-900 ring-1 shadow-xs ring-gray-300 ring-inset hover:bg-gray-50">Get started</a>
+        <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.ctaUrl) }}" class="mt-8 block rounded-xl bg-white px-3.5 py-2.5 text-center text-sm font-semibold text-gray-900 ring-1 shadow-2xs ring-gray-300 ring-inset hover:bg-gray-50">Get started</a>
         
         {{ range $categoryIndex, $category := $featureCategories }}
         <div class="-mx-6 mt-10 rounded-lg bg-gray-50 px-6 py-3 text-sm/6 font-semibold text-gray-950 {{ if eq $categoryIndex 0 }}group-first-of-type:mt-5{{ end }}">{{ $category.name }}</div>

--- a/layouts/partials/sections/pricing/three_tiers_with_toggle.html
+++ b/layouts/partials/sections/pricing/three_tiers_with_toggle.html
@@ -278,7 +278,7 @@
           </p>
           
           {{ if $tier.popular }}
-            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-6 block rounded-md bg-{{ $tier.ctaBgColor }} px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier.cta.text }}</a>
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-6 block rounded-md bg-{{ $tier.ctaBgColor }} px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-2xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier.cta.text }}</a>
           {{ else }}
             <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-6 block rounded-md px-3 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} ring-1 ring-{{ $tier.ctaBorderColor }} ring-inset hover:ring-{{ $tier.ctaHoverBorderColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">{{ $tier.cta.text }}</a>
           {{ end }}

--- a/layouts/partials/sections/pricing/two_tiers.html
+++ b/layouts/partials/sections/pricing/two_tiers.html
@@ -160,7 +160,7 @@
 
 <div class="relative isolate bg-{{ $backgroundColor }} px-6 py-24 sm:py-32 lg:px-8">
   <div class="absolute inset-x-0 -top-3 -z-10 transform-gpu overflow-hidden px-36 blur-3xl" aria-hidden="true">
-    <div class="mx-auto aspect-1155/678 w-[72.1875rem] bg-linear-to-tr from-[{{ $gradientStartColor }}] to-[{{ $gradientEndColor }}] opacity-30" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+    <div class="mx-auto aspect-1155/678 w-288.75 bg-linear-to-tr from-[{{ $gradientStartColor }}] to-[{{ $gradientEndColor }}] opacity-30" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
   </div>
   <div class="mx-auto max-w-4xl text-center">
     <h2 class="text-base/7 font-semibold text-{{ $taglineColor }}">{{ $tagline }}</h2>
@@ -187,7 +187,7 @@
             </li>
             {{ end }}
           </ul>
-          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-8 block rounded-md bg-{{ $tier.ctaBgColor }} px-3.5 py-2.5 text-center text-sm font-semibold text-{{ $tier.ctaColor }} shadow-sm hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $tier.ctaBgColor }} sm:mt-10">{{ $tier.cta.text }}</a>
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-8 block rounded-md bg-{{ $tier.ctaBgColor }} px-3.5 py-2.5 text-center text-sm font-semibold text-{{ $tier.ctaColor }} shadow-xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $tier.ctaBgColor }} sm:mt-10">{{ $tier.cta.text }}</a>
         </div>
       {{ else }}
         <div class="rounded-3xl bg-{{ $tier.backgroundColor }} p-8 ring-1 ring-{{ $tier.borderColor }} sm:mx-8 sm:rounded-t-none sm:p-10 lg:mx-0 lg:rounded-tr-3xl lg:rounded-bl-none">

--- a/layouts/partials/sections/pricing/two_tiers_with_emphasized_tier.html
+++ b/layouts/partials/sections/pricing/two_tiers_with_emphasized_tier.html
@@ -158,7 +158,7 @@
 
 <div class="relative isolate bg-{{ $backgroundColor }} px-6 py-24 sm:py-32 lg:px-8">
   <div class="absolute inset-x-0 -top-3 -z-10 transform-gpu overflow-hidden px-36 blur-3xl" aria-hidden="true">
-    <div class="mx-auto aspect-1155/678 w-[72.1875rem] bg-linear-to-tr from-[{{ $gradientStartColor }}] to-[{{ $gradientEndColor }}] opacity-30" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+    <div class="mx-auto aspect-1155/678 w-288.75 bg-linear-to-tr from-[{{ $gradientStartColor }}] to-[{{ $gradientEndColor }}] opacity-30" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
   </div>
   <div class="mx-auto max-w-4xl text-center">
     <h2 class="text-base/7 font-semibold text-{{ $taglineColor }}">{{ $tagline }}</h2>
@@ -205,7 +205,7 @@
             </li>
             {{ end }}
           </ul>
-          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-8 block rounded-md bg-{{ $tier.ctaBgColor }} px-3.5 py-2.5 text-center text-sm font-semibold text-{{ $tier.ctaColor }} shadow-xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $tier.ctaBgColor }} sm:mt-10">{{ $tier.cta.text }}</a>
+          <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-8 block rounded-md bg-{{ $tier.ctaBgColor }} px-3.5 py-2.5 text-center text-sm font-semibold text-{{ $tier.ctaColor }} shadow-2xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $tier.ctaBgColor }} sm:mt-10">{{ $tier.cta.text }}</a>
         </div>
       {{ end }}
     {{ end }}

--- a/layouts/partials/sections/pricing/two_tiers_with_extra_tier.html
+++ b/layouts/partials/sections/pricing/two_tiers_with_extra_tier.html
@@ -197,7 +197,7 @@
     </div>
     <div class="relative mt-6">
       <p class="mx-auto max-w-2xl text-lg font-medium text-pretty text-{{ $descriptionColor }} sm:text-xl/8">{{ $description }}</p>
-      <svg viewBox="0 0 1208 1024" class="absolute -top-10 left-1/2 -z-10 h-[64rem] -translate-x-1/2 [mask-image:radial-gradient(closest-side,white,transparent)] sm:-top-12 md:-top-20 lg:-top-12 xl:top-0">
+      <svg viewBox="0 0 1208 1024" class="absolute -top-10 left-1/2 -z-10 h-256 -translate-x-1/2 mask-[radial-gradient(closest-side,white,transparent)] sm:-top-12 md:-top-20 lg:-top-12 xl:top-0">
         <ellipse cx="604" cy="512" fill="url(#gradient-{{ now.Unix }})" rx="604" ry="512" />
         <defs>
           <radialGradient id="gradient-{{ now.Unix }}">
@@ -232,7 +232,7 @@
                 {{ end }}
               </ul>
             </div>
-            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-8 block rounded-md bg-{{ $tier.ctaBgColor }} px-3.5 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $tier.ctaBgColor }}">{{ $tier.cta.text }}</a>
+            <a href="{{ partial "helpers/get-translated-url.html" (dict "url" $tier.cta.url) }}" aria-describedby="{{ $tier.id }}" class="mt-8 block rounded-md bg-{{ $tier.ctaBgColor }} px-3.5 py-2 text-center text-sm/6 font-semibold text-{{ $tier.ctaColor }} shadow-2xs hover:bg-{{ $tier.ctaHoverBgColor }} focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-{{ $tier.ctaBgColor }}">{{ $tier.cta.text }}</a>
           </div>
           {{ end }}
 

--- a/layouts/partials/sections/pricing/with_comparison_table.html
+++ b/layouts/partials/sections/pricing/with_comparison_table.html
@@ -132,7 +132,7 @@
                     {{ $columnCount := add (len $tiersComparison) 1 }}
                     {{ $columnWidthVar := div 100.0 (len $tiersComparison) }}
                     {{ if gt (len $featureCategories) $visibleCategories }}
-                    <div id="comparison-gradient-overlay" class="relative after:content-[''] after:block after:w-full after:h-full after:bg-gradient-to-t after:from-white after:to-transparent after:absolute after:bottom-0 after:left-0 after:pointer-events-none after:transition-opacity">
+                    <div id="comparison-gradient-overlay" class="relative after:content-[''] after:block after:w-full after:h-full after:bg-linear-to-t after:from-white after:to-transparent after:absolute after:bottom-0 after:left-0 after:pointer-events-none after:transition-opacity">
                     {{ end }}
                     <div class="relative">
                         {{ range $index, $tier := $tiersComparison }}

--- a/layouts/partials/sections/stats/simple_grid_on_dark.html
+++ b/layouts/partials/sections/stats/simple_grid_on_dark.html
@@ -88,7 +88,7 @@
 
 <div class="{{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   <div class="absolute left-0 right-0 top-0 -z-10 m-auto h-[60%] w-[90%] rounded-full bg-indigo-500 opacity-10 blur-[100px]"></div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/sections/stats/simple_on_dark.html
+++ b/layouts/partials/sections/stats/simple_on_dark.html
@@ -63,7 +63,7 @@
 
 <div class="{{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   <div class="absolute left-0 right-0 top-0 -z-10 m-auto h-[60%] w-[90%] rounded-full bg-indigo-500 opacity-10 blur-[100px]"></div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/sections/stats/split_with_image.html
+++ b/layouts/partials/sections/stats/split_with_image.html
@@ -103,7 +103,7 @@
         {{ partial "components/media/lazyimg.html" (dict 
           "src" $image 
           "alt" $imageAlt
-          "class" "aspect-[3/2] w-full object-cover lg:absolute lg:inset-0 lg:aspect-auto lg:h-full"
+          "class" "aspect-3/2 w-full object-cover lg:absolute lg:inset-0 lg:aspect-auto lg:h-full"
           "maxWidth" 1024
         ) }}
       </div>
@@ -112,7 +112,7 @@
         {{ partial "components/media/lazyimg.html" (dict 
           "src" $image 
           "alt" $imageAlt
-          "class" "aspect-[3/2] w-full object-cover lg:absolute lg:inset-0 lg:aspect-auto lg:h-full"
+          "class" "aspect-3/2 w-full object-cover lg:absolute lg:inset-0 lg:aspect-auto lg:h-full"
           "maxWidth" 1024
         ) }}
       </div>

--- a/layouts/partials/sections/stats/split_with_image_on_dark.html
+++ b/layouts/partials/sections/stats/split_with_image_on_dark.html
@@ -84,7 +84,7 @@
 
 <div class="relative {{ $bgColor }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   
   {{ if $image }}
     {{ if eq $imagePosition "left" }}
@@ -92,7 +92,7 @@
         {{ partial "components/media/lazyimg.html" (dict 
           "src" $image 
           "alt" $imageAlt
-          "class" "aspect-[3/2] w-full object-cover lg:absolute lg:inset-0 lg:aspect-auto lg:h-full"
+          "class" "aspect-3/2 w-full object-cover lg:absolute lg:inset-0 lg:aspect-auto lg:h-full"
           "maxWidth" 1024
         ) }}
       </div>
@@ -101,7 +101,7 @@
         {{ partial "components/media/lazyimg.html" (dict 
           "src" $image 
           "alt" $imageAlt
-          "class" "aspect-[3/2] w-full object-cover lg:absolute lg:inset-0 lg:aspect-auto lg:h-full"
+          "class" "aspect-3/2 w-full object-cover lg:absolute lg:inset-0 lg:aspect-auto lg:h-full"
           "maxWidth" 1024
         ) }}
       </div>

--- a/layouts/partials/sections/stats/stepped_on_dark.html
+++ b/layouts/partials/sections/stats/stepped_on_dark.html
@@ -103,7 +103,7 @@
 
 <div class="{{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   <div class="absolute left-0 right-0 top-0 -z-10 m-auto h-[60%] w-[90%] rounded-full bg-indigo-500 opacity-10 blur-[100px]"></div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/sections/stats/timeline_on_dark.html
+++ b/layouts/partials/sections/stats/timeline_on_dark.html
@@ -92,7 +92,7 @@
 
 <div class="{{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   <div class="absolute left-0 right-0 top-0 -z-10 m-auto h-[60%] w-[90%] rounded-full bg-indigo-500 opacity-10 blur-[100px]"></div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/sections/stats/with_background_image.html
+++ b/layouts/partials/sections/stats/with_background_image.html
@@ -89,7 +89,7 @@
 <div class="relative isolate overflow-hidden bg-gray-900 {{ $padding }}">
   {{ partial "components/media/lazyimg.html" (dict "src" $bgImage "alt" $bgImageAlt "class" "absolute inset-0 -z-10 size-full object-cover" "maxWidth" 1024) }}
   <div class="absolute -bottom-8 -left-96 -z-10 transform-gpu blur-3xl sm:-bottom-64 sm:-left-40 lg:-bottom-32 lg:left-8 xl:-left-10" aria-hidden="true">
-    <div class="aspect-1266/975 w-[79.125rem] bg-linear-to-tr from-[#ff4694] to-[#776fff] opacity-20" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+    <div class="aspect-1266/975 w-316.5 bg-linear-to-tr from-[#ff4694] to-[#776fff] opacity-20" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
   </div>
   <div class="relative mx-auto max-w-7xl px-6 lg:px-8">
     {{ if $showHeading }}

--- a/layouts/partials/sections/stats/with_description_on_dark.html
+++ b/layouts/partials/sections/stats/with_description_on_dark.html
@@ -40,7 +40,7 @@
 
 <div class="{{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   <div class="absolute left-0 right-0 top-0 -z-10 m-auto h-[60%] w-[90%] rounded-full bg-indigo-500 opacity-10 blur-[100px]"></div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/sections/stats/with_two_column_description_on_dark.html
+++ b/layouts/partials/sections/stats/with_two_column_description_on_dark.html
@@ -68,7 +68,7 @@
 
 <div class="{{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   <div class="absolute left-0 right-0 top-0 -z-10 m-auto h-[60%] w-[90%] rounded-full bg-indigo-500 opacity-10 blur-[100px]"></div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/sections/team/full_width_with_vertical_images.html
+++ b/layouts/partials/sections/team/full_width_with_vertical_images.html
@@ -117,7 +117,7 @@
         {{ partial "components/media/lazyimg.html" (dict 
           "src" .image 
           "alt" .name 
-          "class" "aspect-[3/4] w-full rounded-xl bg-gray-50 object-cover" 
+          "class" "aspect-3/4 w-full rounded-xl bg-gray-50 object-cover" 
           "maxWidth" 400
           "loading" "lazy" 
           "decoding" "async"

--- a/layouts/partials/sections/testimonials/grid.html
+++ b/layouts/partials/sections/testimonials/grid.html
@@ -88,10 +88,10 @@
 
 <section class="relative mx-auto max-w-7xl isolate py-24 sm:py-32" aria-label="Customer testimonials section">
   <div class="absolute inset-x-0 top-1/2 -z-10 -translate-y-1/2 transform-gpu overflow-hidden opacity-20 blur-3xl" aria-hidden="true">
-    <div class="ml-[max(50%,38rem)] aspect-[1313/771] w-[82.0625rem] bg-gradient-to-tr from-primary-400 to-primary-700" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+    <div class="ml-[max(50%,38rem)] aspect-1313/771 w-328.25 bg-linear-to-tr from-primary-400 to-primary-700" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
   </div>
   <div class="absolute inset-x-0 top-0 -z-10 flex transform-gpu overflow-hidden pt-32 opacity-20 blur-3xl sm:pt-40 xl:justify-end" aria-hidden="true">
-    <div class="ml-[-22rem] aspect-[1313/771] w-[82.0625rem] flex-none origin-top-right rotate-[30deg] bg-gradient-to-tr from-primary-400 to-primary-700 xl:ml-0 xl:mr-[calc(50%-12rem)]" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+    <div class="-ml-88 aspect-1313/771 w-328.25 flex-none origin-top-right rotate-30 bg-linear-to-tr from-primary-400 to-primary-700 xl:ml-0 xl:mr-[calc(50%-12rem)]" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
   </div>
     {{ if $showHeading }}
     <header class="mx-auto max-w-2xl text-center">

--- a/layouts/partials/sections/testimonials/grid_on_dark.html
+++ b/layouts/partials/sections/testimonials/grid_on_dark.html
@@ -123,13 +123,13 @@
 
 <div class="relative isolate {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   
   <div class="absolute inset-x-0 top-1/2 -z-10 -translate-y-1/2 transform-gpu overflow-hidden opacity-30 blur-3xl" aria-hidden="true">
-    <div class="ml-[max(50%,38rem)] aspect-1313/771 w-[82.0625rem] bg-linear-to-tr from-[{{ $gradientFrom }}] to-[{{ $gradientTo }}]" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+    <div class="ml-[max(50%,38rem)] aspect-1313/771 w-328.25 bg-linear-to-tr from-[{{ $gradientFrom }}] to-[{{ $gradientTo }}]" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
   </div>
   <div class="absolute inset-x-0 top-0 -z-10 flex transform-gpu overflow-hidden pt-32 opacity-25 blur-3xl sm:pt-40 xl:justify-end" aria-hidden="true">
-    <div class="ml-[-22rem] aspect-1313/771 w-[82.0625rem] flex-none origin-top-right rotate-[30deg] bg-linear-to-tr from-[{{ $gradientFrom }}] to-[{{ $gradientTo }}] xl:mr-[calc(50%-12rem)] xl:ml-0" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
+    <div class="-ml-88 aspect-1313/771 w-328.25 flex-none origin-top-right rotate-30 bg-linear-to-tr from-[{{ $gradientFrom }}] to-[{{ $gradientTo }}] xl:mr-[calc(50%-12rem)] xl:ml-0" style="clip-path: polygon(74.1% 44.1%, 100% 61.6%, 97.5% 26.9%, 85.5% 0.1%, 80.7% 2%, 72.5% 32.5%, 60.2% 62.4%, 52.4% 68.1%, 47.5% 58.3%, 45.2% 34.5%, 27.5% 76.7%, 0.1% 64.9%, 17.9% 100%, 27.6% 76.8%, 76.1% 97.7%, 74.1% 44.1%)"></div>
   </div>
   <div class="mx-auto max-w-7xl px-6 lg:px-8">
     {{ if $showHeading }}

--- a/layouts/partials/sections/testimonials/off_white_grid_on_dark.html
+++ b/layouts/partials/sections/testimonials/off_white_grid_on_dark.html
@@ -105,7 +105,7 @@
 
 <div class="{{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   <div class="absolute left-0 right-0 top-0 -z-10 m-auto h-[60%] w-[90%] rounded-full bg-indigo-500 opacity-10 blur-[100px]"></div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/sections/testimonials/side_by_side_on_dark.html
+++ b/layouts/partials/sections/testimonials/side_by_side_on_dark.html
@@ -82,7 +82,7 @@
 
 <section class="{{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-[size:14px_24px]"></div>
+  <div class="absolute inset-0 -z-10 h-full w-full bg-[linear-gradient(to_right,#80808012_1px,transparent_1px),linear-gradient(to_bottom,#80808012_1px,transparent_1px)] bg-size-[14px_24px]"></div>
   <div class="absolute left-0 right-0 top-0 -z-10 m-auto h-[60%] w-[90%] rounded-full bg-indigo-500 opacity-10 blur-[100px]"></div>
   
   <div class="mx-auto max-w-7xl px-6 lg:px-8">

--- a/layouts/partials/sections/testimonials/simple_centered_on_dark.html
+++ b/layouts/partials/sections/testimonials/simple_centered_on_dark.html
@@ -63,7 +63,7 @@
 
 <section class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -73,7 +73,7 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
 
   <div class="absolute inset-0 -z-10 bg-[radial-gradient(45rem_50rem_at_top,{{ $gradientColor }},transparent)] {{ $gradientOpacity }}"></div>

--- a/layouts/partials/sections/testimonials/with_large_avatar.html
+++ b/layouts/partials/sections/testimonials/with_large_avatar.html
@@ -59,7 +59,7 @@
 <section class="{{ $padding }} {{ $bgColor }}">
   <div class="wrapper isolate overflow-hidden ">
     <div class="relative wrapper">
-    <div class="absolute top-0 left-1/2 -z-10 h-[50rem] w-[90rem] -translate-x-1/2 bg-[radial-gradient(50%_100%_at_top,{{ $gradientColor }},white)] {{ $gradientOpacity }} lg:left-36"></div>
+    <div class="absolute top-0 left-1/2 -z-10 h-200 w-360 -translate-x-1/2 bg-[radial-gradient(50%_100%_at_top,{{ $gradientColor }},white)] {{ $gradientOpacity }} lg:left-36"></div>
     <div class="absolute inset-y-0 right-1/2 -z-10 mr-12 w-[150vw] origin-bottom-left skew-x-[-30deg] {{ $skewBgColor }} ring-1 shadow-xl {{ $skewShadowColor }} {{ $skewRingColor }} sm:mr-20 md:mr-0 lg:right-full lg:-mr-36 lg:origin-center"></div>
     <figure class="grid grid-cols-1 items-center gap-x-6 gap-y-8 lg:gap-x-10">
       <div class="relative col-span-2 lg:col-start-1 lg:row-start-2">

--- a/layouts/partials/sections/testimonials/with_large_avatar_on_dark.html
+++ b/layouts/partials/sections/testimonials/with_large_avatar_on_dark.html
@@ -58,7 +58,7 @@
 
 <section class="relative isolate overflow-hidden {{ $bgColor }} {{ $padding }}">
   <!-- Background pattern -->
-  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 [mask-image:radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
+  <svg class="absolute inset-0 -z-10 h-full w-full stroke-white/10 mask-[radial-gradient(100%_100%_at_top_right,white,transparent)]" aria-hidden="true">
     <defs>
       <pattern id="983e3e4c-de6d-4c3f-8d64-b9761d1534cc" width="200" height="200" x="50%" y="-1" patternUnits="userSpaceOnUse">
         <path d="M.5 200V.5H200" fill="none" />
@@ -68,11 +68,11 @@
   </svg>
   
   <div class="absolute left-[calc(50%-4rem)] top-10 -z-10 transform-gpu blur-3xl sm:left-[calc(50%-18rem)] lg:left-48 lg:top-[calc(50%-30rem)] xl:left-[calc(50%-24rem)]" aria-hidden="true">
-    <div class="aspect-[1108/632] w-[69.25rem] bg-gradient-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
+    <div class="aspect-1108/632 w-277 bg-linear-to-r from-[#80caff] to-[#4f46e5] opacity-20" style="clip-path: polygon(73.6% 51.7%, 91.7% 11.8%, 100% 46.4%, 97.4% 82.2%, 92.5% 84.9%, 75.7% 64%, 55.3% 47.5%, 46.5% 49.4%, 45% 62.9%, 50.3% 87.2%, 21.3% 64.1%, 0.1% 100%, 5.4% 51.1%, 21.4% 63.9%, 58.9% 0.2%, 73.6% 51.7%)"></div>
   </div>
 
   <div class="relative mx-auto max-w-2xl py-24 sm:py-32 lg:max-w-4xl">
-    <div class="absolute top-0 left-1/2 -z-10 h-[50rem] w-[90rem] -translate-x-1/2 bg-[radial-gradient(50%_100%_at_top,{{ $gradientColor }},transparent)] {{ $gradientOpacity }} lg:left-36"></div>
+    <div class="absolute top-0 left-1/2 -z-10 h-200 w-360 -translate-x-1/2 bg-[radial-gradient(50%_100%_at_top,{{ $gradientColor }},transparent)] {{ $gradientOpacity }} lg:left-36"></div>
     <div class="absolute inset-y-0 right-1/2 -z-10 mr-12 w-[150vw] origin-bottom-left skew-x-[-30deg] {{ $skewBgColor }} ring-1 shadow-xl {{ $skewShadowColor }} {{ $skewRingColor }} sm:mr-20 md:mr-0 lg:right-full lg:-mr-36 lg:origin-center"></div>
     <figure class="grid grid-cols-1 items-center gap-x-6 gap-y-8 lg:gap-x-10">
       <div class="relative col-span-2 lg:col-start-1 lg:row-start-2">

--- a/layouts/partials/sliders/custom-cards-slider/card.html
+++ b/layouts/partials/sliders/custom-cards-slider/card.html
@@ -25,7 +25,7 @@ PARAMETERS:
     <a href="{{ $resolvedUrl }}" class="block group" tabindex="-1" aria-hidden="true">
     {{ end }}
       {{ with $image }}
-      <div class="relative w-full aspect-[354/500] rounded-xl overflow-hidden bg-gray-100">
+      <div class="relative w-full aspect-354/500 rounded-xl overflow-hidden bg-gray-100">
         {{ partial "components/media/lazyimg.html" (dict "src" . "alt" $imageAlt "class" "absolute inset-0 w-full h-full object-cover transition-transform duration-300 group-hover:scale-105" "figureClass" "absolute inset-0" "width" "354" "height" "500" "nativeLazy" true) }}
       </div>
       {{ end }}

--- a/layouts/partials/table-of-contents.html
+++ b/layouts/partials/table-of-contents.html
@@ -28,8 +28,8 @@
 
 {{ if $headers }}
   {{ $baseClass := "toc-dropdown-container" }}
-  {{ $positionClass := "top-[5rem] sm:top-[5.25rem] fixed left-0 right-0" }}
-  {{ $appearanceClass := "surface-primary border-y border-gray-primary shadow-sm z-40 py-3" }}
+  {{ $positionClass := "top-20 sm:top-21 fixed left-0 right-0" }}
+  {{ $appearanceClass := "surface-primary border-y border-gray-primary shadow-xs z-40 py-3" }}
   {{ $transitionClass := "transition-transform duration-300 transform -translate-y-full opacity-0" }}
   {{ $allClasses := printf "%s %s %s %s %s" $baseClass $positionClass $appearanceClass $transitionClass $class }}
   
@@ -107,7 +107,7 @@
         if (dynamicDropdown) return dynamicDropdown;
 
         dynamicDropdown = document.createElement('ul');
-        dynamicDropdown.className = 'fixed surface-primary border border-gray-primary rounded-md shadow-lg max-h-60 overflow-y-auto hidden z-[9999]';
+        dynamicDropdown.className = 'fixed surface-primary border border-gray-primary rounded-md shadow-lg max-h-60 overflow-y-auto hidden z-9999';
         dynamicDropdown.innerHTML = optionsContainer.querySelector('ul').innerHTML;
         
         // Add event listeners to the new list items

--- a/layouts/shortcodes/content-split-with-image.html
+++ b/layouts/shortcodes/content-split-with-image.html
@@ -133,7 +133,7 @@
     4. JSON DATA ONLY (structured data blocks - no markers needed):
     {{< content-split-with-image
         heading="By the Numbers"
-        backgroundColor="bg-gradient-to-br from-blue-50 to-indigo-100"
+        backgroundColor="bg-linear-to-br from-blue-50 to-indigo-100"
         image="/images/statistics.jpg"
         imageAlt="Platform statistics"
         imageClass="rounded-lg shadow-lg"

--- a/layouts/shortcodes/discussion-op.html
+++ b/layouts/shortcodes/discussion-op.html
@@ -86,7 +86,7 @@
             {{ end }}
 
             {{ if $badge }}
-              <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800">
+              <span class="inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium bg-amber-100 text-amber-800">
                 {{ $badge }}
               </span>
             {{ end }}

--- a/layouts/shortcodes/discussion-reply.html
+++ b/layouts/shortcodes/discussion-reply.html
@@ -91,7 +91,7 @@
         {{ end }}
 
         {{ if $badge }}
-          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800">
+          <span class="inline-flex items-center px-2 py-0.5 rounded-sm text-xs font-medium bg-amber-100 text-amber-800">
             {{ $badge }}
           </span>
         {{ end }}

--- a/layouts/shortcodes/hero-grid-with-assets.html
+++ b/layouts/shortcodes/hero-grid-with-assets.html
@@ -16,7 +16,7 @@
     promoCardTitle="Free Report"
     promoCardDescription="Get your free AI visibility report"
     promoCardLink="/report/"
-    backgroundPattern="bg-gradient-to-b from-primary-50/50 to-white"
+    backgroundPattern="bg-linear-to-b from-primary-50/50 to-white"
     theme="light"
     padding="py-24 sm:py-32"
   >}}

--- a/layouts/shortcodes/hero-simple-centered.html
+++ b/layouts/shortcodes/hero-simple-centered.html
@@ -51,7 +51,7 @@
   - typewriterPause: Pause duration between word cycles in milliseconds (default: 2000)
   - typewriterColor: Tailwind CSS color class for animated text (default: "text-indigo-600")
   - typewriterWordAlternatives: Comma-separated list of alternative words for typewriter effect (optional)
-  - imgBgClass: Background class for image container (default: "bg-[linear-gradient(205deg,_theme(colors.primary.100)_66.27%,_theme(colors.primary.300)_99.99%)]")
+  - imgBgClass: Background class for image container (default: "bg-[linear-gradient(205deg,var(--color-primary-100)_66.27%,var(--color-primary-300)_99.99%)]")
 */ -}}
 
 {{/* Simple Centered Hero Shortcode */}}

--- a/layouts/shortcodes/latest-posts.html
+++ b/layouts/shortcodes/latest-posts.html
@@ -21,7 +21,7 @@ Usage:
 <section class="{{ $darkClass }} my-24 sm:my-32">
     <div class="section-bg-light dark:section-bg-dark relative">
         <div class="wrapper mx-auto max-w-2xl px-4 lg:max-w-7xl lg:px-8">
-            <div class="mx-auto mb-[4.25rem] max-w-2xl text-center">
+            <div class="mx-auto mb-17 max-w-2xl text-center">
                 <h2 class="text-balance text-4xl font-semibold text-heading tracking-tight sm:text-5xl">{{ $heading }}</h2>
                 {{ if $description }}
                     <p class="mt-2 text-lg/8 text-secondary prose-links">{{ $description | safeHTML }}</p>

--- a/layouts/tags/list.html
+++ b/layouts/tags/list.html
@@ -48,9 +48,9 @@
             <h2 class="text-3xl font-bold text-gray-900 border-b border-gray-200 pb-4">{{ $letter }}</h2>
             <ul class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {{ range $tagsInLetter }}
-                <li class="group relative rounded-xl border border-gray-200 bg-white p-6 shadow-sm hover:shadow-md transition-shadow">
+                <li class="group relative rounded-xl border border-gray-200 bg-white p-6 shadow-xs hover:shadow-md transition-shadow">
                   <h3 class="text-lg font-semibold text-gray-900">
-                    <a href="{{ "/tags/" | relLangURL }}{{ .name | urlize }}/" class="hover:text-indigo-600 focus:outline-none">
+                    <a href="{{ "/tags/" | relLangURL }}{{ .name | urlize }}/" class="hover:text-indigo-600 focus:outline-hidden">
                       <span class="absolute inset-0" aria-hidden="true"></span>
                       {{ .name }}
                     </a>

--- a/package.json.example
+++ b/package.json.example
@@ -9,12 +9,11 @@
     "clean": "rm -rf public resources"
   },
   "devDependencies": {
-    "@tailwindcss/aspect-ratio": "^0.4.2",
-    "@tailwindcss/forms": "^0.5.7",
-    "@tailwindcss/typography": "^0.5.10",
-    "autoprefixer": "^10.4.16",
+    "@tailwindcss/forms": "^0.5.11",
+    "@tailwindcss/postcss": "^4.3.3",
+    "@tailwindcss/typography": "^0.5.20",
     "postcss": "^8.4.31",
     "postcss-cli": "^10.1.0",
-    "tailwindcss": "^3.3.5"
+    "tailwindcss": "^4.3.3"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,8 +1,14 @@
+/*
+  Tailwind v4: `@tailwindcss/postcss` replaces the `tailwindcss` plugin and has
+  `@import` inlining plus vendor prefixing (via Lightning CSS) built in, so
+  `postcss-import` and `autoprefixer` are no longer needed.
+
+  The Tailwind config is named from CSS via `@config` in assets/css/main.css, not
+  passed here. Consuming projects generally build through their own gulp/PostCSS
+  setup and never read this file.
+*/
 module.exports = {
   plugins: {
-    tailwindcss: {
-      config: './tailwind.config.js'
-    },
-    autoprefixer: {},
+    '@tailwindcss/postcss': {},
   },
 }

--- a/theme.toml
+++ b/theme.toml
@@ -1,7 +1,13 @@
 name = 'FlowHunt Boilerplate'
-description = 'A clean and minimal Hugo boilerplate theme'
-version = '1.0.0'
+description = 'A clean and minimal Hugo boilerplate theme. REQUIRES Tailwind CSS v4 (>=4.3.3) — see README.'
+version = '2.0.0'
 license = 'MIT'
+
+# Tailwind CSS v4 is required as of version 2.0.0. A project still on v3 will fail
+# to build against this theme: the stylesheets use @import "tailwindcss", @config,
+# @utility and @reference, none of which exist in v3.
+# Migration guide: README.md -> "Migrating a project to Tailwind v4"
+# Last v3-compatible theme commit: 2517448
 
 # The home page of the theme, where the source can be found
 homepage = 'https://github.com/qualityunit/repo'


### PR DESCRIPTION
**Draft — long-running migration branch. Commits land phase by phase; do not merge until all phases are done and verified.**

Migrates the boilerplate theme from Tailwind CSS 3.4.17 to 4.3.3.

## Why

- The colour palette is declared twice (theme + each project config). v4's CSS-first `@theme` eventually removes that duplication.
- v4's Oxide engine: ~3.8x faster full builds, ~182x faster no-op rebuilds. Consumers build up to 29 languages in CI.
- v3.4 is LTS-only (`v3-lts` dist-tag). Dependabot flags it on every sweep.

## Blast radius

This theme is a submodule for LiveAgent, Post Affiliate Pro, FlowHunt, AmICited and smaller sites. **Submodules are pinned by commit SHA**, so nothing changes for a consumer until it bumps its own pointer. The hazard is a consumer bumping the pointer *without* upgrading its own `package.json` — a later phase adds a loud guard (README, `theme.toml`, header comment in `main.css`) so that failure is legible.

Rollout is pinned sequencing: this PR merges first, then LiveAgent bumps pointer + `package.json` in one PR, then the other consumers at their own pace.

## Approach

Pixel-perfect for this migration — a compatibility layer restores v3 defaults (`border-color`, ring width/colour, placeholder colour, button cursor, `dialog` margin, `hover:` without the `(hover: hover)` media query). Every entry is marked `TODO(v4-compat)` so later PRs can remove them one at a time.

Rejected: the upgrade tool's rewrite of `tailwind.config.js` into CSS-first `@theme`. That would collapse the per-site config model. This migration keeps the JS configs and loads them via `@config`; CSS-first is a separate, coordinated follow-up.

## Phases

- [x] **1 — Unblock the codemod.** `bg-opacity-10` in `@apply`; drop `@tailwindcss/aspect-ratio` usage.
- [ ] 2 — Run `npx @tailwindcss/upgrade`, review the diff.
- [ ] 3 — Build pipeline: `@tailwindcss/postcss`, drop `postcss-import` / `autoprefixer` / `@tailwindcss/aspect-ratio`.
- [ ] 4 — Config wiring: `@import "tailwindcss"`, `@config`, `safelist` -> `@source inline()`, `@layer utilities` -> `@utility`.
- [ ] 5 — `@reference` for standalone stylesheets that use `@apply` without importing Tailwind (hard failure in v4).
- [ ] 6 — Compatibility layer.
- [ ] 7 — Measure real old-browser exposure on the built CSS.
- [ ] 8 — Consumer guard.
- [ ] 9 — Verification: CSS diff vs. v3 baseline, Hugo build, screenshot regression, manual review.

## Notes for reviewers of other consumer repos

Two things bit us here and will bite you too:

1. **Standalone CSS compiled by Tailwind without `@import "tailwindcss"` but using `@apply`** is legal in v3 and a hard failure in v4. It needs `@reference`.
2. **Dropping `@tailwindcss/aspect-ratio` is not a pure class rename.** The plugin also styled the direct child (`.aspect-w-N > * { position:absolute; inset:0 }`); native `aspect-ratio` does not. Where the child is a wrapper (e.g. `lazyimg`'s `<figure>`), it needs explicit sizing or images collapse.

Also worth knowing, independent of this work: `gulpfile.js` calls `tailwindcss()` with no argument, so the config resolves from cwd — the **consumer's** root `tailwind.config.js`. `themes/boilerplate/tailwind.config.js` is never read by a consumer that has its own, and `postcss.config.js` is bypassed entirely. Verified by renaming the theme config away and getting a byte-identical build.

## Verification so far

Phase 1: `gulp css` and `hugo --gc --minify --configDir ./config_en` (1452 pages) pass. Rule-level CSS diff against the v3 baseline is 30 rules, all expected; `bg-opacity-10` -> `/10` produces an identical computed value.

Full verification (screenshots, browser-exposure measurement) lands in phase 9 before this leaves draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
