### PR TITLE
fix(translate): stop losing translations silently

### DIFF
--- a/scripts/translate_with_flowhunt.py
+++ b/scripts/translate_with_flowhunt.py
@@ -68,6 +68,7 @@ except ImportError:  # Python < 3.11
         return toml.loads(text)
 
 import translation_url_policy as url_policy
+from translation_body_check import check_body
 
 # Load environment variables from .env file
 script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -234,6 +235,11 @@ def is_translatable_file(file_path):
 # anything left over is written anyway and reported, because a broken file can
 # be fixed by hand while a missing one has to be re-translated.
 # ---------------------------------------------------------------------------
+
+# How many times one (file, language) task may be attempted before it is
+# reported as failed. Stalled flow sessions are transient, so a retry usually
+# succeeds; three attempts keeps a genuinely broken page from looping.
+MAX_TASK_ATTEMPTS = 3
 
 FRONTMATTER_DELIM = '+++'
 
@@ -461,6 +467,24 @@ def initialize_api_client():
     
     return flowhunt.ApiClient(configuration)
 
+def slug_translation_enabled():
+    """
+    Whether the flow should translate the slug in `url` for this project.
+
+    Tied to the same opt-in as the URL policy: a repo that has not committed
+    data/translation-url-policy.toml gets its `url` back untouched. That
+    matters because the flow is shared by every QualityUnit Hugo site, and a
+    translated `url` written without the policy's guard rails would land a page
+    on the wrong path - on the subfolder sites it would overwrite the English
+    page outright.
+    """
+    try:
+        return url_policy.load_policy(hugo_root) is not None
+    except Exception as exc:
+        print(f"[URL] cannot read the url policy ({exc}) - asking the flow to leave slugs alone")
+        return False
+
+
 def create_translation_session(api_instance, file_path, content, target_lang, flow_id, workspace_id):
     """
     Create a FlowHunt flow session for translation using the new session-based API
@@ -496,6 +520,10 @@ def create_translation_session(api_instance, file_path, content, target_lang, fl
                 "target_language": language_name,
                 "filename": filename,
                 "today": time.strftime("%Y-%m-%d %H:00:00"),
+                # "yes" asks the flow to translate the last segment of `url`.
+                # Everything it returns still goes through translation_url_policy,
+                # which owns the prefix, collisions and the ASCII guard.
+                "translate_slug": "yes" if slug_translation_enabled() else "no",
             }
         )
 
@@ -595,7 +623,13 @@ def check_session_results(api_instance, session_info, timeout=600):
         else:
             events = []
 
-        # Update timestamp for next poll
+        # The poll cursor may only move AFTER the whole batch has been
+        # examined. Advancing it inside the loop skipped any event that came
+        # after a later-timestamped one in the same response - and the
+        # artefacts event is sent exactly once, so losing it meant waiting out
+        # the full timeout for a translation that had already been delivered.
+        max_ts = None
+
         for event in events:
             if not isinstance(event, dict):
                 continue
@@ -603,9 +637,11 @@ def check_session_results(api_instance, session_info, timeout=600):
             ts = event.get('created_at_timestamp')
             if ts:
                 try:
-                    session_info['from_timestamp'] = str(int(ts) + 1)
+                    ts_int = int(ts)
                 except (ValueError, TypeError):
-                    pass
+                    ts_int = None
+                if ts_int is not None and (max_ts is None or ts_int > max_ts):
+                    max_ts = ts_int
 
             action_type = event.get('action_type')
             metadata = event.get('metadata') or {}
@@ -628,13 +664,16 @@ def check_session_results(api_instance, session_info, timeout=600):
                 print(f"[ERROR] Session {session_id} failed")
                 return True, None
 
+        if max_ts is not None:
+            session_info['from_timestamp'] = str(max_ts + 1)
+
         # Not ready yet
         return False, None
 
     except Exception as e:
-        # Don't print errors on every check to avoid spam
-        if 'start_time' in session_info and time.time() - session_info['start_time'] > 60:
-            print(f"Error checking session results for {session_info.get('session_id')}: {str(e)}")
+        # Report every failure. Swallowing the first 60 seconds of errors made a
+        # real API failure look identical to "still working".
+        print(f"[WARN] polling session {session_info.get('session_id')} failed: {str(e)[:160]}")
         return False, None
 
 
@@ -810,11 +849,17 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
         # Lists to track completed and failed tasks across all batches
         all_completed_tasks = []
         all_failed_tasks = []
+        # Attempts per (source file, language), for the retry pass below.
+        attempts = {}
+        retried = 0
         # Frontmatter outcomes, reported in the run summary: pages whose TOML
         # was repaired on the way in, and pages written with frontmatter that
         # still does not parse and therefore need a human.
         repaired_frontmatter = []
         invalid_frontmatter = []
+        # Body problems: shortcodes or JSON parameters the flow broke or
+        # dropped. Collected per file and reported in the summary.
+        body_issues = []
 
         # Process translations while maintaining max_scheduled_tasks in queue
         remaining_tasks = translation_tasks.copy()
@@ -929,6 +974,24 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
                                               f"will fail the Hugo build until it is fixed by hand")
                                         invalid_frontmatter.append((target_file, frontmatter_error))
 
+                                # Structural check on the body. The flow drops
+                                # or mangles shortcode delimiters, JSON
+                                # parameters and whole shortcodes, and none of
+                                # that is visible in the frontmatter. Reported,
+                                # never repaired: a missing brace could belong
+                                # in several places, so a human decides.
+                                if is_markdown:
+                                    try:
+                                        reference = file_path.read_text(encoding='utf-8-sig')
+                                    except OSError:
+                                        reference = None
+                                    body_problems = check_body(translated_text, reference)
+                                    if body_problems:
+                                        print(f"[BODY] {target_file}: {len(body_problems)} problem(s)")
+                                        for problem in body_problems:
+                                            print(f"[BODY]   {problem}")
+                                        body_issues.append((target_file, body_problems))
+
                                 # Give the page its own language's URL. The
                                 # flow returns the English one verbatim.
                                 if is_markdown and not frontmatter_error:
@@ -1028,6 +1091,34 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
                       f"Just completed: {completed_in_batch} | "
                       f"Just scheduled: {newly_scheduled}")
 
+            # Re-queue what failed this round. A stalled session is the most
+            # common failure by far: the flow stops emitting events part-way
+            # through and never sends the artefact or a `failed` event, so the
+            # session times out with the page simply not translated (verified by
+            # replaying two timed-out sessions from their first event - el
+            # stopped after 31s, ru after 308s, neither ever delivered).
+            #
+            # That is transient, so retrying the same task usually succeeds. Up
+            # to MAX_TASK_ATTEMPTS tries per task; anything still failing after
+            # that is reported. Without this a run quietly published 26 of 28
+            # languages and looked green.
+            if failed_tasks and not aborted:
+                for task in failed_tasks:
+                    file_path, target_lang, target_file = task
+                    key = (str(file_path), target_lang)
+                    attempts[key] = attempts.get(key, 1) + 1
+                    if attempts[key] <= MAX_TASK_ATTEMPTS:
+                        print(f"[RETRY] {target_file} (attempt {attempts[key]} of {MAX_TASK_ATTEMPTS})")
+                        try:
+                            content = file_path.read_text(encoding='utf-8')
+                        except OSError as exc:
+                            print(f"[RETRY] cannot re-read {file_path}: {exc}")
+                            continue
+                        remaining_tasks.append((file_path, content, target_lang, target_file))
+                        all_failed_tasks.remove(task)
+                        retried += 1
+                failed_tasks = []
+
         # Close the progress bars
         scheduling_progress.close()
         processing_progress.close()
@@ -1050,6 +1141,60 @@ def process_translations(translation_tasks, flow_id, workspace_id, max_scheduled
         print("\n[DEBUG] Pages whose TOML frontmatter was repaired automatically:")
         for target_file, line_list in repaired_frontmatter:
             print(f"[DEBUG]   {target_file} (line(s) {line_list})")
+
+    print(f"[DEBUG] Bodies with structural problems: {len(body_issues)}")
+    print(f"[DEBUG] Tasks retried: {retried}")
+
+    if body_issues:
+        print(f"\n[ERROR] {len(body_issues)} page(s) have shortcode or JSON problems in the body. "
+              f"These break the Hugo build or silently drop content:")
+        for target_file, problems in body_issues:
+            print(f"[ERROR]   {target_file}")
+            for problem in problems:
+                print(f"[ERROR]     {problem}")
+
+    if all_failed_tasks:
+        print(f"\n[ERROR] {len(all_failed_tasks)} translation(s) never arrived after "
+              f"{MAX_TASK_ATTEMPTS} attempts — those pages are NOT translated:")
+        for file_path, target_lang, target_file in all_failed_tasks:
+            print(f"[ERROR]   {target_lang}: {target_file}")
+        print("[ERROR] Re-run the workflow to pick them up — existing files are skipped, "
+              "so only the missing ones are translated.")
+
+    # Surface the same numbers in the GitHub job summary. They used to live only
+    # in the raw log, so a run that translated 195 of 198 files still showed a
+    # green tick and a PR link with nothing to suggest three pages were missing.
+    summary_path = os.getenv('GITHUB_STEP_SUMMARY')
+    if summary_path:
+        try:
+            with open(summary_path, 'a', encoding='utf-8') as fh:
+                fh.write("\n## Translation results\n\n")
+                fh.write(f"- Translated: **{len(all_completed_tasks)}**\n")
+                fh.write(f"- Failed: **{len(all_failed_tasks)}**"
+                         f"{' ⚠️' if all_failed_tasks else ''}\n")
+                fh.write(f"- Retried: {retried}\n")
+                fh.write(f"- Frontmatter repaired: {len(repaired_frontmatter)}\n")
+                fh.write(f"- Frontmatter still invalid: {len(invalid_frontmatter)}"
+                         f"{' ⚠️' if invalid_frontmatter else ''}\n")
+                fh.write(f"- Body problems: {len(body_issues)}"
+                         f"{' ⚠️' if body_issues else ''}\n")
+                if all_failed_tasks:
+                    fh.write("\n### Not translated\n\n")
+                    for _fp, lang, tf in all_failed_tasks:
+                        fh.write(f"- `{lang}` — `{tf}`\n")
+                    fh.write("\nRe-run the workflow to pick these up.\n")
+                if invalid_frontmatter:
+                    fh.write("\n### Invalid front matter (will fail the Hugo build)\n\n")
+                    for tf, err in invalid_frontmatter:
+                        fh.write(f"- `{tf}` — {err}\n")
+                if body_issues:
+                    fh.write("\n### Body problems\n\n")
+                    for tf, problems in body_issues:
+                        fh.write(f"- `{tf}`\n")
+                        for problem in problems:
+                            fh.write(f"  - {problem}\n")
+        except OSError as exc:
+            print(f"[WARN] could not write the job summary: {exc}")
 
     if invalid_frontmatter:
         # Loud and last, so it is the final thing in the job log: these pages

--- a/scripts/translation_body_check.py
+++ b/scripts/translation_body_check.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""
+Structural checks on the body of a translated Hugo page.
+
+The frontmatter guard in translate_with_flowhunt catches broken TOML, but
+nothing looked at the markdown below it - and that is where the translation
+flow breaks things just as often. Two real cases from run #5, each a single
+corrupted character that took down a whole language build:
+
+    fi:661   {{< /table-simple > %}      instead of {{< /table-simple >}}
+    tl:~164  a JSON row object closed with ']' instead of '}'
+
+Both are deterministic to detect: shortcode delimiters either balance or they
+do not, and a JSON parameter either parses or it does not. Neither is
+deterministic to repair - a missing brace could belong in several places - so
+this module only reports. The caller writes the file anyway and says loudly
+what is wrong, on the same principle as the frontmatter guard: a broken file
+can be fixed in the PR, a missing one has to be translated again.
+"""
+
+import json
+import re
+
+# Opening shortcode: {{< name ... >}} or {{% name ... %}}, closing: {{< /name >}}
+_OPEN_RE = re.compile(r'\{\{[<%]\s*(?!/)([a-zA-Z0-9_-]+)')
+_CLOSE_RE = re.compile(r'\{\{[<%]\s*/\s*([a-zA-Z0-9_-]+)')
+
+# A shortcode delimiter that opens but never closes properly, e.g. "> %}".
+_MALFORMED_DELIM_RE = re.compile(r'\{\{[<%][^}]*?(?:>\s*%\}|%\s*>\}\}|>\s*\}(?!\}))')
+
+# Shortcodes that take no closing tag. Anything else that opens is expected to
+# close; a shortcode used both ways in one project would show up as a false
+# positive, which is why the result is a report and not a hard failure.
+SELF_CLOSING_HINT = re.compile(r'/\s*[>%]\}\}\s*$')
+
+
+def _json_blocks(text):
+    """
+    Yield (start_line, block) for every brace-delimited JSON-looking block.
+
+    Deliberately crude: it walks braces from each `{` that is followed by a
+    quoted key on the same or next line, which is what the table-simple style
+    parameters look like. Anything that is not JSON simply fails to parse and
+    is skipped by the caller.
+    """
+    for m in re.finditer(r'\{\s*\n?\s*"', text):
+        start = m.start()
+        depth = 0
+        in_str = False
+        esc = False
+        for i in range(start, len(text)):
+            c = text[i]
+            if esc:
+                esc = False
+                continue
+            if c == '\\':
+                esc = True
+                continue
+            if c == '"':
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if c == '{':
+                depth += 1
+            elif c == '}':
+                depth -= 1
+                if depth == 0:
+                    yield text[:start].count('\n') + 1, text[start:i + 1]
+                    break
+            elif c in ']' and depth == 0:
+                break
+
+
+def check_body(text, reference=None):
+    """
+    Report structural problems in a translated body.
+
+    ``reference`` is the English source. When given, shortcode counts are
+    compared against it rather than judged in isolation, which removes the
+    guesswork about which shortcodes are self-closing: what matters is that the
+    translation has the same structure as the page it was translated from.
+
+    Returns a list of human-readable problem strings, empty when clean.
+    """
+    problems = []
+
+    for m in _MALFORMED_DELIM_RE.finditer(text or ''):
+        line = (text[:m.start()].count('\n')) + 1
+        problems.append(f'line {line}: malformed shortcode delimiter {m.group(0)[:40]!r}')
+
+    def counts(t):
+        opens = {}
+        closes = {}
+        for m in _OPEN_RE.finditer(t or ''):
+            opens[m.group(1)] = opens.get(m.group(1), 0) + 1
+        for m in _CLOSE_RE.finditer(t or ''):
+            closes[m.group(1)] = closes.get(m.group(1), 0) + 1
+        return opens, closes
+
+    opens, closes = counts(text)
+
+    if reference is not None:
+        ref_opens, ref_closes = counts(reference)
+        for name in sorted(set(ref_opens) | set(opens)):
+            if opens.get(name, 0) != ref_opens.get(name, 0):
+                problems.append(
+                    f'shortcode "{name}" opens {opens.get(name, 0)}x, '
+                    f'{ref_opens.get(name, 0)}x in the english source')
+        for name in sorted(set(ref_closes) | set(closes)):
+            if closes.get(name, 0) != ref_closes.get(name, 0):
+                problems.append(
+                    f'shortcode "{name}" closes {closes.get(name, 0)}x, '
+                    f'{ref_closes.get(name, 0)}x in the english source')
+    else:
+        for name, n in sorted(closes.items()):
+            if opens.get(name, 0) != n:
+                problems.append(
+                    f'shortcode "{name}" opens {opens.get(name, 0)}x but closes {n}x')
+
+    # JSON parameters. Only blocks that parse in the English source are
+    # required to parse here, so a page whose source is already odd does not
+    # produce noise.
+    ref_ok = 0
+    if reference is not None:
+        for _, block in _json_blocks(reference):
+            try:
+                json.loads(block)
+                ref_ok += 1
+            except ValueError:
+                pass
+
+    bad_json = []
+    ok_json = 0
+    for line, block in _json_blocks(text or ''):
+        try:
+            json.loads(block)
+            ok_json += 1
+        except ValueError as exc:
+            bad_json.append((line, str(exc)[:80]))
+
+    if reference is None or ref_ok:
+        for line, err in bad_json:
+            problems.append(f'line {line}: JSON parameter does not parse - {err}')
+
+    return problems


### PR DESCRIPTION
Run #5 on LiveAgent-hugo translated **195 of 198** files, reported `success`, and wrote a job summary containing the steps, the parallelism and a PR link. Nothing about the three pages that never arrived. Anyone merging that PR got 26 of 28 languages with no way to notice.

Four changes, plus the `translate_slug` plumbing.

## 1. Retry stalled sessions — the actual cause

I replayed two timed-out sessions from their first event. The flow simply stops:

| session | events | last event | artefact | `failed` event |
|---|---|---|---|---|
| `el` | 14 | +31s | never | never |
| `ru` | 57 | +308s | never | never |

The 600s wait was not too short — nothing was ever coming. Last events are `tool_call_end` / `todo_list`, i.e. the agent quit mid-work.

That is transient, so failed tasks are re-queued, up to `MAX_TASK_ATTEMPTS` (3) per file+language, and whatever still fails is listed by name.

## 2. Advance the poll cursor only after the whole batch

`from_timestamp` was being moved inside the event loop:

```python
for event in events:
    ts = event.get('created_at_timestamp')
    if ts:
        session_info['from_timestamp'] = str(int(ts) + 1)   # moved per event
    ...
    if action_type == 'artefacts':                          # evaluated after
```

An artefacts event arriving before a later-timestamped one in the same response was skipped, and it is sent exactly once. Latent rather than the cause of the failures above — but when it fires, a delivered translation is lost and the task waits out the full timeout. The cursor now moves once, to the highest timestamp in the batch.

## 3. Check the body, not just the front matter

The TOML guard never looked below the `+++` block, which is where the flow breaks things just as often. Both build failures in run #5 were one character each:

```
fi:661   {{< /table-simple > %}   instead of {{< /table-simple >}}
tl:~164  a JSON row object closed with ']' instead of '}'
```

`translation_body_check` compares shortcode open/close counts against the English source and parses every JSON parameter. **Reported, never repaired** — a missing brace could belong in several places, so a human decides. Same principle as the front matter guard: the file is still written, because a broken file can be fixed in the PR while a missing one has to be translated again.

Validated against run #5: it flags both broken files, and on the other 195 it raises **exactly one** thing —

> `spain-customer-service-law` lost its third `lazyimg` in **24 of 28 languages**

which is real content loss that shipped unnoticed, because a missing image is not a syntax error. No false positives.

## 4. Put the numbers in the job summary

Translated / failed / retried / front matter repaired / front matter invalid / body problems now go to `GITHUB_STEP_SUMMARY`, with failing pages listed and a note that re-running picks up only the missing ones. Previously all of this existed only in the raw log.

Polling exceptions are also printed immediately. They used to be swallowed for the first 60 seconds, where a real API failure looked identical to "still working".

## Plus: the `translate_slug` session variable

The flow needs to know whether to translate the slug in `url`, and it must only do that where the URL policy added in #401 is present to guard the result — the prefix, the collision check and the ASCII fallback. Tied to the same opt-in: `"yes"` when the project has `data/translation-url-policy.toml`, `"no"` otherwise. Verified: LiveAgent `yes`, PostAffiliatePro / FlowHunt / amicited `no`.

Tested end to end against the live flow before this PR:

- **raw flow output** (policy deliberately not applied): de `neue-funktion-videochat-videotelefonie`, pl `czat-wideo-rozmowa-wideo`, el `nea-leitourgia-videoklisi`, ru `videochat-videozvonok`, ar `taqdim-mizat-fidio-shat-jadidah` — all ASCII, transliterated, prefix untouched
- **full chain on LiveAgent**: ar came back from the flow as `/blog/…` and the policy rewrote it to `/almodawana/tasneef-tazaker-ai/` from the Arabic section index; zh-hans produced pinyin `ai-gongdan-fenlei`; aliases correct throughout
- **PostAffiliatePro with the variable absent**: `url` byte-identical to English in both de and es, so the prompt's fail-safe default holds

## Follow-ups outside this PR

- The flow stalling at all is worth raising with the FlowHunt side — the retry makes it survivable, not fixed.
- `spain-customer-service-law` needs its missing image restored in 24 languages (already merged to LiveAgent-hugo main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)