### PR TITLE
fix(site-audit): repair NaN embeddings from MPS instead of caching them

### DIFF
--- a/scripts/build_content.sh
+++ b/scripts/build_content.sh
@@ -24,6 +24,33 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 THEME_DIR="$(dirname "$SCRIPT_DIR")"
 HUGO_ROOT="$(dirname "$(dirname "$THEME_DIR")")"
 
+# Load scripts/.env so the settings documented in .env.example actually apply.
+# Both this script (MAX_PARALLEL_EMBED) and the Python steps it spawns
+# (HF_TOKEN, FLOWHUNT_API_KEY) read these from the environment, and only
+# three of the Python scripts call load_dotenv() themselves. Exporting here
+# covers every step uniformly. Values already set in the calling shell win,
+# so `MAX_PARALLEL_EMBED=1 ./build_content.sh` still overrides the file.
+if [ -f "${SCRIPT_DIR}/.env" ]; then
+    while IFS= read -r env_line || [ -n "$env_line" ]; do
+        # Skip blanks and comments; only accept KEY=value lines
+        [[ "$env_line" =~ ^[[:space:]]*# ]] && continue
+        [[ "$env_line" =~ ^[[:space:]]*$ ]] && continue
+        [[ "$env_line" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]] || continue
+
+        env_key="${BASH_REMATCH[1]}"
+        env_val="${BASH_REMATCH[2]}"
+        # Strip surrounding quotes, if any
+        env_val="${env_val%\"}"; env_val="${env_val#\"}"
+        env_val="${env_val%\'}"; env_val="${env_val#\'}"
+
+        # Don't clobber anything the caller already exported
+        if [ -z "${!env_key:-}" ]; then
+            export "$env_key=$env_val"
+        fi
+    done < "${SCRIPT_DIR}/.env"
+    unset env_line env_key env_val
+fi
+
 # Colors for output
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'

--- a/scripts/embedding_cache.py
+++ b/scripts/embedding_cache.py
@@ -47,6 +47,71 @@ def _hf_login():
 _hf_login()
 
 
+def nonfinite_mask(embs):
+    """Boolean mask of rows containing NaN or Inf."""
+    embs = np.asarray(embs)
+    if embs.ndim != 2:
+        return np.zeros(len(embs), dtype=bool)
+    return ~np.isfinite(embs).all(axis=1)
+
+
+def repair_nonfinite(embs, texts, embedder, *, batch_size=32, desc="Embeddings"):
+    """Re-encode NaN/Inf rows on CPU; zero out whatever stays broken.
+
+    Apple's MPS backend intermittently returns non-finite vectors for
+    embeddinggemma — same texts and same fp32 weights give 4/6 NaN rows on
+    mps and 0/6 on cpu, on an otherwise idle machine. One poisoned vector is
+    enough to NaN a whole site centroid and abort faiss k-means, so repair
+    before the value reaches a caller or the cache.
+
+    Returns (embs, unrepaired_mask). Rows still non-finite after the CPU
+    retry are replaced with zeros so downstream maths stays finite; callers
+    should refuse to persist them so the next run can try again.
+    """
+    embs = np.asarray(embs, dtype=np.float32)
+    bad = nonfinite_mask(embs)
+    if not bad.any():
+        return embs, bad
+
+    bad_idx = np.flatnonzero(bad)
+    print(f"{desc}: {len(bad_idx)} non-finite embedding(s) detected → retrying on CPU")
+
+    original_device = None
+    try:
+        original_device = str(embedder.device)
+    except AttributeError:
+        pass
+
+    if original_device is not None and not original_device.startswith("cpu"):
+        try:
+            embedder.to("cpu")
+            retry = embedder.encode(
+                [texts[i] for i in bad_idx],
+                batch_size=batch_size,
+                show_progress_bar=False,
+                normalize_embeddings=True,
+            )
+            embs[bad_idx] = np.asarray(retry, dtype=np.float32)
+        except Exception as e:
+            print(f"{desc}: CPU retry failed ({e})")
+        finally:
+            try:
+                embedder.to(original_device)
+            except Exception:
+                pass
+    else:
+        print(f"{desc}: already on CPU — no fallback device available")
+
+    unrepaired = nonfinite_mask(embs)
+    if unrepaired.any():
+        print(f"{desc}: {int(unrepaired.sum())} embedding(s) still non-finite → zeroed, not cached")
+        embs[unrepaired] = 0.0
+    else:
+        print(f"{desc}: all {len(bad_idx)} repaired on CPU")
+
+    return embs, unrepaired
+
+
 def cache_path_for(hugo_root, lang, model_name):
     slug = model_name.replace("/", "_").replace("-", "_")
     return Path(hugo_root) / ".audit_cache" / f"{lang}__{slug}.npz"
@@ -268,6 +333,8 @@ class EmbeddingCache:
             embs = embedder.encode(texts, batch_size=batch_size,
                                    show_progress_bar=show_progress_bar,
                                    normalize_embeddings=True)
+            embs, _ = repair_nonfinite(embs, texts, embedder,
+                                       batch_size=batch_size, desc=desc)
             self._release(embedder, embedder_or_model)
             return np.asarray(embs, dtype=np.float32)
 
@@ -279,6 +346,7 @@ class EmbeddingCache:
                 seen_keys[k] = t
 
         cached: dict = {}
+        poisoned = 0
         unique = list(seen_keys)
         for start in range(0, len(unique), 900):
             chunk = unique[start:start + 900]
@@ -289,7 +357,17 @@ class EmbeddingCache:
                 [self.model, *chunk],
             ).fetchall()
             for key, dim, blob in rows:
-                cached[key] = np.frombuffer(blob, dtype=np.float32, count=dim)
+                vec = np.frombuffer(blob, dtype=np.float32, count=dim)
+                # Vectors poisoned by an earlier run (see repair_nonfinite)
+                # count as misses, so a stale NaN self-heals instead of
+                # crashing every future run that reads it.
+                if not np.isfinite(vec).all():
+                    poisoned += 1
+                    continue
+                cached[key] = vec
+
+        if poisoned:
+            print(f"{desc}: {poisoned} cached vector(s) were non-finite → discarded, re-embedding")
 
         missing = [k for k in unique if k not in cached]
         if missing:
@@ -301,10 +379,16 @@ class EmbeddingCache:
                                        show_progress_bar=show_progress_bar,
                                        normalize_embeddings=True)
             new_embs = np.asarray(new_embs, dtype=np.float32)
+            new_embs, unrepaired = repair_nonfinite(new_embs, missing_texts, embedder,
+                                                    batch_size=batch_size, desc=desc)
             rows_to_insert = []
-            for k, vec in zip(missing, new_embs):
+            for pos, (k, vec) in enumerate(zip(missing, new_embs)):
                 vec32 = vec.astype(np.float32)
                 cached[k] = vec32
+                # Persisting a NaN would make this failure permanent for every
+                # later run; leave it out so the next one re-embeds instead.
+                if unrepaired[pos]:
+                    continue
                 rows_to_insert.append((self.model, k, int(vec32.shape[0]), vec32.tobytes()))
             self.conn.executemany(
                 "INSERT OR REPLACE INTO embeddings (model, text_hash, dim, vector) VALUES (?, ?, ?, ?)",
@@ -349,7 +433,10 @@ class EmbeddingCache:
                 [self.model, *chunk],
             ).fetchall()
             for key, dim, blob in rows:
-                cached[key] = np.frombuffer(blob, dtype=np.float32, count=dim)
+                vec = np.frombuffer(blob, dtype=np.float32, count=dim)
+                if not np.isfinite(vec).all():
+                    continue  # treat as a miss; see repair_nonfinite
+                cached[key] = vec
 
         missing = [k for k in unique if k not in cached]
         if missing:
@@ -361,10 +448,17 @@ class EmbeddingCache:
                     f"{desc}: compute_missing returned {new_embs.shape[0]} vectors "
                     f"for {len(missing)} cache misses"
                 )
+            bad = nonfinite_mask(new_embs)
+            if bad.any():
+                print(f"{desc}: {int(bad.sum())} non-finite vector(s) → zeroed, not cached")
+                new_embs = new_embs.copy()
+                new_embs[bad] = 0.0
             rows_to_insert = []
-            for k, vec in zip(missing, new_embs):
+            for pos, (k, vec) in enumerate(zip(missing, new_embs)):
                 vec32 = vec.astype(np.float32)
                 cached[k] = vec32
+                if bad[pos]:
+                    continue
                 rows_to_insert.append((self.model, k, int(vec32.shape[0]), vec32.tobytes()))
             self.conn.executemany(
                 "INSERT OR REPLACE INTO embeddings (model, text_hash, dim, vector) VALUES (?, ?, ?, ?)",

--- a/scripts/generate_site_audit.py
+++ b/scripts/generate_site_audit.py
@@ -47,7 +47,7 @@ import umap
 from bs4 import BeautifulSoup
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from embedding_cache import EmbeddingCache, shared_sqlite_cache_path
+from embedding_cache import EmbeddingCache, nonfinite_mask, shared_sqlite_cache_path
 
 DEFAULT_MODEL = "google/embeddinggemma-300m"
 DEFAULT_MAX_CHARS = 2000
@@ -446,6 +446,21 @@ def main():
     embeddings = cache.encode(args.model, embed_texts, batch_size=32, show_progress_bar=True,
                               desc="Page embeddings")
     cache.close()
+
+    # Last line of defence: the cache repairs non-finite vectors on CPU, but if
+    # anything slips through, drop those pages instead of letting a single NaN
+    # poison the site centroid and abort faiss k-means 200 lines later.
+    bad = nonfinite_mask(embeddings)
+    if bad.any():
+        print(f"WARNING: dropping {int(bad.sum())} page(s) with non-finite embeddings:")
+        for i in np.flatnonzero(bad):
+            print(f"  - {pages[i]['file_path']}")
+        keep = ~bad
+        pages = [p for p, k in zip(pages, keep) if k]
+        embeddings = embeddings[keep]
+        if not pages:
+            print("No usable embeddings left — aborting.")
+            return
 
     site_centroid = l2_normalize(embeddings.mean(axis=0))
     site_metrics = focus_metrics(embeddings, site_centroid)


### PR DESCRIPTION
## Problem

`generate_site_audit` crashed for most languages:

```
RuntimeError: Error in ... faiss::Clustering::train_encoded ...
Error: '!(std::isfinite(x[i]))' failed: input contains NaN's or Inf's
```

Apple's MPS backend intermittently returns non-finite vectors for `embeddinggemma-300m`. Same texts, same fp32 weights, otherwise idle machine:

| device | non-finite rows |
|---|---|
| mps | 4 / 6 |
| cpu | 0 / 6 |

Those vectors went straight into the shared SQLite cache, so a poisoned language failed on **every** later run — the crash survived re-runs because the NaN came back as a cache hit (`Page embeddings: all 1379 texts from cache` → immediate crash).

One bad vector is enough to break a whole language: it NaNs `embeddings.mean(axis=0)`, so every metric in `site_metrics.json` is NaN. That file is written *before* the crash, and `NaN` is not valid JSON — the `/audit` page's `fetch()` fails to parse it, while `scatterplot.json` keeps stale data because the script dies before writing it.

The poisoned count was growing with each attempted run: 130 → 692.

## Fix

- **`repair_nonfinite()`** — after each encode, re-run the non-finite rows on CPU, then restore the model to its original device.
- **Never persist a vector that stays non-finite** — so the next run retries instead of the failure becoming permanent.
- **Treat non-finite cached vectors as misses** — a poisoned cache self-heals rather than failing forever. No manual DB purge needed.
- **`generate_site_audit`** — if anything still slips through, drop those pages and name the files, instead of aborting the language deep inside faiss.
- Same read/write guards in `encode_by_keys()` (image embeddings).

## Also: `build_content.sh` now loads `scripts/.env`

`.env.example` documents `MAX_PARALLEL_EMBED` as a `.env` setting, but nothing in bash ever read the file — only three Python scripts call `load_dotenv()`. The cap is read in bash (`${MAX_PARALLEL_EMBED:-3}`), so setting it in `.env` silently did nothing and three concurrent workers ran anyway, exhausting RAM on a 32 GB machine and pushing 27 GB into swap.

Parsed line by line rather than `source`d, so a stray backtick in a file that holds API keys can't execute. Values already exported by the caller still win, so `MAX_PARALLEL_EMBED=1 ./build_content.sh` keeps working.

## Verification

Full run across all 29 languages:

- poisoned vectors in cache: **692 → 0**
- `site_metrics.json` for every language: parses, no `NaN`
- `scatterplot.json` regenerated for every language (previously stale since June 22)
- zero crashes; repairs logged as `4 non-finite embedding(s) detected → retrying on CPU` / `all 4 repaired on CPU`
- `bash -n` clean; `.env` loader tested for both the file value and the shell override

## Risk

Tier 3 — `themes/boilerplate` scripts, affects all downstream sites. Build-time only; no runtime or template changes.