### PR TITLE
fix(translate): exit non-zero when the run aborts before translating anything

### DIFF
--- a/scripts/translate_with_flowhunt.py
+++ b/scripts/translate_with_flowhunt.py
@@ -581,6 +581,7 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
         failed_tasks = []
         total_scheduled = 0
         total_completed = 0
+        aborted = False
 
         print(f"\nStarting translation of {len(translation_tasks)} files")
         print(f"Maintaining up to {max_scheduled_tasks} tasks in the queue at all times")
@@ -728,6 +729,7 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
                 print("[ERROR] A 401 here usually means FLOWHUNT_API_KEY was issued in a "
                       "different workspace than FLOWHUNT_WORKSPACE_ID — workspace-scoped "
                       "calls return 401 while unscoped ones still succeed.")
+                aborted = True
                 break
 
             # Update progress
@@ -757,6 +759,14 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
     print(f"[DEBUG] Files failed: {len(all_failed_tasks)}")
     print(f"[DEBUG] Total files processed: {len(all_completed_tasks) + len(all_failed_tasks)}")
     print(f"[DEBUG] Translation process completed at {time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+    # Exit non-zero so the caller fails. Without this the abort above returned
+    # normally, build_content.sh printed "Translation of missing content
+    # completed!" and the workflow went green having translated nothing — the
+    # exact silent-success the abort was added to prevent.
+    if aborted:
+        print("[ERROR] Aborted before any translation succeeded — failing the run.")
+        sys.exit(1)
 
 def main():
     """Main function to parse arguments and process files"""


### PR DESCRIPTION
Follow-up to #396 — fixes a flaw in that PR's abort path.

## Problem

The abort broke out of the scheduling loop and then returned normally, so the process exited **0**. `build_content.sh` printed *"Translation of missing content completed!"*, `create-pull-request` opened nothing because there was nothing to commit, and the job went **green having translated nothing**.

That is precisely the silent success the abort was added to prevent — it fixed the two-hour hang but replaced it with a false pass.

Observed on PostAffiliatePro-hugo [run 31098988392](https://github.com/QualityUnit/PostAffiliatePro-hugo/actions/runs/31098988392):

```
[ERROR] Could not create any translation session out of 5 attempt(s), and nothing is in flight. Aborting.
[DEBUG] Files translated successfully: 0
[DEBUG] Files failed: 10
```

Job conclusion: **success**.

## Fix

Track the abort and `sys.exit(1)` after the summaries print, so the counts stay visible in the log before the process dies.

## Verification

Live against the API with a deliberately invalid key:

```
[DEBUG] Files translated successfully: 0
[DEBUG] Files failed: 6
[ERROR] Aborted before any translation succeeded — failing the run.
>>> SystemExit(1)
```

An empty task list still takes the early return further up and never reaches the flag — checked, no `NameError`.

## Note

The rest of #396 is confirmed working in that same run:

```
[DEBUG] - Workspace ID: 015bcd0a-e7e4-4db1-a700-2520a4a8e32a
```

and the abort fired after **6 seconds** where the pre-fix scheduler had spun for 2h20m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)