### PR TITLE
fix(related-content): sort JSON keys so output is stable across runs

### DIFF
--- a/scripts/generate_related_content.py
+++ b/scripts/generate_related_content.py
@@ -327,8 +327,13 @@ def generate_json_per_section(related_content, hugo_root, output_dir, lang):
 
         output_file = os.path.join(lang_output_path, f"{section}.json")
 
+        # sort_keys: page keys are emitted in dict insertion order, which varies
+        # between runs because results are collected with --max-parallel. Without
+        # this every run rewrites every file even when nothing changed, burying
+        # the real edits in a ~215k-line diff. The related-file arrays are ranked
+        # by similarity and are left in their computed order.
         with open(output_file, 'w', encoding='utf-8') as f:
-            json.dump(section_data, f, ensure_ascii=False, indent=2)
+            json.dump(section_data, f, ensure_ascii=False, indent=2, sort_keys=True)
 
         file_count += 1
         total_entries += len(section_data)


### PR DESCRIPTION
Adds `sort_keys=True` to the `json.dump` in `generate_related_content.py`, so the generated related-content JSON is byte-stable across runs.

Fixes QualityUnit/web-issues#4227.

## Problem

Each section file was written in dict insertion order, which varies between runs because per-page results are collected with `--max-parallel`. Every run therefore rewrote every output file even when the computed relations were unchanged.

Downstream this made the weekly **Related content** PRs unreviewable. QualityUnit/FlowHunt-hugo#731 is **378 files, +215 114 / −215 029**. Comparing every changed file's base and head revision with keys sorted recursively (`jq -S`, which preserves array order):

```
pure key-order churn : 376
real content change  :   2
```

The only two genuine changes in that whole PR:

| File | Change |
|---|---|
| `data/related_content/ar/blog.json` | `blog/openai-astra-math-microsoft-orchard-ai-agent-training` → `blog/openai-o3-mini-ai-agent-a-compact-yet-powerful-ai-model` |
| `data/related_content/es/ai-tools.json` | `ai-tools/job-description-generator` → `ai-tools/ai-press-release-generator` |

Runs #1–#4 downstream ([#695](https://github.com/QualityUnit/FlowHunt-hugo/pull/695), [#704](https://github.com/QualityUnit/FlowHunt-hugo/pull/704), [#722](https://github.com/QualityUnit/FlowHunt-hugo/pull/722), [#731](https://github.com/QualityUnit/FlowHunt-hugo/pull/731)) have never been merged — three closed unreviewed, one still open — so `data/related_content/` is going stale.

## Why `sort_keys` is sufficient

The related-file arrays are ranked by similarity and were **already deterministic**: `jq -S` does not reorder arrays, and 376/378 files still matched under it. Only the enclosing dict's key order was unstable, so sorting keys is the whole fix — the ranking is untouched.

Verified on a real output file (`data/related_content/en/faq.json`), loading it and re-dumping from two independently shuffled key orders:

```
without sort_keys, two orderings identical?  False
with    sort_keys, two orderings identical?  True
sort_keys output semantically == original?   True
array order preserved?                       True
```

## Rollout note

The first run after this lands still rewrites every file once, normalising key order on disk. Every run after that produces a diff proportional to what actually changed.

## Out of scope

`save_clustering_data` (line 571) also omits `sort_keys`, but it writes a `{"name", "children"}` tree to `static/data/clustering/` where the churn vector would be array order — which `sort_keys` does not address. It is also outside the `add-paths: data/related_content/**` scope of the downstream workflow, so it is not implicated. Left alone until there is evidence of a problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
