### PR TITLE
[4216] - fix validation error and switch buttons of the tags

### DIFF
--- a/assets/js/components/item-toggle.js
+++ b/assets/js/components/item-toggle.js
@@ -91,8 +91,12 @@ function getHiddenItemClass(containerType) {
     return classMap[containerType] || classMap['items'];
 }
 
-// Initialize when DOM is ready
-document.addEventListener('DOMContentLoaded', initItemToggle);
+// Script may be inserted after DOMContentLoaded already fired
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initItemToggle);
+} else {
+    initItemToggle();
+}
 
 // Re-initialize for dynamically added content
 window.reinitItemToggle = initItemToggle;

--- a/layouts/partials/components/tooltip/tooltip.html
+++ b/layouts/partials/components/tooltip/tooltip.html
@@ -26,12 +26,12 @@
   <span class="md:group md:relative"><span class="pr-2">{{ .content }}</span><button type="button" class="inline-flex focus:outline-none align-text-bottom">
       {{ partial (printf "icons/%s" $icon) (printf "%s cursor-pointer tooltip-trigger %s" $sizeIcon $colorIcon) }}
     </button>
-    <div
+    <span
       class="pointer-events-none absolute left-4 right-4 md:left-1/2 md:right-auto bottom-4 md:bottom-auto {{ $tooltipPosition }} z-[9999] md:w-72 rounded-md bg-gray-900 px-4 py-3 text-sm text-white font-normal opacity-0 shadow-xl transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100 tooltip-content leading-relaxed"
       data-tooltip
       role="tooltip"
     >
       {{ $text }}
-    </div>
+    </span>
   </span>
 </div>

--- a/layouts/partials/sections/tags/tags.html
+++ b/layouts/partials/sections/tags/tags.html
@@ -54,16 +54,16 @@
     <!-- Show more/less buttons -->
     {{ if gt $tagsCount $maxTags }}
         <button type="button" class="show-more-btn text-secondary font-semibold text-xs tracking-[0.216px] cursor-pointer" data-container="{{ $containerId }}" data-container-type="tags">
-            <div class="flex items-center gap-1">
+            <span class="inline-flex items-center gap-1">
                 <span>{{ (printf "+%d %s" (sub $tagsCount $maxTags) (i18n "show_more" | default "more")) }}</span>
                 {{ partial "icons/chevron-down" "size-5 text-secondary" }}
-            </div>
+            </span>
         </button>
         <button type="button" class="show-less-btn text-secondary font-semibold text-xs tracking-[0.216px] cursor-pointer hidden" data-container="{{ $containerId }}" data-container-type="tags">
-            <div class="flex items-center gap-1">
+            <span class="inline-flex items-center gap-1">
                 <span>{{ i18n "show_less" | default "Show less" }}</span>
                 {{ partial "icons/chevron-up" "size-5 text-secondary" }}
-            </div>
+            </span>
         </button>
     {{ end }}
 </div>


### PR DESCRIPTION
**Changes proposed in this Pull Request**

Changed button/span contain only phrasing content - no nested div.
Fixed switch show/more buttons for tags

**Testing instructions**
- Go to /blog/10-types-of-affiliate-marketing-content-you-can-use-in-2021/, click "+N more", inspect .show-more-btn markup and check correct switch of the tags.
- Go to /pricing/, and inspect tooltip in the comparison table.

QualityUnit/web-issues#4216
