### PR TITLE
fix(translate): map the directory codes LiveAgent actually uses

### DIFF
--- a/scripts/translate_with_flowhunt.py
+++ b/scripts/translate_with_flowhunt.py
@@ -140,6 +140,13 @@ LANGUAGE_MAP = {
     'pt-br': 'Brazilian Portuguese',
     'zh-cn': 'Simplified Chinese',
     'zh-tw': 'Traditional Chinese',
+    # Directory names in use that are not ISO 639-1. An unmapped code is passed
+    # to the flow verbatim (LANGUAGE_MAP.get(code, code)), so content/jp/ would
+    # ask the model to "translate to jp" instead of to Japanese.
+    'jp': 'Japanese',            # LiveAgent uses jp/, not ja/
+    'zh-hans': 'Simplified Chinese',
+    'zh-hant': 'Traditional Chinese',
+    'tl': 'Filipino',
     'en-gb': 'British English',
     'en-us': 'American English',
     'es-mx': 'Mexican Spanish',


### PR DESCRIPTION
## Problem

`create_translation_session` resolves the target language with:

```python
language_name = LANGUAGE_MAP.get(target_lang.lower(), target_lang)
```

An unmapped directory falls back to the raw code, so the flow is asked to *"translate to jp"* instead of *"translate to Japanese"*. There is no error and no warning — just a worse translation, silently.

## What is unmapped

LiveAgent-hugo has 28 target languages; three of them miss:

| directory | sent to the flow | should be |
|---|---|---|
| `content/jp/` | `jp` | Japanese — the map has `ja`, not `jp` |
| `content/tl/` | `tl` | Filipino |
| `content/zh-hans/` | `zh-hans` | Simplified Chinese — the map has `zh-cn` |

This has applied to every `translate-content` run on that repo, not just future ones.

## Fix

Adds those three, plus `zh-hant` for symmetry with `zh-hans`.

## Verification

Cross-checked every consumer's content directories against the map afterwards:

```
LiveAgent: OK — all 28 mapped
FlowHunt : OK — all 20 mapped
PAP      : OK — all 9 mapped
```

`python -m py_compile` clean.

## Note

Only affects languages that are not yet translated, since the run is missing-only. Existing `jp/`, `tl/` and `zh-hans/` pages were produced under the old behaviour and are not revisited unless deleted or `--force` is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)