### PR TITLE
fix(404): keep /404.html out of the index

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,10 @@
 <!-- Favicon -->
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/favicon.ico">
-{{ if .Params.private }}
+{{/* /404.html itself answers with HTTP 200, so without this it is a crawlable,
+     indexable page — a "this page no longer exists" result in the SERP. The 404
+     responses it is served for are never indexed anyway; the status code decides. */}}
+{{ if or .Params.private (eq .Kind "404") }}
 <meta name="robots" content="noindex, nofollow">
 {{ end }}
 


### PR DESCRIPTION
## What

One-line condition change in `layouts/partials/head.html`:

```diff
-{{ if .Params.private }}
+{{ if or .Params.private (eq .Kind "404") }}
 <meta name="robots" content="noindex, nofollow">
 {{ end }}
```

## Why

`/404.html` is a regular URL that answers with **HTTP 200**, so it is crawlable and indexable — verified on production (`https://www.liveagent.com/404.html` currently ships no robots meta at all; `qualityunit.com/404.html` even says `index, follow`). Left alone it becomes a "This page no longer exists" result in the SERP and noise in Search Console.

The 404 responses the page is *served for* need no help — the status code keeps those URLs out of the index, meta tags are irrelevant there.

A `robots.txt` Disallow was deliberately not used: it would stop Google from crawling the page and therefore from ever seeing the `noindex`, while the URL could still be indexed by reference. Sitemap and `index.json` already exclude the 404 page (Hugo omits kind `404`) — checked on production.

## Note

Not build-verified locally (no Hugo run in this session); it is a template condition on `.Kind`, which the 404 page already uses in consumer sites' partials.

Ref: QualityUnit/web-issues#4213

🤖 Generated with [Claude Code](https://claude.com/claude-code)