### PR TITLE
fix(dates): skip date bump during merge/rebase commits

### DIFF
--- a/scripts/update-content-dates.py
+++ b/scripts/update-content-dates.py
@@ -43,6 +43,14 @@ def get_staged_files() -> list[str]:
     ]
 
 
+def is_merge_or_rebase_in_progress(repo_root: str) -> bool:
+    # During a merge/rebase, staged files can differ from HEAD purely because
+    # they picked up someone else's already-dated changes — not because the
+    # author edited them. Bumping the date in that case is wrong.
+    git_dir = Path(repo_root) / '.git'
+    return any((git_dir / name).exists() for name in ('MERGE_HEAD', 'rebase-merge', 'rebase-apply'))
+
+
 def read_blob(ref: str) -> str | None:
     code, out = git('show', ref)
     # Strip a leading BOM so the `^\+\+\+` front matter regexes below match.
@@ -74,6 +82,9 @@ def update_date(content: str, new_date: str) -> str:
 def main() -> None:
     _, repo_root = git('rev-parse', '--show-toplevel')
     repo_root = repo_root.strip()
+
+    if is_merge_or_rebase_in_progress(repo_root):
+        return
 
     staged_files = get_staged_files()
     if not staged_files:


### PR DESCRIPTION
**Changes proposed in this Pull Request**
Update-content-dates.py decided whether to bump a file's `date` frontmatter up someone else's already-dated changes look identical to a real edit from this check's point of view, so their date got overwritten to "now" even though nothing was actually edited.

Skip the hook entirely while MERGE_HEAD or a rebase is in progress, since the incoming side's date is already correct.

**Testing instructions**

1. Take any dependabot/dependency PR branch that's behind main.
2. Run git merge main on it.
3. If Git reports a conflict (e.g. in package.json) — resolve it and finish with git commit.
4. Run git diff main -- content/ — it should show no changes at all in content files.
  - If it's empty → fix works correctly.
  - If some content/en/*.md files show up with only a changed date line → bug is back.
5. Sanity check: edit the body of any content/en/*.md file yourself and commit normally — its date should still update to today, confirming the hook still works for real edits.