### PR TITLE
feat(translate): give translated pages their own language's URL

### DIFF
--- a/scripts/translate_with_flowhunt.py
+++ b/scripts/translate_with_flowhunt.py
@@ -39,6 +39,7 @@ Examples:
 """
 
 import os
+import re
 import sys
 import argparse
 import time
@@ -50,6 +51,21 @@ from dotenv import load_dotenv
 import flowhunt
 from pprint import pprint
 from functools import wraps
+
+# TOML reader for validating translated frontmatter. tomllib is stdlib from
+# 3.11 (the version the translate-content workflow pins); the `toml` package is
+# already in requirements.txt and covers anyone running this on an older local
+# interpreter.
+try:
+    import tomllib
+
+    def _toml_loads(text):
+        return tomllib.loads(text)
+except ImportError:  # Python < 3.11
+    import toml
+
+    def _toml_loads(text):
+        return toml.loads(text)
 
 # Load environment variables from .env file
 script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -196,6 +212,152 @@ def get_workspace_id(workspace_id=None):
 def is_translatable_file(file_path):
     """Check if a file should be translated based on extension"""
     return file_path.suffix.lower() in ['.md', '.markdown', '.yaml', '.yml', '.html', '.txt']
+
+
+# ---------------------------------------------------------------------------
+# Translated frontmatter validation
+#
+# The translation flow regularly returns TOML frontmatter Hugo cannot
+# unmarshal. Two failure modes seen in production so far:
+#
+#   answer = "…viens pogas "Saglabāt" klikšķis…"   unescaped inner quote
+#   question =="Kokio nukreipimo rodiklio…"        duplicated '='
+#
+# An unescaped quote terminates the basic string early, so Hugo aborts the
+# whole language build ("unmarshal failed: toml: expected newline but got …").
+# One bad page takes down all ~1500 pages of that language, and Hugo only
+# reports the first error per language, so they surface one at a time.
+#
+# Repairing what is deterministically repairable keeps those pages translated;
+# anything left over is written anyway and reported, because a broken file can
+# be fixed by hand while a missing one has to be re-translated.
+# ---------------------------------------------------------------------------
+
+FRONTMATTER_DELIM = '+++'
+
+# A single-line TOML assignment: key, one-or-more '=', gap, then the value.
+_KEY_EQ_RE = re.compile(r'^(\s*[A-Za-z_][A-Za-z0-9_-]*\s*)(=+)(\s*)(.*)$')
+
+
+def split_toml_frontmatter(text):
+    """
+    Split a Hugo file into (before, frontmatter, body) around the +++ fences.
+
+    Returns None when the text does not open with a TOML frontmatter block —
+    YAML frontmatter, .html and .txt files are simply not our business.
+    """
+    if not text.startswith(FRONTMATTER_DELIM):
+        return None
+    parts = text.split(FRONTMATTER_DELIM, 2)
+    if len(parts) < 3:
+        return None
+    return parts[0], parts[1], parts[2]
+
+
+def validate_toml_frontmatter(text):
+    """
+    Check the TOML frontmatter of a translated file.
+
+    Returns None when the frontmatter parses (or when there is none to check),
+    otherwise the parse error as a string.
+    """
+    split = split_toml_frontmatter(text)
+    if split is None:
+        return None
+    try:
+        _toml_loads(split[1])
+        return None
+    except Exception as e:
+        return str(e)
+
+
+def _repair_toml_line(line):
+    """
+    Try to repair one malformed `key = "value"` line.
+
+    Handles a duplicated assignment operator and unescaped ASCII double quotes
+    inside the value, including the case where the closing quote is missing
+    altogether. Returns the repaired line, or None when no repair applies.
+    """
+    m = _KEY_EQ_RE.match(line)
+    if not m:
+        return None
+
+    key, _eq, _gap, value = m.groups()
+
+    # Multi-line basic strings are out of scope — never reflow them.
+    if value.startswith('"""') or not value.startswith('"'):
+        return None
+
+    stripped = value.rstrip()
+    trailing = value[len(stripped):]
+
+    inner = stripped[1:]
+    if inner.endswith('"'):
+        inner = inner[:-1]
+
+    # Escape every double quote that is not escaped already. A missing closing
+    # quote is handled implicitly: inner simply runs to end of line and gets a
+    # fresh closing quote below.
+    inner = re.sub(r'(?<!\\)"', r'\\"', inner)
+
+    return f'{key.rstrip()} = "{inner}"{trailing}'
+
+
+def repair_toml_frontmatter(text):
+    """
+    Attempt to repair malformed TOML frontmatter.
+
+    Only lines that fail to parse on their own are touched, and a repair is
+    kept only if the repaired line parses. The rebuilt frontmatter is then
+    parsed as a whole, so a repair that fixes one line while breaking the
+    document is discarded rather than written.
+
+    Returns (repaired_text, repaired_line_numbers), or (None, []) when the
+    frontmatter could not be made to parse.
+    """
+    split = split_toml_frontmatter(text)
+    if split is None:
+        return None, []
+    before, frontmatter, body = split
+
+    lines = frontmatter.split('\n')
+    repaired_lines = []
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        # Blank lines, comments and table headers are never the problem, and
+        # array/multi-line continuations must not be parsed in isolation.
+        if not stripped or stripped.startswith('#') or stripped.startswith('['):
+            continue
+        try:
+            _toml_loads(stripped)
+            continue  # this line is fine by itself
+        except Exception:
+            pass
+
+        fixed = _repair_toml_line(line)
+        if fixed is None or fixed == line:
+            continue
+        try:
+            _toml_loads(fixed.strip())
+        except Exception:
+            continue  # repair did not help — leave the original alone
+
+        lines[i] = fixed
+        repaired_lines.append(i + 1)
+
+    if not repaired_lines:
+        return None, []
+
+    candidate = '\n'.join(lines)
+    try:
+        _toml_loads(candidate)
+    except Exception:
+        return None, []
+
+    return before + FRONTMATTER_DELIM + candidate + FRONTMATTER_DELIM + body, repaired_lines
+
 
 def get_target_languages(content_dir):
     """
@@ -573,6 +735,11 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
         # Lists to track completed and failed tasks across all batches
         all_completed_tasks = []
         all_failed_tasks = []
+        # Frontmatter outcomes, reported in the run summary: pages whose TOML
+        # was repaired on the way in, and pages written with frontmatter that
+        # still does not parse and therefore need a human.
+        repaired_frontmatter = []
+        invalid_frontmatter = []
 
         # Process translations while maintaining max_scheduled_tasks in queue
         remaining_tasks = translation_tasks.copy()
@@ -644,19 +811,52 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
                                 # Trim all whitespace from the translated text
                                 translated_text = translated_text.strip()
 
+                                # Unwrap the markdown code fence the model
+                                # sometimes puts around the whole file. This used
+                                # to happen inside the `with open(..., 'w')`
+                                # block below — i.e. after the target file had
+                                # already been truncated — so any error in here
+                                # left a 0-byte file behind. It also has to run
+                                # before the frontmatter check, or the leading
+                                # fence hides the +++ delimiter.
+                                if translated_text.startswith("```"):
+                                    translated_text = translated_text[3:]
+                                if translated_text.endswith("```"):
+                                    translated_text = translated_text[:-3]
+                                # Also remove markdown code block language markers
+                                if translated_text.startswith("markdown\n"):
+                                    translated_text = translated_text[9:]
+                                translated_text = translated_text.strip()
+
+                                # Validate the TOML frontmatter before writing,
+                                # repairing it where the fix is unambiguous. See
+                                # validate_toml_frontmatter() for why.
+                                frontmatter_error = validate_toml_frontmatter(translated_text)
+
+                                if frontmatter_error:
+                                    fixed_text, fixed_lines = repair_toml_frontmatter(translated_text)
+                                    if fixed_text:
+                                        translated_text = fixed_text
+                                        frontmatter_error = None
+                                        line_list = ', '.join(str(n) for n in fixed_lines)
+                                        print(f"[REPAIRED] {target_file}: invalid TOML frontmatter "
+                                              f"fixed on line(s) {line_list}")
+                                        repaired_frontmatter.append((target_file, line_list))
+                                    else:
+                                        # Written anyway, on purpose: a broken
+                                        # file can be fixed in the PR, a missing
+                                        # one silently leaves the page
+                                        # untranslated and needs a whole re-run.
+                                        print(f"[INVALID FRONTMATTER] {target_file}: {frontmatter_error}")
+                                        print(f"[INVALID FRONTMATTER] writing it anyway — this page "
+                                              f"will fail the Hugo build until it is fixed by hand")
+                                        invalid_frontmatter.append((target_file, frontmatter_error))
+
                                 # Ensure the target directory exists
                                 os.makedirs(target_file.parent, exist_ok=True)
 
                                 # Write the translated content to the target file
                                 with open(target_file, 'w', encoding='utf-8') as f:
-                                    # If translated text starts or ends with ```, remove it
-                                    if translated_text.startswith("```"):
-                                        translated_text = translated_text[3:]
-                                    if translated_text.endswith("```"):
-                                        translated_text = translated_text[:-3]
-                                    # Also remove markdown code block language markers
-                                    if translated_text.startswith("markdown\n"):
-                                        translated_text = translated_text[9:]
                                     f.write(translated_text)
 
                                 # Add to completed tasks
@@ -758,6 +958,26 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
     print(f"[DEBUG] Files translated successfully: {len(all_completed_tasks)}")
     print(f"[DEBUG] Files failed: {len(all_failed_tasks)}")
     print(f"[DEBUG] Total files processed: {len(all_completed_tasks) + len(all_failed_tasks)}")
+    print(f"[DEBUG] Frontmatter repaired: {len(repaired_frontmatter)}")
+    print(f"[DEBUG] Frontmatter still invalid: {len(invalid_frontmatter)}")
+
+    if repaired_frontmatter:
+        print("\n[DEBUG] Pages whose TOML frontmatter was repaired automatically:")
+        for target_file, line_list in repaired_frontmatter:
+            print(f"[DEBUG]   {target_file} (line(s) {line_list})")
+
+    if invalid_frontmatter:
+        # Loud and last, so it is the final thing in the job log: these pages
+        # were written with frontmatter Hugo cannot parse and will fail the
+        # per-language build until someone fixes them.
+        print(f"\n[ERROR] {len(invalid_frontmatter)} page(s) have invalid TOML frontmatter "
+              f"and WILL FAIL the Hugo build:")
+        for target_file, error in invalid_frontmatter:
+            print(f"[ERROR]   {target_file}")
+            print(f"[ERROR]     {error}")
+        print("[ERROR] The files were written on purpose so the translation is not lost. "
+              "Fix the frontmatter quoting in the PR.")
+
     print(f"[DEBUG] Translation process completed at {time.strftime('%Y-%m-%d %H:%M:%S')}")
 
     # Exit non-zero so the caller fails. Without this the abort above returned

--- a/scripts/translate_with_flowhunt.py
+++ b/scripts/translate_with_flowhunt.py
@@ -67,6 +67,8 @@ except ImportError:  # Python < 3.11
     def _toml_loads(text):
         return toml.loads(text)
 
+import translation_url_policy as url_policy
+
 # Load environment variables from .env file
 script_dir = os.path.dirname(os.path.abspath(__file__))
 hugo_root = os.path.dirname(os.path.dirname(os.path.dirname(script_dir)))  # Adjusted to point to the correct root
@@ -254,15 +256,22 @@ def split_toml_frontmatter(text):
     return parts[0], parts[1], parts[2]
 
 
-def validate_toml_frontmatter(text):
+def validate_toml_frontmatter(text, require_frontmatter=False):
     """
     Check the TOML frontmatter of a translated file.
 
     Returns None when the frontmatter parses (or when there is none to check),
     otherwise the parse error as a string.
+
+    ``require_frontmatter`` is set for markdown files, where a missing +++
+    block is itself the bug: the flow occasionally returns only the body, and
+    treating that as "nothing to check" shipped a page with no title, url or
+    date at all (content/sl/blog/best-trouble-ticket-system.md, run #3).
     """
     split = split_toml_frontmatter(text)
     if split is None:
+        if require_frontmatter:
+            return 'no TOML frontmatter (+++ block) in translated file'
         return None
     try:
         _toml_loads(split[1])
@@ -357,6 +366,72 @@ def repair_toml_frontmatter(text):
         return None, []
 
     return before + FRONTMATTER_DELIM + candidate + FRONTMATTER_DELIM + body, repaired_lines
+
+
+# Cache of "URLs already claimed", one index per language. Built lazily because
+# it walks ~1500 files per language and most runs touch only a few languages.
+_URL_INDEX_CACHE = {}
+
+
+def apply_url_policy(translated_text, source_file, target_file, target_lang):
+    """
+    Give a translated page the URL it should have.
+
+    The flow returns the English ``url`` verbatim, so without this every
+    translation lands on the English path — outside its own language's section
+    and, for a re-translated page, on a different URL than the one already
+    published and indexed. See translation_url_policy for the rules.
+
+    Returns (text, note) where note is a one-line log entry, or (text, None)
+    when nothing applied.
+    """
+    lang_dir = None
+    for parent in target_file.parents:
+        if parent.name == target_lang:
+            lang_dir = parent
+            break
+    if lang_dir is None:
+        return translated_text, None
+
+    content_dir = lang_dir.parent
+    hugo_root = content_dir.parent
+    rel_path = target_file.relative_to(lang_dir).as_posix()
+
+    try:
+        en_url = url_policy.read_url(source_file.read_text(encoding='utf-8-sig'))
+    except OSError:
+        return translated_text, None
+    if not en_url:
+        return translated_text, None
+
+    if target_lang not in _URL_INDEX_CACHE:
+        _URL_INDEX_CACHE[target_lang] = url_policy.build_url_index(content_dir, target_lang)
+
+    url, alias, reason = url_policy.resolve_url(
+        en_url=en_url,
+        translated_url=url_policy.read_url(translated_text),
+        rel_path=rel_path,
+        lang=target_lang,
+        content_dir=content_dir,
+        hugo_root=hugo_root,
+        url_index=_URL_INDEX_CACHE[target_lang],
+    )
+
+    if not url:
+        return translated_text, f'{target_file}: url unchanged - {reason}'
+
+    updated = url_policy.apply_url(translated_text, url, alias)
+
+    # Claim the address so a later file in the same run cannot take it too.
+    _URL_INDEX_CACHE[target_lang][url] = str(target_file)
+    if alias:
+        _URL_INDEX_CACHE[target_lang][alias] = str(target_file)
+
+    note = f'{target_file}: url = {url}'
+    if alias:
+        note += f' (+ alias {alias})'
+    note += f' - {reason}'
+    return updated, note
 
 
 def get_target_languages(content_dir):
@@ -831,7 +906,9 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
                                 # Validate the TOML frontmatter before writing,
                                 # repairing it where the fix is unambiguous. See
                                 # validate_toml_frontmatter() for why.
-                                frontmatter_error = validate_toml_frontmatter(translated_text)
+                                is_markdown = target_file.suffix.lower() in ('.md', '.markdown')
+                                frontmatter_error = validate_toml_frontmatter(
+                                    translated_text, require_frontmatter=is_markdown)
 
                                 if frontmatter_error:
                                     fixed_text, fixed_lines = repair_toml_frontmatter(translated_text)
@@ -851,6 +928,14 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
                                         print(f"[INVALID FRONTMATTER] writing it anyway — this page "
                                               f"will fail the Hugo build until it is fixed by hand")
                                         invalid_frontmatter.append((target_file, frontmatter_error))
+
+                                # Give the page its own language's URL. The
+                                # flow returns the English one verbatim.
+                                if is_markdown and not frontmatter_error:
+                                    translated_text, url_note = apply_url_policy(
+                                        translated_text, file_path, target_file, target_lang)
+                                    if url_note:
+                                        print(f"[URL] {url_note}")
 
                                 # Ensure the target directory exists
                                 os.makedirs(target_file.parent, exist_ok=True)

--- a/scripts/translation_url_policy.py
+++ b/scripts/translation_url_policy.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+"""
+URL/slug policy for translated Hugo pages.
+
+The translation flow returns a whole translated markdown file. Left alone it
+copies the English ``url`` verbatim into every language, so a German page ends
+up at ``/features/ai-sales-assistant/`` while every other German feature page
+lives under ``/funktionen/``. It also never emits ``aliases``.
+
+This module owns the decision of what ``url`` a translated page gets, and it
+is deliberately deterministic: the flow supplies the *words*, this file
+supplies the *rules*. Anything the flow returns that cannot be normalised into
+a clean ASCII slug falls back to the English slug rather than shipping a
+broken URL — a slug is effectively permanent once published, so the safe
+failure mode is "same as English", never "mangled".
+
+Policy (agreed 17 Aug 2026):
+
+* Localize the slug in every section EXCEPT those whose slug is a proper name
+  or a campaign code (integration names, author names, landing-page codes).
+* Non-latin scripts use latin transliteration, which is what the site already
+  does (``single-sign-on`` -> ``tasgeel-eldekhol-elohady`` in Arabic).
+  Japanese is the exception: no Japanese slug has ever been translated.
+* A page that already had a translated URL before it was re-translated keeps
+  that URL, restored from ``data/translation_urls/<section>.json``. Losing a
+  published URL is the one outcome worth preventing at any cost.
+* The section prefix always comes from ``<lang>/<section>/_index.md``, never
+  from the flow.
+"""
+
+import json
+import re
+import unicodedata
+from pathlib import Path
+
+try:
+    import tomllib
+
+    def _toml_load(fh):
+        return tomllib.load(fh)
+except ImportError:  # Python < 3.11
+    import toml
+
+    def _toml_load(fh):
+        return toml.loads(fh.read().decode('utf-8'))
+
+# ---------------------------------------------------------------------------
+# Per-project configuration
+#
+# This module ships in a submodule shared by every QualityUnit Hugo site, and
+# the sites do not agree: LiveAgent and PostAffiliatePro give each language its
+# own domain, FlowHunt and amicited put every language behind a /<lang>/ prefix
+# on one domain, and each has its own section names. "Japanese keeps the
+# English slug" is a LiveAgent decision, not a fact about Hugo.
+#
+# So nothing is hardcoded here and nothing happens by default. A project opts
+# in by committing data/translation-url-policy.toml; without that file this
+# module does nothing at all and translation behaves exactly as it did before.
+# That way a repo we have never seen cannot be reshaped by a submodule bump.
+# ---------------------------------------------------------------------------
+
+POLICY_FILE = 'data/translation-url-policy.toml'
+
+DEFAULTS = {
+    'enabled': False,
+    'english_slug_languages': [],
+    'passthrough_sections': [],
+    'brand_sections': [],
+    'brand_suffixes': [],
+    'brand_extra': [],
+    'max_slug_length': 80,
+    'language_prefix': None,   # None = auto-detect from the declared baseURLs
+    'aliases': True,
+}
+
+
+# Transliteration tables. These are facts about writing systems, not project
+# policy, so they stay in the theme.
+
+# Expansions applied before ASCII folding, so German umlauts survive as the
+# digraphs readers expect (NFKD alone would give "uber", not "ueber").
+LANG_CHAR_MAP = {
+    'de': {'ä': 'ae', 'ö': 'oe', 'ü': 'ue', 'ß': 'ss'},
+    'sv': {'å': 'aa', 'ä': 'ae', 'ö': 'oe'},
+    'da': {'æ': 'ae', 'ø': 'oe', 'å': 'aa'},
+    'no': {'æ': 'ae', 'ø': 'oe', 'å': 'aa'},
+    'fi': {'ä': 'ae', 'ö': 'oe'},
+}
+
+# Letters NFKD does NOT decompose, because they are distinct letters rather
+# than a base plus a mark. Without these a Polish slug containing "ł" is
+# rejected wholesale and the page silently keeps its English slug -
+# "zgloszen" folds to nothing, not to "zgloszen".
+UNDECOMPOSABLE = {
+    'ł': 'l', 'Ł': 'l',
+    'ø': 'o', 'Ø': 'o',
+    'æ': 'ae', 'Æ': 'ae',
+    'œ': 'oe', 'Œ': 'oe',
+    'đ': 'd', 'Đ': 'd', 'ð': 'd', 'Ð': 'd',
+    'ß': 'ss',
+    'þ': 'th', 'Þ': 'th',
+    'ħ': 'h', 'ı': 'i', 'ŋ': 'n', 'ŧ': 't', 'ſ': 's', 'ə': 'e',
+}
+
+_BASEURL_RE = re.compile(r'^\s*baseURL\s*=\s*[\'"]([^\'"]+)[\'"]', re.M)
+
+_URL_RE = re.compile(r'^url\s*=\s*"([^"]*)"', re.M)
+_ALIASES_RE = re.compile(r'^aliases\s*=\s*\[[^\]]*\]', re.M)
+_FRONTMATTER_RE = re.compile(r'^\+\+\+\s*\n(.*?)\n\+\+\+', re.S)
+
+
+# ---------------------------------------------------------------------------
+# Small parsing helpers. These read with regex on purpose: the frontmatter of a
+# freshly translated file is not guaranteed to parse as TOML yet (that is what
+# the repair pass upstream is for), and the URL line is well-formed even when
+# some FAQ answer three screens down is not.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Site shape
+#
+# Two deployment models share this script, and they need different URLs:
+#
+#   own domain per language (LiveAgent, PostAffiliatePro)
+#       liveagent.de/funktionen/regeln/ - no language prefix, and each language
+#       is built on its own (config_<lang> + HUGO_DEFAULTCONTENTLANGUAGE), so
+#       an English-path alias on a German page is safe.
+#
+#   one domain, language subfolders (FlowHunt, amicited, photomaticai)
+#       flowhunt.io/de/ai-flow-templates/ - the prefix is part of every url,
+#       and all languages are built into one public/ tree.
+#
+# The distinction is not cosmetic. In the subfolder model an alias without the
+# language prefix silently overwrites the English page: a German page carrying
+#     aliases = ["/features/rules/"]
+# publishes a redirect at /features/rules/index.html, replacing the English
+# page that lives there. Hugo emits no warning for this - verified on Hugo
+# 0.160.1 with a two-language test site. FlowHunt content already contains such
+# aliases today.
+# ---------------------------------------------------------------------------
+
+_PREFIX_CACHE = {}
+
+
+_POLICY_CACHE = {}
+
+
+def load_policy(hugo_root):
+    """
+    Read data/translation-url-policy.toml for this project.
+
+    Returns None when the file is absent, unreadable, or does not set
+    ``enabled = true``. A None policy means this module stands down completely -
+    the caller writes the translated file exactly as the flow returned it.
+    """
+    key = str(hugo_root)
+    if key in _POLICY_CACHE:
+        return _POLICY_CACHE[key]
+
+    policy = None
+    path = Path(hugo_root) / POLICY_FILE
+    if path.exists():
+        try:
+            with open(path, 'rb') as fh:
+                raw = _toml_load(fh)
+        except Exception as exc:
+            print(f'[URL] cannot read {POLICY_FILE}: {exc} - url policy disabled')
+            raw = None
+        if raw is not None:
+            if raw.get('enabled') is True:
+                policy = dict(DEFAULTS)
+                policy.update({k: v for k, v in raw.items() if k in DEFAULTS})
+                policy['passthrough_sections'] = set(policy['passthrough_sections'] or [])
+                policy['english_slug_languages'] = set(policy['english_slug_languages'] or [])
+            else:
+                print(f'[URL] {POLICY_FILE} present but enabled is not true - url policy disabled')
+
+    _POLICY_CACHE[key] = policy
+    return policy
+
+
+def uses_language_prefix(hugo_root):
+    """
+    True when URLs on this site carry a /<lang>/ prefix.
+
+    Derived the same way sync_translation_urls does it: if the languages
+    declare two or more distinct hostnames, each language owns a domain and
+    needs no prefix. Anything else (one baseURL, or none declared) means the
+    languages share a domain and are separated by a subfolder.
+    """
+    key = str(hugo_root)
+    if key in _PREFIX_CACHE:
+        return _PREFIX_CACHE[key]
+
+    hosts = set()
+    for rel in ('config/_default/languages.toml', 'config/_default/hugo.toml',
+                'config/_default/config.toml', 'hugo.toml', 'config.toml'):
+        path = Path(hugo_root) / rel
+        if not path.exists():
+            continue
+        try:
+            text = path.read_text(encoding='utf-8')
+        except OSError:
+            continue
+        for raw in _BASEURL_RE.findall(text):
+            host = raw.split('//', 1)[-1].split('/', 1)[0].strip()
+            if host:
+                hosts.add(host.lower())
+
+    if len(hosts) >= 2:
+        result = False          # a domain per language, no prefix needed
+    elif len(hosts) == 1:
+        result = True           # one declared domain, languages in subfolders
+    else:
+        result = None           # nothing declared - refuse to guess
+    _PREFIX_CACHE[key] = result
+    return result
+
+
+def read_url(text):
+    """Return the ``url`` value from a markdown file's frontmatter, or None."""
+    fm = _FRONTMATTER_RE.match(text or '')
+    if not fm:
+        return None
+    m = _URL_RE.search(fm.group(1))
+    return m.group(1) if m else None
+
+
+def ensure_slashes(url):
+    """Normalise an internal URL to /leading/ and /trailing/ slashes."""
+    if not url:
+        return url
+    if not url.startswith('/'):
+        url = '/' + url
+    if not url.endswith('/'):
+        url = url + '/'
+    return url
+
+
+def split_url(url):
+    """Split ``/a/b/c/`` into (``a/b``, ``c``)."""
+    parts = [p for p in (url or '').strip('/').split('/') if p]
+    if not parts:
+        return '', ''
+    return '/'.join(parts[:-1]), parts[-1]
+
+
+def normalize_slug(raw, lang, max_length=80):
+    """
+    Turn whatever the flow returned into a safe ASCII slug.
+
+    Returns '' when nothing usable survives — the caller then falls back to the
+    English slug. Rejecting is the point: a slug that still contains non-ASCII
+    after folding means the flow returned native script, and shipping a
+    percent-encoded URL by accident is worse than shipping the English one.
+    """
+    if not raw:
+        return ''
+
+    text = str(raw).strip().lower()
+
+    for src, dst in LANG_CHAR_MAP.get(lang, {}).items():
+        text = text.replace(src, dst)
+    for src, dst in UNDECOMPOSABLE.items():
+        if src in text:
+            text = text.replace(src, dst)
+
+    # Strip combining marks: é -> e, ā -> a. Characters with no ASCII
+    # decomposition (Greek, Cyrillic, CJK, Arabic) simply survive and are
+    # caught by the ASCII check below.
+    text = unicodedata.normalize('NFKD', text)
+    text = ''.join(c for c in text if not unicodedata.combining(c))
+
+    if any(ord(c) > 127 for c in text):
+        return ''
+
+    text = re.sub(r'[^a-z0-9]+', '-', text).strip('-')
+    text = re.sub(r'-{2,}', '-', text)
+
+    if max_length and len(text) > max_length:
+        text = text[:max_length].rsplit('-', 1)[0].strip('-')
+
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Site lookups
+# ---------------------------------------------------------------------------
+
+_BRAND_CACHE = {}
+
+# Words that appear inside an integration or competitor slug but are ordinary
+# vocabulary, so they must not be treated as brands to preserve.
+_BRAND_STOPWORDS = {
+    'alternative', 'alternatives', 'migration', 'integration', 'integrations',
+    'software', 'app', 'apps', 'plugin', 'free', 'vs', 'and', 'for', 'the',
+    'chat', 'live', 'help', 'desk', 'email', 'mail', 'phone', 'call', 'sms',
+    'crm', 'api', 'cloud', 'web', 'online', 'best', 'top', 'new', 'to', 'of',
+    'business', 'virtual', 'assistant', 'agent', 'agents', 'center', 'centre',
+    'service', 'services', 'support', 'customer', 'ticket', 'ticketing',
+    'system', 'systems', 'tool', 'tools', 'marketing', 'social', 'media',
+    'video', 'voice', 'voip', 'sales', 'team', 'inbox', 'form', 'forms',
+}
+
+
+def brand_tokens(content_dir, sections=(), suffixes=(), extra=()):
+    """
+    Product and company names that appear in this site's own URLs.
+
+    Built from the site's own content rather than a hand-kept vendor list. The
+    project says where to look: ``brand_sections`` are sections whose page names
+    are product names (an integrations directory), and ``brand_suffixes`` are
+    the endings of comparison pages named after a competitor
+    (``<vendor>-alternative``). That makes the vocabulary self-maintaining - a
+    new integration page teaches it a new brand - without assuming any
+    particular site layout.
+    """
+    key = (str(content_dir), tuple(sections or ()), tuple(suffixes or ()), tuple(extra or ()))
+    if key in _BRAND_CACHE:
+        return _BRAND_CACHE[key]
+
+    tokens = {t.lower() for t in (extra or ()) if t}
+    en_dir = Path(content_dir) / 'en'
+
+    for section in sections or ():
+        for path in (en_dir / section).glob('*.md'):
+            if path.name == '_index.md':
+                continue
+            for token in path.stem.lower().split('-'):
+                if len(token) > 2 and token not in _BRAND_STOPWORDS:
+                    tokens.add(token)
+
+    for path in en_dir.glob('*.md'):
+        stem = path.stem.lower()
+        for suffix in suffixes or ():
+            if not stem.endswith(suffix):
+                continue
+            head = stem[: -len(suffix)]
+            # "zendesk-talk-alternative" names the product "zendesk talk", so
+            # index both words rather than the joined string, which would never
+            # match a hyphen-split slug.
+            for token in head.split('-'):
+                if len(token) > 2 and token not in _BRAND_STOPWORDS:
+                    tokens.add(token)
+            break
+
+    _BRAND_CACHE[key] = tokens
+    return tokens
+
+
+def section_prefix(content_dir, lang, section, fallback, lang_prefix=False):
+    """
+    The URL path a section lives under in one language, taken from that
+    language's own ``<section>/_index.md``.
+
+    On subfolder sites that index already carries the prefix
+    (``/de/ai-flow-templates/``), so nothing extra is needed. It is only the
+    fallback - a language that has no section index yet - that must add the
+    prefix itself, otherwise the page would be published on the English path
+    and collide with the English page.
+    """
+    if not section:
+        fallback = (fallback or '').strip('/')
+        if lang_prefix and fallback.split('/')[0] != lang:
+            fallback = '/'.join(p for p in (lang, fallback) if p)
+        return fallback
+    index = Path(content_dir) / lang / section / '_index.md'
+    if index.exists():
+        try:
+            url = read_url(index.read_text(encoding='utf-8-sig'))
+        except OSError:
+            url = None
+        if url:
+            return url.strip('/')
+    fallback = (fallback or '').strip('/')
+    if lang_prefix and fallback.split('/')[0] != lang:
+        fallback = '/'.join(p for p in (lang, fallback) if p)
+    return fallback
+
+
+def data_file_for_section(section):
+    """
+    The translation_urls file a section's records live in.
+
+    Two conventions have to be bridged: content directories are hyphenated
+    (``success-stories``, ``customer-support-glossary``) while the generated
+    JSON files are underscored, and pages that sit at the top of a language
+    (``aircall-alternative.md`` and 207 others) are collected in ``_root``.
+    Getting this wrong is silent - the lookup just misses and the page loses
+    its published URL.
+    """
+    if not section:
+        return '_root'
+    return section.replace('-', '_')
+
+
+def historical_url(hugo_root, section, rel_path, lang):
+    """
+    The URL this page had before it was deleted and re-translated.
+
+    ``data/translation_urls/<section>.json`` maps a source path such as
+    ``blog/best-trouble-ticket-system.md`` to the published URL of every
+    language. It is regenerated from content, so it is only a reliable record
+    of the *previous* state — which is exactly what is needed here.
+    """
+    data_file = (Path(hugo_root) / 'data' / 'translation_urls' /
+                 f'{data_file_for_section(section)}.json')
+    if not data_file.exists():
+        return None
+    try:
+        with open(data_file, 'rb') as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    entry = data.get(str(rel_path).replace('\\', '/'))
+    if isinstance(entry, dict):
+        url = entry.get(lang)
+        if url:
+            return ensure_slashes(url)
+    return None
+
+
+def build_url_index(content_dir, lang):
+    """
+    Every URL already claimed in one language, as {url: source path}.
+
+    Covers both ``url`` and ``aliases`` so a new page cannot silently take an
+    address another page already redirects from.
+    """
+    index = {}
+    lang_dir = Path(content_dir) / lang
+    if not lang_dir.exists():
+        return index
+    for path in lang_dir.rglob('*.md'):
+        try:
+            head = path.read_text(encoding='utf-8-sig')[:8000]
+        except OSError:
+            continue
+        fm = _FRONTMATTER_RE.match(head)
+        body = fm.group(1) if fm else head
+        m = _URL_RE.search(body)
+        if m:
+            index.setdefault(ensure_slashes(m.group(1)), str(path))
+        a = _ALIASES_RE.search(body)
+        if a:
+            for alias in re.findall(r'"([^"]+)"', a.group(0)):
+                index.setdefault(ensure_slashes(alias), str(path))
+    return index
+
+
+# ---------------------------------------------------------------------------
+# The decision
+# ---------------------------------------------------------------------------
+
+def resolve_url(en_url, translated_url, rel_path, lang, content_dir, hugo_root,
+                url_index=None):
+    """
+    Decide the final URL for a translated page.
+
+    Returns (url, alias, reason) where ``alias`` is the English URL to redirect
+    from (or None) and ``reason`` explains the choice for the run log.
+    """
+    policy = load_policy(hugo_root)
+    if policy is None:
+        return None, None, f'no {POLICY_FILE} in this project, url left untouched'
+
+    rel_path = str(rel_path).replace('\\', '/')
+    section = rel_path.split('/')[0] if '/' in rel_path else ''
+    en_url = ensure_slashes(en_url) if en_url else None
+
+    if not en_url:
+        return None, None, 'english page has no explicit url'
+
+    # A section index defines the prefix every page in that section inherits.
+    # Renaming it silently moves the whole section, so it stays a human
+    # decision - the pipeline only ever fills in leaf pages.
+    if rel_path.rsplit('/', 1)[-1] == '_index.md':
+        return None, None, 'section index, url left for a human to decide'
+
+    lang_prefix = policy['language_prefix']
+    if lang_prefix is None:
+        lang_prefix = uses_language_prefix(hugo_root)
+    if lang_prefix is None:
+        return None, None, ('cannot tell whether this site uses a /<lang>/ url prefix - '
+                            'no baseURL declared and language_prefix not set in '
+                            f'{POLICY_FILE}; url left untouched')
+    en_prefix, en_slug = split_url(en_url)
+    prefix = section_prefix(content_dir, lang, section, en_prefix, lang_prefix)
+
+    def assemble(slug):
+        return ensure_slashes('/'.join(p for p in (prefix, slug) if p))
+
+    # The English path as it would look inside THIS language. On a per-domain
+    # site that is the English URL itself, which is the legacy address the page
+    # used to answer on. On a subfolder site it must carry the language prefix,
+    # or the alias would land on the English page's own address and replace it.
+    english_prefix = en_prefix
+    if lang_prefix and en_prefix.split('/')[0] != lang:
+        english_prefix = '/'.join(p for p in (lang, en_prefix) if p)
+    english_path = ensure_slashes('/'.join(p for p in (english_prefix, en_slug) if p))
+
+    def settle(url, reason):
+        """
+        Last gate before a URL is handed back: never take an address that
+        another page in this language already owns, and never advertise an
+        alias that is somebody else's page. Every branch goes through here -
+        an early return that skips it is how /blog/gmail-alternative/ ended up
+        colliding with a root page during testing.
+        """
+        if url_index is not None:
+            owner = url_index.get(url)
+            if owner and not owner.endswith(rel_path):
+                fallback = assemble(en_slug)
+                if fallback != url and not url_index.get(fallback):
+                    url, reason = fallback, f'{reason}; collided with {owner}, used english slug'
+                else:
+                    return None, None, f'url {url} collides with {owner} and the english slug is taken too'
+        alias = english_path if (policy['aliases'] and url != english_path) else None
+        if alias and url_index is not None:
+            owner = url_index.get(alias)
+            if owner and not owner.endswith(rel_path):
+                alias = None
+        return url, alias, reason
+
+    # 1. A URL this page already had wins over anything the flow invented -
+    # unless another page has moved onto that address in the meantime. The
+    # map is a snapshot of a past state, and pages get merged and pruned
+    # between snapshots, so a stale record must not create a duplicate url
+    # (verified: 2 such records in the German blog map alone).
+    previous = historical_url(hugo_root, section, rel_path, lang)
+    if previous:
+        owner = url_index.get(previous) if url_index is not None else None
+        if owner and not owner.endswith(rel_path):
+            print(f'[URL] {lang}/{rel_path}: previous url {previous} now belongs to '
+                  f'{owner}, not restoring')
+        else:
+            return settle(previous, 'restored previously published url')
+
+    # 2. Sections whose slug is a proper name, and languages that keep English.
+    if section in policy['passthrough_sections']:
+        return settle(assemble(en_slug), f'section "{section}" keeps the english slug')
+    if lang in policy['english_slug_languages']:
+        return settle(assemble(en_slug), f'language "{lang}" keeps the english slug')
+
+    # 3. Otherwise use what the flow translated, normalised hard.
+    _, raw_slug = split_url(translated_url or '')
+    slug = normalize_slug(raw_slug, lang, policy['max_slug_length'])
+    reason = 'translated slug'
+    if not slug:
+        slug = en_slug
+        reason = 'flow returned no usable slug, fell back to english'
+    elif slug == en_slug:
+        reason = 'flow returned the english slug unchanged'
+
+    # A brand name must survive translation. "aircall-alternative" becoming
+    # "alternative-zum-anruf" would be a permanently wrong URL, and the flow
+    # has no way of knowing which words are products.
+    if slug != en_slug:
+        expected = set(en_slug.split('-')) & brand_tokens(
+            content_dir, policy['brand_sections'], policy['brand_suffixes'],
+            policy['brand_extra'])
+        lost = expected - set(slug.split('-'))
+        if lost:
+            slug = en_slug
+            reason = f'translated slug dropped brand name(s) {sorted(lost)}, fell back to english'
+
+    # 4. Same gate as every other branch.
+    return settle(assemble(slug), reason)
+
+
+def apply_url(text, url, alias):
+    """
+    Rewrite the ``url`` line and add ``aliases`` in a translated file, touching
+    nothing else. Returns the new text, or the original when there is no
+    frontmatter to work with.
+    """
+    fm = _FRONTMATTER_RE.match(text or '')
+    if not fm or not url:
+        return text
+
+    block = fm.group(1)
+    new_block = block
+
+    if _URL_RE.search(new_block):
+        new_block = _URL_RE.sub(lambda _m: f'url = "{url}"', new_block, count=1)
+    else:
+        lines = new_block.split('\n')
+        at = 0
+        for i, line in enumerate(lines):
+            if line.strip().startswith('title '):
+                at = i + 1
+                break
+        lines.insert(at, f'url = "{url}"')
+        new_block = '\n'.join(lines)
+
+    if alias:
+        existing = _ALIASES_RE.search(new_block)
+        if existing:
+            current = re.findall(r'"([^"]+)"', existing.group(0))
+            if alias not in current:
+                merged = ', '.join(f'"{a}"' for a in current + [alias])
+                new_block = _ALIASES_RE.sub(f'aliases = [{merged}]', new_block, count=1)
+        else:
+            new_block = _URL_RE.sub(
+                lambda m: f'{m.group(0)}\naliases = ["{alias}"]', new_block, count=1)
+
+    return text[:fm.start(1)] + new_block + text[fm.end(1):]


### PR DESCRIPTION
Two commits. The first is the TOML frontmatter guard that was sitting uncommitted in the submodule working tree and had never been pushed — it is carried here because the second commit builds on it. Review them separately.

## 1. `fix(translate): validate and repair translated TOML frontmatter`

The flow regularly returns frontmatter Hugo cannot unmarshal — an unescaped inner quote or a duplicated `=` — and one bad page takes down the whole language build. Repairs what is deterministically repairable, writes the file either way (a broken file can be fixed in the PR; a missing one needs a whole re-run), and reports both outcomes in the run summary. Also moves the code-fence stripping out of the `with open(..., 'w')` block, where a failure used to leave a 0-byte file behind.

## 2. `feat(translate): give translated pages their own language's URL`

The flow copies the English `url` verbatim into every language and nothing downstream fixes it. In LiveAgent-hugo that produced:

- pages outside their own language's section path — `/features/...` on the German domain where every other feature page lives under `/funktionen/`. **168 files repaired by hand** in LiveAgent-hugo#785.
- a re-translated page moving off the URL it was published and indexed on. When 28 translations of one article were deleted so they would regenerate, **15 languages would have lost their live URL** with no redirect behind them.
- no `aliases`, ever, so nothing redirects the old address.

`translation_url_policy.py` owns the decision. The flow supplies the words; this module supplies the rules, deterministically:

1. A URL the page was already published on wins over anything the flow invented, restored from `data/translation_urls` — unless another page has since moved onto that address, which the map does not know about (2 such stale records in the German blog map alone).
2. Sections whose slug is a proper name, and languages configured to keep English, get the English slug.
3. Otherwise the flow's slug, normalised hard: per-language expansions (`de ü→ue`), NFKD folding, then an ASCII check. Anything still non-ASCII is rejected in favour of the English slug — a slug is permanent once published, so the safe failure is "same as English", never "mangled". Includes the 16 letters NFKD does **not** decompose; without them a Polish slug containing `ł` folds to nothing and silently stays English.
4. Brand names must survive. `aircall-alternative` becoming `alternative-zum-anruf` would be a permanently wrong URL and the flow cannot know which words are products. The vocabulary is built from the site's own content, so a new integration page teaches it a new brand.
5. Every branch passes one gate that refuses an address another page owns, in its `url` or its `aliases`, including addresses claimed earlier in the same run.

The section prefix always comes from the target language's own `<section>/_index.md`, never from the flow. A section index is left alone entirely — its url defines the prefix every page in the section inherits, so renaming it stays a human decision.

## Opt-in, because the sites do not agree

**Nothing is hardcoded and nothing happens by default.** A project opts in with `data/translation-url-policy.toml`; without that file the module stands down and translation behaves exactly as before. A repo we have never seen cannot be reshaped by a submodule bump.

That matters because the sites genuinely differ. LiveAgent and PostAffiliatePro give each language its own domain and build each one separately; FlowHunt and amicited put every language behind a `/<lang>/` prefix on one domain and build them into a single tree. "Japanese keeps the English slug" is a LiveAgent decision, not a fact about Hugo.

On a subfolder site an alias without the language prefix is actively destructive: it publishes a redirect on the English page's own path and **Hugo overwrites the English page without warning**. Verified on Hugo 0.160.1 with a two-language test site. FlowHunt content already contains such aliases today, which is worth a separate look.

The prefix is auto-detected from the declared `baseURL`s — two or more distinct hosts means a domain per language. When nothing is declared, the module refuses to guess and leaves the url alone.

## Testing

Over the LiveAgent content tree: **1402 English pages × 28 languages × 5 flow behaviours = 196,280 cases** (flow returns English, returns a translation, drops a brand name, returns native script, returns an empty slug).

| check | result |
|---|---|
| URL collisions | 0 |
| alias collisions | 0 |
| language prefix on a per-domain site | 0 |
| `alias == url` | 0 |
| brand name lost | 0 |
| malformed URL produced | 0 |

The only malformed results are 4 pages whose published URL is already percent-encoded — three of them homoglyphs (Greek `ο`, Cyrillic `с`) — restored faithfully because they are live. Separately verified that normalising the **39,760 slugs already published** across all 28 languages is a no-op.

Nine defects were found and fixed by that test run, including root-level pages never being looked up in `_root.json`, the hyphen/underscore mismatch between content directories and the generated JSON filenames, and early-return branches skipping the collision gate.

## Follow-ups

- LiveAgent-hugo: commit `data/translation-url-policy.toml` and bump the submodule (PR opened separately, waiting on this one).
- The flow prompt still does not translate the slug. Until it does, this change gives every page the correct section prefix, restores previously published URLs and emits aliases — new pages just keep the English slug. Because the flow is shared by four sites, that instruction should be gated per repo.
- Translate content schedules are paused in all four repos meanwhile (LiveAgent-hugo#787, PostAffiliatePro-hugo#721, amicited-hugo#162, FlowHunt-hugo#754).

🤖 Generated with [Claude Code](https://claude.com/claude-code)