### PR TITLE
[4217] - fix invalid role="group" on testimonial article elements

### DIFF
--- a/layouts/partials/sections/testimonials/grid.html
+++ b/layouts/partials/sections/testimonials/grid.html
@@ -114,7 +114,7 @@
             <div class="block sm:hidden">
               {{ if $testimonial.featured }}
                 <!-- Featured testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" aria-label="Featured customer testimonial">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -137,7 +137,7 @@
                 </article>
               {{ else }}
                 <!-- Regular testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" aria-label="Customer testimonial">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -166,7 +166,7 @@
             <div class="hidden sm:block lg:hidden">
               {{ if $testimonial.featured }}
                 <!-- Featured testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" aria-label="Featured customer testimonial">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-tablet-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -189,7 +189,7 @@
                 </article>
               {{ else }}
                 <!-- Regular testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" aria-label="Customer testimonial">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-tablet-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -218,7 +218,7 @@
             <div class="hidden lg:block">
               {{ if $testimonial.featured }}
                 <!-- Featured testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" aria-label="Featured customer testimonial">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col1-desktop-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -241,7 +241,7 @@
                 </article>
               {{ else }}
                 <!-- Regular testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" aria-label="Customer testimonial">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col1-desktop-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -279,7 +279,7 @@
             <div class="block lg:hidden">
               {{ if $testimonial.featured }}
                 <!-- Featured testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" aria-label="Featured customer testimonial">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-tablet-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -302,7 +302,7 @@
                 </article>
               {{ else }}
                 <!-- Regular testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" aria-label="Customer testimonial">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-tablet-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -331,7 +331,7 @@
             <div class="hidden lg:block">
               {{ if $testimonial.featured }}
                 <!-- Featured testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" aria-label="Featured customer testimonial">
                   <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-desktop-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -354,7 +354,7 @@
                 </article>
               {{ else }}
                 <!-- Regular testimonial -->
-                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial">
+                <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" aria-label="Customer testimonial">
                   <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col2-desktop-{{ $index }}">
                     <p class="prose-links">"{{ $testimonial.quote | safeHTML }}"</p>
                   </blockquote>
@@ -388,7 +388,7 @@
           {{ if eq (mod $index 3) 2 }}
             {{ if $testimonial.featured }}
               <!-- Featured testimonial -->
-              <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Featured customer testimonial">
+              <article class="break-inside-avoid rounded-xl surface-primary ring-2 ring-gray-200 border-gray-primary shadow-lg" aria-label="Featured customer testimonial">
                 <blockquote class="p-6 text-lg font-semibold tracking-tight text-heading sm:p-10 sm:text-xl/8" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col3-{{ $index }}">
                   <p>"{{ $testimonial.quote }}"</p>
                 </blockquote>
@@ -411,7 +411,7 @@
               </article>
             {{ else }}
               <!-- Regular testimonial -->
-              <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" role="group" aria-label="Customer testimonial">
+              <article class="break-inside-avoid rounded-xl surface-primary p-6 ring-1 ring-gray-200 border-gray-primary shadow-lg" aria-label="Customer testimonial">
                 <blockquote class="text-secondary" cite="{{ $testimonial.personName }}" aria-describedby="testimonial-author-col3-{{ $index }}">
                   <p>"{{ $testimonial.quote }}"</p>
                 </blockquote>


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Removed invalid role="group" on testimonial article elements

**Testing instructions**
- Go to any page using {{< testimonial-grid >}} (e.g. /pricing/)
- Inspect a testimonial card
- Check the role attribute on

QualityUnit/web-issues#4217
