### PR TITLE
feat(translate): detect truncated translations by heading count

### DIFF
--- a/scripts/translation_body_check.py
+++ b/scripts/translation_body_check.py
@@ -21,6 +21,12 @@ can be fixed in the PR, a missing one has to be translated again.
 import json
 import re
 
+# Markdown ATX headings, ## and deeper. The count per level is a structural
+# invariant: a translation renames a heading, it does not add or remove one.
+# Length is NOT such an invariant - Russian runs ~65% longer than English on the
+# same page and Vietnamese ~45%, so comparing sizes would only produce noise.
+_HEADING_RE = re.compile(r'^(#{2,6})\s+\S', re.M)
+
 # Opening shortcode: {{< name ... >}} or {{% name ... %}}, closing: {{< /name >}}
 _OPEN_RE = re.compile(r'\{\{[<%]\s*(?!/)([a-zA-Z0-9_-]+)')
 _CLOSE_RE = re.compile(r'\{\{[<%]\s*/\s*([a-zA-Z0-9_-]+)')
@@ -72,6 +78,14 @@ def _json_blocks(text):
                 break
 
 
+def _heading_counts(text):
+    counts = {}
+    for m in _HEADING_RE.finditer(text or ''):
+        level = len(m.group(1))
+        counts[level] = counts.get(level, 0) + 1
+    return counts
+
+
 def check_body(text, reference=None):
     """
     Report structural problems in a translated body.
@@ -88,6 +102,20 @@ def check_body(text, reference=None):
     for m in _MALFORMED_DELIM_RE.finditer(text or ''):
         line = (text[:m.start()].count('\n')) + 1
         problems.append(f'line {line}: malformed shortcode delimiter {m.group(0)[:40]!r}')
+
+    # Missing headings mean the flow stopped early. That is how 24 of 28
+    # translations of one page lost their last two sections - the text simply
+    # ends mid-list, which is still valid markdown, so the build passed and the
+    # loss shipped unnoticed.
+    if reference is not None:
+        mine = _heading_counts(text)
+        theirs = _heading_counts(reference)
+        for level in sorted(set(mine) | set(theirs)):
+            got, want = mine.get(level, 0), theirs.get(level, 0)
+            if got != want:
+                problems.append(
+                    f'has {got} H{level} heading(s), the english source has {want}'
+                    + (' - the translation looks truncated' if got < want else ''))
 
     def counts(t):
         opens = {}


### PR DESCRIPTION
The body check added in #402 compares shortcodes and JSON parameters, but never noticed when the flow simply **stops writing**.

That is how **24 of the 28** translations of `blog/spain-customer-service-law` lost their last two sections. The German file ends here:

```
* Wenn ein Kunde eine Belastung oder Verlängerung anficht, haben Sie einen …
```

and never gets to the compliance-timeline image, the closing paragraph, `## Will other countries follow?` or `## Conclusion`. 99 lines against 112 in English. The text ends mid-list, which is **still valid markdown** — so the Hugo build passed, CI passed, review passed, and the loss shipped to `main`. A 25th file (`it/7-ways-businesses-use-ai-virtual-assistant`) lost two headings the same way.

## What this adds

Heading counts per level, compared against the English source:

```
has 4 H2 heading(s), the english source has 6 - the translation looks truncated
```

Heading count is a **structural invariant** — a translation renames a heading, it does not add or remove one.

Length deliberately is **not** compared. It is useless as a signal here:

| | chars vs English |
|---|---|
| `ru` | 1.08× |
| `vi` | 1.05× |
| `ar` | 0.93× |
| `zh-hans` | **0.37×** |

Chinese is a third of the size of the English page and Russian is longer; a size threshold would be pure noise.

## Validation over the 195 files of run #5

| | |
|---|---|
| truncated files flagged | **25 / 25** |
| false positives | **0** |
| `fi` broken delimiter from #791 | still caught |
| `tl` broken JSON from #791 | still caught |
| long/short-language files (`ru`, `vi`, `ar`, `zh-hans`) | 0 problems |

## Follow-up, not in this PR

Those 25 truncated files are already on `LiveAgent-hugo` `main`. Fixing them means re-translating, not patching — the missing part is two sections of prose per language, and the pipeline now has both retry (#402) and this check to stop it happening again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)