### PR TITLE
[4218] - change ul to div for validate in author, faq and glossary list pages

### DIFF
--- a/layouts/author/list.html
+++ b/layouts/author/list.html
@@ -103,7 +103,7 @@
         {{ if $authorsInCategory }}
           <div id="{{ $letter }}" class="py-10">
             <h2 class="text-5xl font-semibold text-heading">{{ $letter }}</h2>
-            <ul class="mt-8 grid gap-16 sm:grid-cols-2 lg:grid-cols-3">
+            <div class="mt-8 grid gap-16 sm:grid-cols-2 lg:grid-cols-3">
               {{ range sort $authorsInCategory "Title" }}
                 {{ partial "components/cards/post_card_with_image.html" (
                   dict "page" .
@@ -119,7 +119,7 @@
                   "descriptionLength" $descriptionLength
                 ) }}
               {{ end }}
-            </ul>
+            </div>
           </div>
         {{ end }}
       {{ end }}

--- a/layouts/faq/list.html
+++ b/layouts/faq/list.html
@@ -112,7 +112,7 @@
         {{ if $termsInCategory }}
           <div id="{{ $letter }}" class="my-10">
             <h2 class="text-5xl font-semibold text-heading">{{ $letter }}</h2>
-            <ul class="mt-8 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
+            <div class="mt-8 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
               {{ range sort $termsInCategory "Title" }}
                 {{ partial "components/cards/post_card_with_image.html" (
                   dict "page" . "cardHeight" $cardHeight
@@ -122,7 +122,7 @@
                   "iconClass" "w-5 h-5 text-gray-900 shrink-0"
                 ) }}
               {{ end }}
-            </ul>
+            </div>
           </div>
         {{ end }}
       {{ end }}

--- a/layouts/glossary/list.html
+++ b/layouts/glossary/list.html
@@ -90,7 +90,7 @@
         {{ if $termsInCategory }}
           <div id="{{ $letter }}" class="my-10">
             <h2 class="text-5xl font-semibold text-heading">{{ $letter }}</h2>
-            <ul class="mt-8 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
+            <div class="mt-8 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
               {{ range sort $termsInCategory "Title" }}
                 {{ partial "components/cards/post_card_with_image.html" (
                   dict "page" . "cardHeight" $cardHeight
@@ -98,7 +98,7 @@
                   "showDateReadingTime" false
                 ) }}
               {{ end }}
-            </ul>
+            </div>
           </div>
         {{ end }}
       {{ end }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Changed ul to div for validate in author, faq and glossary list pages

**Testing instructions**
- Go to author, faq and glossary list pages and check html tag (should be div instead ul) 

QualityUnit/web-issues#4218
