### PR TITLE
[4223] - fix datetime in post-card-wirh-image partial

### DIFF
--- a/layouts/partials/components/cards/post_card_with_image.html
+++ b/layouts/partials/components/cards/post_card_with_image.html
@@ -83,6 +83,7 @@
 
 {{/* Date & Permalink */}}
 {{ $date := partial "helpers/format-date.html" (dict "date" $page.Date) }}
+{{ $isoDate := $page.Date.Format "2006-01-02" }}
 {{ $permalink := $page.RelPermalink }}
 
 {{/* Show date & reading time section */}}
@@ -121,7 +122,7 @@
     <div class="flex items-center gap-4 my-2.5 pt-2">
       <span class="flex items-center text-xs font-normal text-secondary">
         {{ if $page.Date }}
-          <time datetime="{{ $date }}">{{ $date }}</time>
+          <time datetime="{{ $isoDate }}">{{ $date }}</time>
         {{ end }}
         {{ if $page.ReadingTime }}
           {{ if $page.Date }}


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Fixed datetime in post-card-wirh-image partial

**Testing instructions**
- Go to /blog-categories/ or any pages with post_card_with_image component
- Open devtools, find a <time> element in a post card
- Check the datetime attribute value

QualityUnit/web-issues#4223
