### PR TITLE
fix(translate): configurable FlowHunt workspace + stop the scheduler deadlocking

### DIFF
--- a/scripts/translate_with_flowhunt.py
+++ b/scripts/translate_with_flowhunt.py
@@ -68,11 +68,22 @@ if not api_key:
     print("Please set the FLOWHUNT_API_KEY environment variable or add it to the .env file")
     sys.exit(1)
 
-# Default FlowHunt flow ID for translation service (new session-based flow)
-DEFAULT_FLOW_ID = '9df82032-0c90-4a60-8538-5d724590562b'
+# Default FlowHunt flow ID for translation service (new session-based flow).
+# Override with FLOWHUNT_FLOW_ID or --flow-id.
+DEFAULT_FLOW_ID = os.getenv('FLOWHUNT_FLOW_ID', '9df82032-0c90-4a60-8538-5d724590562b')
 
-# Default workspace ID for LiveAgent translations
-DEFAULT_WORKSPACE_ID = '70ff1135-5ce6-42a7-8abe-ec03f58e828e'
+# Workspace that owns the translation flow.
+#
+# FlowHunt API keys are scoped to a single workspace — a key issued in
+# workspace A cannot act on workspace B, and every workspace-scoped call
+# (create_flow_session, GET /v2/flows/{id}, …) answers 401 while unscoped ones
+# like /v2/credits/balance still return 200. That asymmetry makes it look like
+# a bad key when it is really a workspace mismatch.
+#
+# Hard-coding LiveAgentWP here forced every downstream project to use a key
+# from that one workspace. Override with FLOWHUNT_WORKSPACE_ID or
+# --workspace-id to point at the workspace your own key belongs to.
+DEFAULT_WORKSPACE_ID = os.getenv('FLOWHUNT_WORKSPACE_ID', '70ff1135-5ce6-42a7-8abe-ec03f58e828e')
 
 # Map of folder names to full language names
 LANGUAGE_MAP = {
@@ -769,6 +780,13 @@ Examples:
         default=DEFAULT_FLOW_ID
     )
     parser.add_argument(
+        "--workspace-id",
+        help="FlowHunt workspace that owns the flow. Must be the workspace the "
+             "API key was issued in — a key from another workspace gets 401 on "
+             "every workspace-scoped call (default: %(default)s)",
+        default=DEFAULT_WORKSPACE_ID
+    )
+    parser.add_argument(
         "--files",
         nargs="*",
         default=None,
@@ -791,6 +809,7 @@ Examples:
     print(f"[DEBUG] - Check interval: {args.check_interval} seconds")
     print(f"[DEBUG] - Max scheduled tasks: {args.max_scheduled_tasks}")
     print(f"[DEBUG] - Flow ID: {args.flow_id}")
+    print(f"[DEBUG] - Workspace ID: {args.workspace_id}")
     print(f"[DEBUG] - Files: {args.files if args.files else 'ALL (full en/ walk)'}")
     print(f"[DEBUG] - Force overwrite: {args.force}")
     
@@ -798,7 +817,7 @@ Examples:
     content_dir = Path(args.path)
 
     print(f"[DEBUG] Getting workspace ID...")
-    workspace_id = get_workspace_id()
+    workspace_id = get_workspace_id(args.workspace_id)
     if not workspace_id:
         print("[ERROR] Unable to retrieve workspace ID. Please check your API key.")
         sys.exit(1)

--- a/scripts/translate_with_flowhunt.py
+++ b/scripts/translate_with_flowhunt.py
@@ -682,10 +682,22 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
             if completed_in_batch > 0:
                 print(f"[DEBUG] Completed {completed_in_batch} tasks in this batch")
 
-            # Schedule new tasks to replace completed ones, maintaining max_scheduled_tasks
-            tasks_to_schedule = min(completed_in_batch, len(remaining_tasks))
+            # Refill the queue up to max_scheduled_tasks.
+            #
+            # This used to schedule min(completed_in_batch, ...) — one new task
+            # per completed one. A task whose session could not be created is
+            # never "completed", so every creation failure shrank the queue by
+            # one permanently, and once the queue hit zero the loop span forever:
+            # nothing pending to complete, therefore nothing scheduled, therefore
+            # nothing pending. A run that hit 401 on its first five creations sat
+            # at 0/369 for hours until the job timeout killed it.
+            #
+            # Refilling by free slots instead makes the queue self-healing, and
+            # guarantees the loop terminates even when every creation fails.
+            free_slots = max(0, max_scheduled_tasks - len(pending_sessions))
+            tasks_to_schedule = min(free_slots, len(remaining_tasks))
             if tasks_to_schedule > 0:
-                print(f"[DEBUG] Scheduling {tasks_to_schedule} new tasks to replace completed ones")
+                print(f"[DEBUG] Scheduling {tasks_to_schedule} new task(s) to refill the queue")
 
             for i in range(tasks_to_schedule):
                 file_path, content, target_lang, target_file = remaining_tasks.pop(0)
@@ -705,6 +717,18 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
                     all_failed_tasks.append((file_path, target_lang, target_file))
 
                 scheduling_progress.update(1)
+
+            # Nothing in flight and not one session could be created this round:
+            # the next round will fail identically (bad key, wrong workspace, API
+            # down), so stop instead of grinding the whole backlog into the same
+            # error and emitting one traceback per file.
+            if tasks_to_schedule > 0 and newly_scheduled == 0 and not pending_sessions:
+                print(f"[ERROR] Could not create any translation session out of "
+                      f"{tasks_to_schedule} attempt(s), and nothing is in flight. Aborting.")
+                print("[ERROR] A 401 here usually means FLOWHUNT_API_KEY was issued in a "
+                      "different workspace than FLOWHUNT_WORKSPACE_ID — workspace-scoped "
+                      "calls return 401 while unscoped ones still succeed.")
+                break
 
             # Update progress
             processing_progress.update(completed_in_batch)


### PR DESCRIPTION
Fixes QualityUnit/web-issues#4232.

Two independent bugs, one per commit, both found while debugging why **Translate content** stopped working on PostAffiliatePro-hugo.

## 1. The workspace was hard-coded and shared by every project

```python
DEFAULT_WORKSPACE_ID = '70ff1135-5ce6-42a7-8abe-ec03f58e828e'   # LiveAgentWP
```

FlowHunt API keys are scoped to a single workspace — a key issued in workspace A cannot act on workspace B. The failure mode is deceptive because only *workspace-scoped* endpoints reject it:

| Endpoint | takes `workspace_id` | result |
|---|---|---|
| `/v2/credits/balance` | no | **200** |
| `/v2/workspaces/me/my_workspaces` | no | **200** |
| `GET /v2/flows/{id}?workspace_id=70ff1135…` | yes | **401** |
| `POST /v2/flows/sessions/from_flow/create?workspace_id=70ff1135…` | yes | **401** |

The key is valid; it simply is not a member of the hard-coded workspace. Proven by pointing the same key at the workspace it belongs to:

```
GET /v2/flows/9df82032-…?workspace_id=015bcd0a-…  →  200
GET /v2/flows/9df82032-…?workspace_id=70ff1135-…  →  401
```

Both IDs now come from the environment, keeping the current values as defaults so existing callers are unaffected:

```
FLOWHUNT_WORKSPACE_ID / --workspace-id
FLOWHUNT_FLOW_ID      / --flow-id
```

The startup debug block also prints the resolved workspace next to the flow ID. It previously printed the flow but not the workspace — the one value that was wrong.

## 2. The scheduler deadlocked when sessions could not be created

```python
tasks_to_schedule = min(completed_in_batch, len(remaining_tasks))
```

The queue was refilled one-per-completion. A task whose session could not be created never completes, so every creation failure shrank the queue permanently. At zero the loop span forever — nothing pending to complete, so nothing scheduled, so nothing pending.

In the real incident the first five creations returned 401 and the job sat at `Processing translations: 0/369` for **2h20m**, emitting a tqdm tick every 5 s until cancelled. Only the 6h job timeout would have ended it. The tell is that no `[STATUS]` line ever appeared — that line prints only when something is in flight.

Now the queue refills by free slots, and a round that creates nothing while nothing is in flight aborts with a message naming the workspace/key mismatch.

## Verification

Env resolution:

| | result |
|---|---|
| no env | default `70ff1135…` — unchanged |
| `FLOWHUNT_WORKSPACE_ID` set | overrides the default |
| `--workspace-id` passed | overrides the env |
| `--help` | renders |

Scheduler, simulated with every creation failing:

```
old logic       -> never terminates
refill only     -> terminates after 74 rounds, 369 attempts
refill + abort  -> stops after 1 round, 5 attempts
```

`python -m py_compile` clean.

## Rollout

Defaults are unchanged, so this is safe to merge on its own. Downstream repos then set `FLOWHUNT_WORKSPACE_ID` next to `FLOWHUNT_API_KEY` and bump the submodule.

## Not addressed here

The key currently in repo secrets is an org-admin key that can enumerate every workspace on the platform. Translating articles needs a key scoped to one workspace — worth tightening separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
