### PR TITLE
fix(schema): build JSON-LD image URLs from the static assets CDN

### DIFF
--- a/layouts/partials/functions/get-absolute-static-url.html
+++ b/layouts/partials/functions/get-absolute-static-url.html
@@ -1,0 +1,29 @@
+{{/*
+@function: Get Absolute Static URL
+@description: Returns an absolute URL for a static asset - the CDN domain when staticAssets is
+              enabled, otherwise the site baseURL. Use this wherever an absolute URL is required
+              (structured data, meta tags, feeds), so those URLs stay in sync with the CDN-aware
+              image components.
+@params:
+  - path: Path to the static asset (required)
+@returns: Absolute URL to the static asset. Inputs that are already absolute (http://, https://, //)
+          are returned unchanged.
+@example:
+  {{ $imageUrl := partial "functions/get-absolute-static-url.html" (dict "path" .Params.image) }}
+  {{ $img := dict "@type" "ImageObject" "url" $imageUrl }}
+*/}}
+
+{{ $path := .path }}
+{{ $result := $path }}
+
+{{ if not (or (hasPrefix $path "http://") (hasPrefix $path "https://") (hasPrefix $path "//")) }}
+  {{ $normalized := printf "/%s" (strings.TrimPrefix "/" $path) }}
+  {{ $static := partial "functions/get-static-url.html" (dict "path" $normalized) }}
+  {{ if hasPrefix $static "http" }}
+    {{ $result = $static }}
+  {{ else }}
+    {{ $result = printf "%s%s" site.BaseURL (strings.TrimPrefix "/" $static) }}
+  {{ end }}
+{{ end }}
+
+{{ return $result }}

--- a/layouts/partials/schemaorg/aggregaterating.html
+++ b/layouts/partials/schemaorg/aggregaterating.html
@@ -32,7 +32,7 @@
 {{- $schema := dict "@context" "https://schema.org" "@type" $itemType "name" $itemName "aggregateRating" $rating -}}
 {{- with .url }}{{ $schema = merge $schema (dict "url" .) }}{{ else }}{{ $schema = merge $schema (dict "url" $site.BaseURL) }}{{ end -}}
 {{- with .description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
-{{- with .image }}{{ $schema = merge $schema (dict "image" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .))) }}{{ end -}}
+{{- with .image }}{{ $schema = merge $schema (dict "image" (partial "functions/get-absolute-static-url.html" (dict "path" .))) }}{{ end -}}
 <script type="application/ld+json">
 {{- $schema | jsonify | safeJS -}}
 </script>

--- a/layouts/partials/schemaorg/article.html
+++ b/layouts/partials/schemaorg/article.html
@@ -43,7 +43,7 @@
     {{ if $authorPage }}
       {{ $authorName = $authorPage.Title }}
       {{ with $authorPage.Params.image }}
-        {{ $authorImage = (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) }}
+        {{ $authorImage = (partial "functions/get-absolute-static-url.html" (dict "path" .)) }}
       {{ end }}
       {{ $authorURL = $authorPage.Permalink }}
     {{ end }}
@@ -53,11 +53,11 @@
 {{/* Get article image */}}
 {{ $image := "" }}
 {{ with $page.Params.image }}
-  {{ $image = (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) }}
+  {{ $image = (partial "functions/get-absolute-static-url.html" (dict "path" .)) }}
 {{ else with $page.Params.featured_image }}
-  {{ $image = (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) }}
+  {{ $image = (partial "functions/get-absolute-static-url.html" (dict "path" .)) }}
 {{ else with $site.Params.defaultImage }}
-  {{ $image = (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) }}
+  {{ $image = (partial "functions/get-absolute-static-url.html" (dict "path" .)) }}
 {{ end }}
 
 {{- $authorObj := dict "@type" "Person" "name" $authorName -}}
@@ -66,7 +66,7 @@
 
 {{- $publisher := dict "@type" "Organization" "name" $site.Title "url" $site.BaseURL -}}
 {{- with $site.Params.organization.logo -}}
-  {{- $logo := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $logo := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $publisher = merge $publisher (dict "logo" $logo) -}}
 {{- end -}}
 

--- a/layouts/partials/schemaorg/author.html
+++ b/layouts/partials/schemaorg/author.html
@@ -41,7 +41,7 @@
         {{ if $authorPage }}
             {{ $authorName = $authorPage.Title }}
             {{ with $authorPage.Params.image }}
-                {{ $authorImage = (printf "%s%s" $.Site.BaseURL (strings.TrimPrefix "/" .)) }}
+                {{ $authorImage = (partial "functions/get-absolute-static-url.html" (dict "path" .)) }}
             {{ end }}
             {{ $authorRole = $authorPage.Params.role }}
             {{ $authorDescription = $authorPage.Description | default $authorPage.Params.description }}

--- a/layouts/partials/schemaorg/course.html
+++ b/layouts/partials/schemaorg/course.html
@@ -45,13 +45,13 @@
 {{ if and $name $description }}
 {{- $providerOrg := dict "@type" "Organization" "name" (.provider | default $site.Title) "url" $site.BaseURL -}}
 {{- with $site.Params.organization.logo -}}
-  {{- $logo := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $logo := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $providerOrg = merge $providerOrg (dict "logo" $logo) -}}
 {{- end -}}
 
 {{- $schema := dict "@context" "https://schema.org" "@type" "Course" "name" $name "description" $description "provider" $providerOrg "url" ($page.Permalink | default $site.BaseURL) -}}
 {{- with .image -}}
-  {{- $img := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $img := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $schema = merge $schema (dict "image" $img) -}}
 {{- end -}}
 {{- with .courseMode }}{{ $schema = merge $schema (dict "courseMode" .) }}{{ end -}}

--- a/layouts/partials/schemaorg/discussion.html
+++ b/layouts/partials/schemaorg/discussion.html
@@ -35,12 +35,12 @@
 
 {{- $mainEntity := dict "@type" "WebPage" "@id" $page.Permalink -}}
 
-{{- $publisherLogo := dict "@type" "ImageObject" "url" (printf "%simages/logo.png" $site.BaseURL) -}}
+{{- $publisherLogo := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" "/images/logo.png")) -}}
 {{- $publisher := dict "@type" "Organization" "name" $site.Title "url" $site.BaseURL "logo" $publisherLogo -}}
 
 {{- $schema := dict "@context" "https://schema.org" "@type" "DiscussionForumPosting" "@id" $page.Permalink "headline" $page.Title "text" ($page.Description | default $page.Summary | plainify) "url" $page.Permalink "datePublished" ($page.Date.Format "2006-01-02T15:04:05-07:00") "dateModified" ($page.Lastmod.Format "2006-01-02T15:04:05-07:00") "author" $authorObj "interactionStatistic" (slice $likeCounter $commentCounter) "discussionUrl" $page.Permalink "isPartOf" $forum "mainEntityOfPage" $mainEntity "publisher" $publisher -}}
 {{- with $page.Params.tags }}{{ $schema = merge $schema (dict "keywords" .) }}{{ end -}}
-{{- with $page.Params.image }}{{ $schema = merge $schema (dict "image" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .))) }}{{ end -}}
+{{- with $page.Params.image }}{{ $schema = merge $schema (dict "image" (partial "functions/get-absolute-static-url.html" (dict "path" .))) }}{{ end -}}
 <!-- Schema.org structured data for discussion forum posting -->
 <script type="application/ld+json">
 {{- $schema | jsonify | safeJS -}}

--- a/layouts/partials/schemaorg/event.html
+++ b/layouts/partials/schemaorg/event.html
@@ -45,7 +45,7 @@
   {{- $schema = merge $schema (dict "eventStatus" "https://schema.org/EventScheduled") -}}
 {{- end -}}
 {{- with .image -}}
-  {{- $img := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $img := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $schema = merge $schema (dict "image" $img) -}}
 {{- end -}}
 

--- a/layouts/partials/schemaorg/howto.html
+++ b/layouts/partials/schemaorg/howto.html
@@ -50,7 +50,7 @@
 {{- $stepItems := slice -}}
 {{- range $index, $step := $steps -}}
   {{- $item := dict "@type" "HowToStep" "position" (add $index 1) "name" $step.name "text" $step.text -}}
-  {{- with $step.image }}{{ $item = merge $item (dict "image" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .))) }}{{ end -}}
+  {{- with $step.image }}{{ $item = merge $item (dict "image" (partial "functions/get-absolute-static-url.html" (dict "path" .))) }}{{ end -}}
   {{- with $step.url }}{{ $item = merge $item (dict "url" .) }}{{ end -}}
   {{- $stepItems = $stepItems | append $item -}}
 {{- end -}}
@@ -58,7 +58,7 @@
 {{- $schema := dict "@context" "https://schema.org" "@type" "HowTo" "name" $name "step" $stepItems -}}
 {{- with $description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
 {{- with $image -}}
-  {{- $img := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $img := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $schema = merge $schema (dict "image" $img) -}}
 {{- end -}}
 {{- with .totalTime }}{{ $schema = merge $schema (dict "totalTime" .) }}{{ end -}}

--- a/layouts/partials/schemaorg/itemlist.html
+++ b/layouts/partials/schemaorg/itemlist.html
@@ -36,7 +36,7 @@
   {{- if $item.url -}}
     {{- $thing := dict "@type" "Thing" "name" $item.name "url" $item.url -}}
     {{- with $item.description }}{{ $thing = merge $thing (dict "description" .) }}{{ end -}}
-    {{- with $item.image }}{{ $thing = merge $thing (dict "image" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .))) }}{{ end -}}
+    {{- with $item.image }}{{ $thing = merge $thing (dict "image" (partial "functions/get-absolute-static-url.html" (dict "path" .))) }}{{ end -}}
     {{- $element = merge $element (dict "item" $thing) -}}
   {{- else -}}
     {{- $element = merge $element (dict "name" $item.name) -}}

--- a/layouts/partials/schemaorg/jobposting.html
+++ b/layouts/partials/schemaorg/jobposting.html
@@ -31,7 +31,7 @@
 {{ if and $title $description $datePosted }}
 {{- $hiringOrg := dict "@type" "Organization" "name" (.hiringOrganization | default $site.Title) "url" $site.BaseURL -}}
 {{- with $site.Params.organization.logo -}}
-  {{- $logo := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $logo := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $hiringOrg = merge $hiringOrg (dict "logo" $logo) -}}
 {{- end -}}
 

--- a/layouts/partials/schemaorg/offer.html
+++ b/layouts/partials/schemaorg/offer.html
@@ -50,7 +50,7 @@
 {{- with .itemOffered -}}
   {{- $item := dict "@type" (.type | default "Product") "name" .name -}}
   {{- with .description }}{{ $item = merge $item (dict "description" .) }}{{ end -}}
-  {{- with .image }}{{ $item = merge $item (dict "image" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .))) }}{{ end -}}
+  {{- with .image }}{{ $item = merge $item (dict "image" (partial "functions/get-absolute-static-url.html" (dict "path" .))) }}{{ end -}}
   {{- $schema = merge $schema (dict "itemOffered" $item) -}}
 {{- end -}}
 {{- with .eligibleRegion }}{{ $schema = merge $schema (dict "eligibleRegion" .) }}{{ end -}}

--- a/layouts/partials/schemaorg/organization.html
+++ b/layouts/partials/schemaorg/organization.html
@@ -39,7 +39,7 @@
 {{- with $org.legalName }}{{ $schema = merge $schema (dict "legalName" .) }}{{ end -}}
 {{- with $org.description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
 {{- with $org.logo -}}
-  {{- $logo := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $logo := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $schema = merge $schema (dict "logo" $logo) -}}
 {{- end -}}
 {{- with $org.email }}{{ $schema = merge $schema (dict "email" .) }}{{ end -}}

--- a/layouts/partials/schemaorg/product.html
+++ b/layouts/partials/schemaorg/product.html
@@ -33,7 +33,7 @@
 {{- $manufacturer := dict "@type" "Organization" "name" $site.Title -}}
 {{- $schema := dict "@context" "https://schema.org" "@type" "Product" "name" $product.name "manufacturer" $manufacturer -}}
 {{- with $product.description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
-{{- with $product.image }}{{ $schema = merge $schema (dict "image" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .))) }}{{ end -}}
+{{- with $product.image }}{{ $schema = merge $schema (dict "image" (partial "functions/get-absolute-static-url.html" (dict "path" .))) }}{{ end -}}
 {{- with $product.sku }}{{ $schema = merge $schema (dict "sku" .) }}{{ end -}}
 {{- with $product.mpn }}{{ $schema = merge $schema (dict "mpn" .) }}{{ end -}}
 {{- with $product.brand -}}
@@ -82,7 +82,7 @@
   {{- $manufacturer := dict "@type" "Organization" "name" $site.Title -}}
   {{- $prod := dict "@context" "https://schema.org" "@type" "Product" "name" .name "manufacturer" $manufacturer -}}
   {{- with .description }}{{ $prod = merge $prod (dict "description" .) }}{{ end -}}
-  {{- with .image }}{{ $prod = merge $prod (dict "image" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .))) }}{{ end -}}
+  {{- with .image }}{{ $prod = merge $prod (dict "image" (partial "functions/get-absolute-static-url.html" (dict "path" .))) }}{{ end -}}
   {{- with .sku }}{{ $prod = merge $prod (dict "sku" .) }}{{ end -}}
   {{- with .brand -}}
     {{- $prod = merge $prod (dict "brand" (dict "@type" "Brand" "name" .)) -}}

--- a/layouts/partials/schemaorg/service.html
+++ b/layouts/partials/schemaorg/service.html
@@ -35,7 +35,7 @@
 {{- with $service.description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
 {{- with $service.serviceType }}{{ $schema = merge $schema (dict "serviceType" .) }}{{ end -}}
 {{- with $service.image -}}
-  {{- $img := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $img := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $schema = merge $schema (dict "image" $img) -}}
 {{- end -}}
 {{- with $service.areaServed }}{{ $schema = merge $schema (dict "areaServed" .) }}{{ else }}{{ $schema = merge $schema (dict "areaServed" "Worldwide") }}{{ end -}}
@@ -67,7 +67,7 @@
   {{- with .description }}{{ $svc = merge $svc (dict "description" .) }}{{ end -}}
   {{- with .serviceType }}{{ $svc = merge $svc (dict "serviceType" .) }}{{ end -}}
   {{- with .image -}}
-    {{- $img := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+    {{- $img := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
     {{- $svc = merge $svc (dict "image" $img) -}}
   {{- end -}}
   {{- with .areaServed }}{{ $svc = merge $svc (dict "areaServed" .) }}{{ else }}{{ $svc = merge $svc (dict "areaServed" "Worldwide") }}{{ end -}}

--- a/layouts/partials/schemaorg/softwareapplication.html
+++ b/layouts/partials/schemaorg/softwareapplication.html
@@ -70,7 +70,7 @@
 {{- with $software.requirements }}{{ $schema = merge $schema (dict "requirements" .) }}{{ end -}}
 {{- with $software.featureList }}{{ $schema = merge $schema (dict "featureList" .) }}{{ end -}}
 {{- with $software.screenshot -}}
-  {{- $img := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $img := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $schema = merge $schema (dict "screenshot" $img) -}}
 {{- end -}}
 {{- with $software.offers -}}

--- a/layouts/partials/schemaorg/video.html
+++ b/layouts/partials/schemaorg/video.html
@@ -32,11 +32,11 @@
 {{ if and $name $description $thumbnailUrl $uploadDate }}
 {{- $publisher := dict "@type" "Organization" "name" $site.Title "url" $site.BaseURL -}}
 {{- with $site.Params.organization.logo -}}
-  {{- $logo := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $logo := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $publisher = merge $publisher (dict "logo" $logo) -}}
 {{- end -}}
 
-{{- $schema := dict "@context" "https://schema.org" "@type" "VideoObject" "name" $name "description" $description "thumbnailUrl" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" $thumbnailUrl)) "uploadDate" $uploadDate "publisher" $publisher -}}
+{{- $schema := dict "@context" "https://schema.org" "@type" "VideoObject" "name" $name "description" $description "thumbnailUrl" (partial "functions/get-absolute-static-url.html" (dict "path" $thumbnailUrl)) "uploadDate" $uploadDate "publisher" $publisher -}}
 {{- with .contentUrl }}{{ $schema = merge $schema (dict "contentUrl" .) }}{{ end -}}
 {{- with .embedUrl }}{{ $schema = merge $schema (dict "embedUrl" .) }}{{ end -}}
 {{- if and .width .height }}{{ $schema = merge $schema (dict "width" .width "height" .height) }}{{ end -}}

--- a/layouts/partials/schemaorg/webpage.html
+++ b/layouts/partials/schemaorg/webpage.html
@@ -46,14 +46,14 @@
 
 {{- $publisher := dict "@type" "Organization" "name" $site.Title "url" $site.BaseURL -}}
 {{- with $site.Params.organization.logo -}}
-  {{- $logo := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $logo := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $publisher = merge $publisher (dict "logo" $logo) -}}
 {{- end -}}
 
 {{- $schema := dict "@context" "https://schema.org" "@type" $pageType "@id" $page.Permalink "url" $page.Permalink "name" $page.Title "inLanguage" $page.Language.Locale "isPartOf" $isPartOf "datePublished" ($page.Date.Format "2006-01-02T15:04:05Z07:00") "dateModified" ($page.Lastmod.Format "2006-01-02T15:04:05Z07:00") "publisher" $publisher -}}
 {{- with $page.Description }}{{ $schema = merge $schema (dict "description" .) }}{{ end -}}
 {{- with $page.Params.image -}}
-  {{- $img := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $img := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $schema = merge $schema (dict "image" $img) -}}
 {{- end -}}
 {{- with $page.Params.author -}}

--- a/layouts/partials/schemaorg/website.html
+++ b/layouts/partials/schemaorg/website.html
@@ -16,7 +16,7 @@
 
 {{- $publisher := dict "@type" "Organization" "name" $site.Title "url" $site.BaseURL -}}
 {{- with $site.Params.organization.logo -}}
-  {{- $logo := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
+  {{- $logo := dict "@type" "ImageObject" "url" (partial "functions/get-absolute-static-url.html" (dict "path" .)) -}}
   {{- $publisher = merge $publisher (dict "logo" $logo) -}}
 {{- end -}}
 


### PR DESCRIPTION
## Problem

Every schema.org partial built its image URLs as `site.BaseURL + path`:

```go-html-template
{{- $img := dict "@type" "ImageObject" "url" (printf "%s%s" $site.BaseURL (strings.TrimPrefix "/" .)) -}}
```

The image components (`lazyimg`, `og:image`, …) resolve the same paths through `functions/get-static-url.html`, which is CDN-aware. On every site that serves images from a `staticAssets` CDN, the main domain does **not** serve `/images/` at all — so all 28 structured-data image URLs return 404. Google drops rich results whose image is unreachable, so this silently disabled image-based rich snippets across all products.

Live evidence (before this PR):

| Page | `og:image` | JSON-LD `image` |
|---|---|---|
| `www.liveagent.com/templates/zoom-meeting-invitation/` | `images.liveagent.com/…` → **200** | `www.liveagent.com/…` → **404** |
| `www.postaffiliatepro.com/` | `images.postaffiliatepro.com/…` → **200** | `www.postaffiliatepro.com/…` → **404** |
| `www.flowhunt.io/` | `static.flowhunt.io/…` → **200** | `www.flowhunt.io/…` → **404** |
| `www.amicited.com/` | `static.amicited.com/…` → **200** | `www.amicited.com/…` → **404** |

## Solution

New helper `layouts/partials/functions/get-absolute-static-url.html`, which delegates to the existing `get-static-url.html` (single source of truth for the CDN) and only adds absolutization for the case where `staticAssets` is disabled:

```go-html-template
{{ $static := partial "functions/get-static-url.html" (dict "path" $normalized) }}
{{ if hasPrefix $static "http" }}
  {{ $result = $static }}
{{ else }}
  {{ $result = printf "%s%s" site.BaseURL (strings.TrimPrefix "/" $static) }}
{{ end }}
```

Already-absolute inputs (`http://`, `https://`, `//`) pass through unchanged.

Applied to all 28 occurrences across 17 partials: `webpage`, `article`, `product`, `video`, `organization`, `website`, `softwareapplication`, `howto`, `event`, `course`, `service`, `offer`, `itemlist`, `jobposting`, `aggregaterating`, `discussion`, `author`.

Not touched: `website.html:26` (`urlTemplate` for the search entry point) and `discussion.html:39` (`Organization.url`) — those are page URLs, not assets, and correctly stay on the main domain.

## Verification

Full LiveAgent build, 1455 pages, `hugo --gc --minify`.

**1. No regression when `staticAssets` is off** — built the same content with the old and the new code (`--baseURL https://www.liveagent.com/`, `enabled = false`), extracted every `image` / `logo` / `thumbnailUrl` value from all generated HTML, and diffed:

```
diff old-html.txt new-html.txt  →  IDENTICAL
```

This is the path QualityUnit and PhotomaticAI take — output is byte-identical for them.

**2. CDN branch resolves correctly** — same build with `enabled = true`:

```
non-CDN schema image URLs left: 0
CDN schema image URLs:       6444
```

Zoom-template page, `og:image` and JSON-LD now agree:

```
og:image      https://images.liveagent.com/images/templates/price-increase_…jpg
JSON-LD image https://images.liveagent.com/images/templates/price-increase_…jpg
```

**3. URLs actually resolve** — all 495 distinct schema image URLs from that build were requested live: **434 → 200**, 61 → 403.

The 61 are images referenced in frontmatter that were never uploaded to the CDN (e.g. `images/features/features-category_call-center.jpg`, the `*-migration_*.svg` set). They were 404 before this PR and are 403 after — a pre-existing content gap, not a regression. Worth a separate cleanup pass.

## Consumers

One theme bump fixes LiveAgent (26 domains), PostAffiliatePro (~13), FlowHunt and AmICited. Each project additionally has a one-line fix in its own `layouts/partials/schemaorg/pricing.html` override (present in LA, FH, PAP) — LiveAgent's is in QualityUnit/LiveAgent-hugo.

Ref: QualityUnit/web-issues#4226

🤖 Generated with [Claude Code](https://claude.com/claude-code)
